### PR TITLE
refactoring v2

### DIFF
--- a/src/common/extensions.rs
+++ b/src/common/extensions.rs
@@ -29,9 +29,9 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use serde::{Deserializer, Serialize, Serializer};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
+use serde::{Deserializer, Serialize, Serializer};
 
 pub fn deserialize<'de, D>(
     deserializer: D,

--- a/src/common/extensions.rs
+++ b/src/common/extensions.rs
@@ -29,9 +29,9 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+use serde::{Deserializer, Serialize, Serializer};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
-use serde::{Deserializer, Serialize, Serializer};
 
 pub fn deserialize<'de, D>(
     deserializer: D,

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -1,0 +1,78 @@
+use std::collections::HashSet;
+
+use enumset::EnumSet;
+use regex::Regex;
+
+use crate::validation::Options;
+
+pub trait ValidateWithContext<T> {
+    fn validate_with_context(&self, ctx: &mut Context<T>, path: String);
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Context<'a, T> {
+    pub spec: &'a T,
+    pub visited: HashSet<String>,
+    pub errors: Vec<String>,
+    pub options: EnumSet<Options>,
+}
+
+impl Context<'_, ()> {
+    pub fn new<T>(spec: &T, options: EnumSet<Options>) -> Context<T> {
+        Context {
+            spec,
+            visited: HashSet::new(),
+            errors: Vec::new(),
+            options,
+        }
+    }
+}
+
+pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: String) {
+    if let Some(email) = email {
+        if !email.contains('@') {
+            ctx.errors.push(format!(
+                "{}: must be a valid email address, found `{}`",
+                path, email
+            ));
+        }
+    }
+}
+
+const HTTP: &str = "http://";
+const HTTPS: &str = "https://";
+
+pub fn validate_url<T>(url: &Option<String>, ctx: &mut Context<T>, path: String) {
+    if let Some(url) = url {
+        if !url.starts_with(HTTP) && !url.starts_with(HTTPS) {
+            ctx.errors
+                .push(format!("{}: must be a valid URL, found `{}`", path, url));
+        }
+    }
+}
+
+pub fn validate_required_string<T>(s: &str, ctx: &mut Context<T>, path: String) {
+    if s.is_empty() {
+        ctx.errors.push(format!("{}: must not be empty", path));
+    }
+}
+
+pub fn validate_string_matches<T>(s: &str, pattern: &Regex, ctx: &mut Context<T>, path: String) {
+    if !pattern.is_match(s) {
+        ctx.errors.push(format!(
+            "{}: must match pattern `{}`, found `{}`",
+            path, pattern, s
+        ));
+    }
+}
+
+pub fn validate_optional_string_matches<T>(
+    s: &Option<String>,
+    pattern: &Regex,
+    ctx: &mut Context<T>,
+    path: String,
+) {
+    if let Some(s) = s {
+        validate_string_matches(s, pattern, ctx, path);
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod bool_or;
 pub mod extensions;
+pub mod helpers;
 pub mod reference;

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -2,9 +2,10 @@
 
 use std::ops::Add;
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
-use crate::validation::{Context, Options, ValidateWithContext};
+use crate::validation::Options;
 
 pub enum ResolveError {
     NotFound,

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -2,9 +2,9 @@
 
 use std::ops::Add;
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use crate::validation::Options;
 
 pub enum ResolveError {

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -3,10 +3,10 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{validate_url, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
 use crate::v2::spec::Spec;
-use crate::validation::{validate_url, Context, ValidateWithContext};
 
 /// Allows referencing an external resource for extended documentation.
 ///

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
-use crate::common::helpers::{validate_url, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{validate_url, Context, ValidateWithContext};
 use crate::v2::spec::Spec;
 
 /// Allows referencing an external resource for extended documentation.

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v2::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::v2::items::Items;
 use crate::v2::spec::Spec;

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -3,12 +3,12 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
 use crate::v2::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::v2::items::Items;
 use crate::v2::spec::Spec;
-use crate::validation::{Context, ValidateWithContext};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -3,11 +3,11 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use serde::{Deserialize, Serialize};
+
 use crate::common::helpers::{
     validate_email, validate_required_string, validate_url, Context, ValidateWithContext,
 };
-use serde::{Deserialize, Serialize};
-
 use crate::v2::spec::Spec;
 
 /// The object provides metadata about the API.

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -3,12 +3,12 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{
+    validate_email, validate_required_string, validate_url, Context, ValidateWithContext,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::v2::spec::Spec;
-use crate::validation::{
-    validate_email, validate_required_string, validate_url, Context, ValidateWithContext,
-};
 
 /// The object provides metadata about the API.
 /// The metadata can be used by the clients if needed, and can be presented in the Swagger-UI for convenience.

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -28,7 +28,6 @@ use crate::validation::{
 /// version: 1.0.1
 /// ```
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
-#[serde(rename_all = "camelCase")]
 pub struct Info {
     /// **Required** The title of the application.
     pub title: String,
@@ -40,6 +39,7 @@ pub struct Info {
 
     /// The Terms of Service for the API.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "termsOfService")]
     pub terms_of_service: Option<String>,
 
     /// The contact information for the exposed API.

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v2::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::v2::spec::Spec;
 

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -3,11 +3,11 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
 use crate::v2::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::v2::spec::Spec;
-use crate::validation::{Context, ValidateWithContext};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
-use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use crate::common::reference::{RefOr, ResolveReference};
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::parameter::Parameter;

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -6,11 +6,12 @@ use std::ops::Add;
 use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
-use crate::common::reference::RefOr;
+use crate::common::reference::{RefOr, ResolveReference};
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::parameter::Parameter;
 use crate::v2::response::Responses;
 use crate::v2::spec::{Scheme, Spec};
+use crate::v2::tag::Tag;
 use crate::validation::Options;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
@@ -117,15 +118,26 @@ impl ValidateWithContext<Spec> for Operation {
                 if tag.is_empty() {
                     continue;
                 }
-                if !ctx.options.contains(Options::IgnoreMissingTags)
-                    && !ctx.visited.contains(format!("#/tags/{}", tag).as_str())
-                {
-                    ctx.errors.push(format!(
-                        "{}.tags[{}]: `{}` not found in spec",
-                        path.clone(),
-                        i,
-                        tag
-                    ));
+                let spec_tag: Option<&Tag> = ctx
+                    .spec
+                    .resolve_reference(format!("#/tags/{}", tag).as_str());
+                match spec_tag {
+                    Some(spec_tag) => {
+                        let path = format!("#/tags/{}", tag);
+                        if ctx.visited.insert(path.clone()) {
+                            spec_tag.validate_with_context(ctx, path);
+                        }
+                    }
+                    None => {
+                        if !ctx.options.contains(Options::IgnoreMissingTags) {
+                            ctx.errors.push(format!(
+                                "{}.tags[{}]: `{}` not found in spec",
+                                path.clone(),
+                                i,
+                                tag
+                            ));
+                        }
+                    }
                 }
             }
         }

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
 use crate::common::reference::RefOr;
@@ -10,7 +11,7 @@ use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::parameter::Parameter;
 use crate::v2::response::Responses;
 use crate::v2::spec::{Scheme, Spec};
-use crate::validation::{validate_required_string, Context, Options, ValidateWithContext};
+use crate::validation::Options;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Operation {

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
 use crate::common::reference::RefOr;
@@ -10,7 +11,6 @@ use crate::v2::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFo
 use crate::v2::items::Items;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
-use crate::validation::{validate_required_string, Context, ValidateWithContext};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "in")]

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
-use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v2::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::v2::items::Items;

--- a/src/v2/paths.rs
+++ b/src/v2/paths.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -11,12 +12,61 @@ use crate::common::reference::RefOr;
 use crate::v2::operation::Operation;
 use crate::v2::parameter::Parameter;
 use crate::v2::spec::Spec;
-use crate::validation::{Context, ValidateWithContext};
 
 /// Describes the operations available on a single path.
 /// A Path Item may be empty, due to [ACL constraints](https://swagger.io/specification/v2/#security-filtering).
 /// The path itself is still exposed to the documentation viewer
 /// but they will not know which operations and parameters are available.
+///
+/// Specification example:
+///
+/// ```yaml
+/// get:
+///   description: Returns pets based on ID
+///   summary: Find pets by ID
+///   operationId: getPetsById
+///   produces:
+///   - application/json
+///   - text/html
+///   responses:
+///     '200':
+///       description: pet response
+///       schema:
+///         type: array
+///         items:
+///           $ref: '#/definitions/Pet'
+///     default:
+///       description: error payload
+///       schema:
+///         $ref: '#/definitions/ErrorModel'
+/// search:
+///   description: Returns pets based on the search parameters
+///   summary: Find pets by ID
+///   operationId: getPetsById
+///   produces:
+///   - application/json
+///   - text/html
+///   responses:
+///     '200':
+///       description: pet response
+///       schema:
+///         type: array
+///         items:
+///           $ref: '#/definitions/Pet'
+///     default:
+///       description: error payload
+///       schema:
+///         $ref: '#/definitions/ErrorModel'
+/// parameters:
+/// - name: id
+///   in: path
+///   description: ID of pet to use
+///   required: true
+///   type: array
+///   items:
+///     type: string
+///   collectionFormat: csv
+/// ```
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct PathItem {
     /// A definition of the operations on this path.

--- a/src/v2/paths.rs
+++ b/src/v2/paths.rs
@@ -3,11 +3,11 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::common::helpers::{Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v2::operation::Operation;
 use crate::v2::parameter::Parameter;

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Add;
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -12,7 +13,6 @@ use crate::common::reference::RefOr;
 use crate::v2::header::Header;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
-use crate::validation::{validate_required_string, Context, ValidateWithContext};
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Responses {

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Add;
 
-use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v2::header::Header;
 use crate::v2::schema::Schema;

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -7,12 +7,12 @@ use std::ops::Add;
 use serde::{Deserialize, Serialize};
 
 use crate::common::bool_or::BoolOr;
+use crate::common::helpers::{Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::formats::{IntegerFormat, NumberFormat, StringFormat};
 use crate::v2::spec::Spec;
 use crate::v2::xml::XML;
-use crate::validation::{Context, ValidateWithContext};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 
+use serde::{Deserialize, Serialize};
+
 use crate::common::helpers::{
     validate_required_string, validate_url, Context, ValidateWithContext,
 };
-use serde::{Deserialize, Serialize};
-
 use crate::v2::spec::Spec;
 
 /// Allows the definition of a security scheme that can be used by the operations.

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -4,10 +4,12 @@ use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 
+use crate::common::helpers::{
+    validate_required_string, validate_url, Context, ValidateWithContext,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::v2::spec::Spec;
-use crate::validation::{validate_required_string, validate_url, Context, ValidateWithContext};
 
 /// Allows the definition of a security scheme that can be used by the operations.
 /// Supported schemes are basic authentication, an API key (either as a header or as a query parameter)

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -1,4 +1,4 @@
-//! The root document object for the API specification.
+//! The root document object of the OpenAPI v2.0 specification.
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 
+use crate::common::helpers::{validate_optional_string_matches, Context, ValidateWithContext};
 use enumset::EnumSet;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -19,9 +20,7 @@ use crate::v2::response::Response;
 use crate::v2::schema::{ObjectSchema, Schema};
 use crate::v2::security_scheme::SecurityScheme;
 use crate::v2::tag::Tag;
-use crate::validation::{
-    validate_optional_string_matches, Context, Error, Options, Validate, ValidateWithContext,
-};
+use crate::validation::{Error, Options, Validate};
 
 /// This is the root document object for the API specification.
 /// It combines what previously was the Resource Listing and API Declaration (version 1.2 and earlier) together into one document.

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -1,16 +1,15 @@
 //! The root document object of the OpenAPI v2.0 specification.
 
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 
-use crate::common::helpers::{validate_optional_string_matches, Context, ValidateWithContext};
 use enumset::EnumSet;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{validate_optional_string_matches, Context, ValidateWithContext};
 use crate::common::reference::ResolveReference;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::info::Info;
@@ -286,6 +285,15 @@ impl ResolveReference<SecurityScheme> for Spec {
     }
 }
 
+impl ResolveReference<Tag> for Spec {
+    fn resolve_reference(&self, reference: &str) -> Option<&Tag> {
+        self.tags
+            .iter()
+            .flatten()
+            .find(|tag| tag.name == reference.trim_start_matches("#/tags/"))
+    }
+}
+
 impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
@@ -297,23 +305,13 @@ impl Validate for Spec {
     }
 }
 
-thread_local! {
-    static HOST_RE: RefCell<Regex> = RefCell::new(Regex::new(r"^[^{}/ :\\]+(?::\d+)?$").unwrap());
-}
-
 impl ValidateWithContext<Spec> for Spec {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         self.info
             .validate_with_context(ctx, path.clone().add(".info"));
 
-        HOST_RE.with(|re| {
-            validate_optional_string_matches(
-                &self.host,
-                &re.borrow(),
-                ctx,
-                path.clone().add(".host"),
-            )
-        });
+        let re = Regex::new(r"^[^{}/ :\\]+(?::\d+)?$").unwrap();
+        validate_optional_string_matches(&self.host, &re, ctx, path.clone().add(".host"));
 
         if let Some(base_path) = &self.base_path {
             if !base_path.starts_with('/') {
@@ -321,52 +319,6 @@ impl ValidateWithContext<Spec> for Spec {
                     "{}.basePath: must start with `/`, found `{}`",
                     path, base_path
                 ));
-            }
-        }
-
-        // validate tags and memorize them first, so the validation of the operations can use them
-        if let Some(tags) = &self.tags {
-            for tag in tags.iter() {
-                let path = format!("{}/tags/{}", path, tag.name);
-                if ctx.visited.insert(path.clone()) {
-                    tag.validate_with_context(ctx, path)
-                }
-            }
-        }
-
-        if let Some(definitions) = &self.security_definitions {
-            for (name, definition) in definitions {
-                let path = format!("{}/securityDefinitions/{}", path, name);
-                if ctx.visited.insert(path.clone()) {
-                    definition.validate_with_context(ctx, path)
-                }
-            }
-        }
-
-        if let Some(definitions) = &self.definitions {
-            for (name, definition) in definitions {
-                let path = format!("{}/definitions/{}", path, name);
-                if ctx.visited.insert(path.clone()) {
-                    definition.validate_with_context(ctx, path)
-                }
-            }
-        }
-
-        if let Some(responses) = &self.responses {
-            for (name, response) in responses {
-                let path = format!("{}/responses/{}", path, name);
-                if ctx.visited.insert(path.clone()) {
-                    response.validate_with_context(ctx, path)
-                }
-            }
-        }
-
-        if let Some(parameters) = &self.parameters {
-            for (name, parameter) in parameters {
-                let path = format!("{}/parameters/{}", path, name);
-                if ctx.visited.insert(path.clone()) {
-                    parameter.validate_with_context(ctx, path)
-                }
             }
         }
 
@@ -380,7 +332,56 @@ impl ValidateWithContext<Spec> for Spec {
         }
 
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, path.add(".externalDocs"))
+            docs.validate_with_context(ctx, path.clone().add(".externalDocs"))
+        }
+
+        // validate unused components
+        if !ctx.options.contains(Options::IgnoreUnusedTags) {
+            if let Some(tags) = &self.tags {
+                for tag in tags.iter() {
+                    let path = format!("{}/tags/{}", path, tag.name);
+                    if ctx.visited.insert(path.clone()) {
+                        ctx.errors.push(format!("{}: unused", path));
+                        tag.validate_with_context(ctx, path);
+                    }
+                }
+            }
+        }
+
+        if !ctx.options.contains(Options::IgnoreUnusedDefinitions) {
+            if let Some(definitions) = &self.definitions {
+                for (name, definition) in definitions.iter() {
+                    let path = format!("{}/definitions/{}", path, name);
+                    if ctx.visited.insert(path.clone()) {
+                        ctx.errors.push(format!("{}: unused", path));
+                        definition.validate_with_context(ctx, path);
+                    }
+                }
+            }
+        }
+
+        if !ctx.options.contains(Options::IgnoreUnusedParameters) {
+            if let Some(parameters) = &self.parameters {
+                for (name, parameter) in parameters.iter() {
+                    let path = format!("{}/parameters/{}", path, name);
+                    if ctx.visited.insert(path.clone()) {
+                        ctx.errors.push(format!("{}: unused", path));
+                        parameter.validate_with_context(ctx, path);
+                    }
+                }
+            }
+        }
+
+        if !ctx.options.contains(Options::IgnoreUnusedResponses) {
+            if let Some(responses) = &self.responses {
+                for (name, response) in responses.iter() {
+                    let path = format!("{}/responses/{}", path, name);
+                    if ctx.visited.insert(path.clone()) {
+                        ctx.errors.push(format!("{}: unused", path));
+                        response.validate_with_context(ctx, path);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -3,11 +3,11 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::spec::Spec;
-use crate::validation::{validate_required_string, Context, ValidateWithContext};
 
 /// Allows adding meta data to a single tag that is used by the Operation Object.
 /// It is not mandatory to have a Tag Object per tag used there.

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
-use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
+use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::spec::Spec;
 

--- a/src/v2/xml.rs
+++ b/src/v2/xml.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use serde::{Deserialize, Serialize};
+
 use crate::common::helpers::{
     validate_required_string, validate_url, Context, ValidateWithContext,
 };
-use serde::{Deserialize, Serialize};
-
 use crate::v2::spec::Spec;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]

--- a/src/v2/xml.rs
+++ b/src/v2/xml.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeMap;
 use std::ops::Add;
 
+use crate::common::helpers::{
+    validate_required_string, validate_url, Context, ValidateWithContext,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::v2::spec::Spec;
-use crate::validation::{validate_required_string, validate_url, Context, ValidateWithContext};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct XML {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,19 +1,10 @@
-use std::collections::HashSet;
 use std::fmt::Display;
 
 use enumset::{EnumSet, EnumSetType};
-use regex::Regex;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {
     pub errors: Vec<String>,
-}
-
-#[derive(EnumSetType, Debug)]
-pub enum Options {
-    IgnoreMissingTags,
-    IgnoreExternalReferences,
-    IgnoreNonUniqOperationIDs,
 }
 
 impl Display for Error {
@@ -26,80 +17,15 @@ impl Display for Error {
     }
 }
 
+#[derive(EnumSetType, Debug)]
+pub enum Options {
+    IgnoreMissingTags,
+    IgnoreExternalReferences,
+    IgnoreNonUniqOperationIDs,
+}
+
 pub trait Validate {
     fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
         Ok(())
-    }
-}
-
-pub trait ValidateWithContext<T> {
-    fn validate_with_context(&self, ctx: &mut Context<T>, path: String);
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Context<'a, T> {
-    pub spec: &'a T,
-    pub visited: HashSet<String>,
-    pub errors: Vec<String>,
-    pub options: EnumSet<Options>,
-}
-
-impl Context<'_, ()> {
-    pub fn new<T>(spec: &T, options: EnumSet<Options>) -> Context<T> {
-        Context {
-            spec,
-            visited: HashSet::new(),
-            errors: Vec::new(),
-            options,
-        }
-    }
-}
-
-pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: String) {
-    if let Some(email) = email {
-        if !email.contains('@') {
-            ctx.errors.push(format!(
-                "{}: must be a valid email address, found `{}`",
-                path, email
-            ));
-        }
-    }
-}
-
-const HTTP: &str = "http://";
-const HTTPS: &str = "https://";
-
-pub fn validate_url<T>(url: &Option<String>, ctx: &mut Context<T>, path: String) {
-    if let Some(url) = url {
-        if !url.starts_with(HTTP) && !url.starts_with(HTTPS) {
-            ctx.errors
-                .push(format!("{}: must be a valid URL, found `{}`", path, url));
-        }
-    }
-}
-
-pub fn validate_required_string<T>(s: &str, ctx: &mut Context<T>, path: String) {
-    if s.is_empty() {
-        ctx.errors.push(format!("{}: must not be empty", path));
-    }
-}
-
-pub fn validate_string_matches<T>(s: &str, pattern: &Regex, ctx: &mut Context<T>, path: String) {
-    if !pattern.is_match(s) {
-        ctx.errors.push(format!(
-            "{}: must match pattern `{}`, found `{}`",
-            path, pattern, s
-        ));
-    }
-}
-
-pub fn validate_optional_string_matches<T>(
-    s: &Option<String>,
-    pattern: &Regex,
-    ctx: &mut Context<T>,
-    path: String,
-) {
-    if let Some(s) = s {
-        validate_string_matches(s, pattern, ctx, path);
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -2,6 +2,10 @@ use std::fmt::Display;
 
 use enumset::{EnumSet, EnumSetType};
 
+use crate::validation::Options::{
+    IgnoreUnusedDefinitions, IgnoreUnusedParameters, IgnoreUnusedResponses, IgnoreUnusedTags,
+};
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {
     pub errors: Vec<String>,
@@ -22,10 +26,18 @@ pub enum Options {
     IgnoreMissingTags,
     IgnoreExternalReferences,
     IgnoreNonUniqOperationIDs,
+    IgnoreUnusedTags,
+    IgnoreUnusedDefinitions,
+    IgnoreUnusedParameters,
+    IgnoreUnusedResponses,
+}
+
+impl Options {
+    pub fn ignore_unused() -> EnumSet<Options> {
+        IgnoreUnusedTags | IgnoreUnusedDefinitions | IgnoreUnusedParameters | IgnoreUnusedResponses
+    }
 }
 
 pub trait Validate {
-    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
-        Ok(())
-    }
+    fn validate(&self, options: EnumSet<Options>) -> Result<(), Error>;
 }

--- a/tests/v2_test.rs
+++ b/tests/v2_test.rs
@@ -12,12 +12,8 @@ mod v2_tests {
             println!("validating: {:?}", path_buf);
             let json_spec = fs::read_to_string(&path_buf).unwrap();
             let spec = serde_json::from_str::<Spec>(&json_spec).unwrap();
-            match spec.validate(Options::IgnoreMissingTags | Options::IgnoreExternalReferences) {
-                Ok(_) => {}
-                Err(err) => {
-                    panic!("validation failed: {}", err);
-                }
-            }
+            spec.validate(Options::IgnoreMissingTags | Options::IgnoreExternalReferences)
+                .unwrap();
             assert_eq!(
                 serde_json::from_str::<serde_json::Value>(&json_spec).unwrap(),
                 serde_json::to_value(spec).unwrap(),


### PR DESCRIPTION
### Refactoring the operations

The swagger v2.0 supports only a subset of the possible http methods and does not support any custom methods, like SEARCH and etc...

This change fixes the issue by getting rid of the predefined `get`, `post` and other operations and using the `BTreeMap<String, Operation>` instead. So any operations can be used.

The operation's name (method) is converted to lowercase in order to avoid duplications.


### Reorganizing the validations

Move the helpers methods and the ValidateWithContext with Context to common::helpers mod.
So the libs::validation should have only Validate trait


### Detect unused components

Refactor code to detect unused components, validate all components at the end and check if they were visited 


