### PR TITLE
backporting the refactors of v2 schemas from v2_0 branch

### DIFF
--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -42,12 +42,16 @@ pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: Str
 const HTTP: &str = "http://";
 const HTTPS: &str = "https://";
 
-pub fn validate_url<T>(url: &Option<String>, ctx: &mut Context<T>, path: String) {
+pub fn validate_optional_url<T>(url: &Option<String>, ctx: &mut Context<T>, path: String) {
     if let Some(url) = url {
-        if !url.starts_with(HTTP) && !url.starts_with(HTTPS) {
-            ctx.errors
-                .push(format!("{}: must be a valid URL, found `{}`", path, url));
-        }
+        validate_required_url(url, ctx, path);
+    }
+}
+
+pub fn validate_required_url<T>(url: &String, ctx: &mut Context<T>, path: String) {
+    if !url.starts_with(HTTP) && !url.starts_with(HTTPS) {
+        ctx.errors
+            .push(format!("{}: must be a valid URL, found `{}`", path, url));
     }
 }
 

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -5,7 +5,9 @@ use std::ops::Add;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_url, Context, ValidateWithContext};
+use crate::common::helpers::{
+    validate_optional_url, validate_required_url, Context, ValidateWithContext,
+};
 use crate::v2::spec::Spec;
 
 /// Allows referencing an external resource for extended documentation.
@@ -37,7 +39,7 @@ pub struct ExternalDocumentation {
 
 impl ValidateWithContext<Spec> for ExternalDocumentation {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_url(&Some(self.url.clone()), ctx, path.add(".url"));
+        validate_required_url(&self.url, ctx, path.add(".url"));
     }
 }
 

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -6,7 +6,7 @@ use std::ops::Add;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_email, validate_required_string, validate_url, Context, ValidateWithContext,
+    validate_email, validate_optional_url, validate_required_string, Context, ValidateWithContext,
 };
 use crate::v2::spec::Spec;
 
@@ -142,7 +142,7 @@ impl ValidateWithContext<Spec> for Info {
 
 impl ValidateWithContext<Spec> for Contact {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_url(&self.url, ctx, path.clone().add(".url"));
+        validate_optional_url(&self.url, ctx, path.clone().add(".url"));
         validate_email(&self.email, ctx, path.add(".email"));
     }
 }
@@ -150,7 +150,7 @@ impl ValidateWithContext<Spec> for Contact {
 impl ValidateWithContext<Spec> for License {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         validate_required_string(&self.name, ctx, path.clone().add(".name"));
-        validate_url(&self.url, ctx, path.add(".url"));
+        validate_optional_url(&self.url, ctx, path.add(".url"));
     }
 }
 

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -6,7 +6,7 @@ pub mod info;
 pub mod items;
 pub mod operation;
 pub mod parameter;
-pub mod paths;
+pub mod path_item;
 pub mod response;
 pub mod schema;
 pub mod security_scheme;

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1,5 +1,6 @@
 //! Implementation of v2.0 Specification
-
+//!
+//! Full specification can be found [here](https://spec.openapis.org/oas/v2.0).
 pub mod external_documentation;
 pub mod header;
 pub mod info;

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -74,7 +74,7 @@ pub struct PathItem {
     /// Any map items that can be converted to an `Operation` object will be stored here.
     /// This includes `get`, `put`, `post`, `delete`, `options`, `head`, `patch`, `trace`,
     /// and any other custom operations, like SEARCH and etc...
-    operations: Option<BTreeMap<String, Operation>>,
+    pub operations: Option<BTreeMap<String, Operation>>,
 
     /// A list of parameters that are applicable for all the operations described under this path.
     /// These parameters can be overridden at the operation level, but cannot be removed there.

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -7,7 +7,7 @@ use std::ops::Add;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_required_string, validate_url, Context, ValidateWithContext,
+    validate_optional_url, validate_required_string, Context, ValidateWithContext,
 };
 use crate::v2::spec::Spec;
 
@@ -191,7 +191,7 @@ impl ValidateWithContext<Spec> for OAuth2SecurityScheme {
                 path, self.flow,
             ));
         } else {
-            validate_url(&self.authorization_url, ctx, path.add(".authorizationUrl"));
+            validate_optional_url(&self.authorization_url, ctx, path.add(".authorizationUrl"));
         }
     }
 }

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -14,7 +14,7 @@ use crate::common::reference::ResolveReference;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::info::Info;
 use crate::v2::parameter::Parameter;
-use crate::v2::paths::PathItem;
+use crate::v2::path_item::PathItem;
 use crate::v2::response::Response;
 use crate::v2::schema::{ObjectSchema, Schema};
 use crate::v2::security_scheme::SecurityScheme;

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -348,7 +348,7 @@ impl ValidateWithContext<Spec> for Spec {
             }
         }
 
-        if !ctx.options.contains(Options::IgnoreUnusedDefinitions) {
+        if !ctx.options.contains(Options::IgnoreUnusedSchemas) {
             if let Some(definitions) = &self.definitions {
                 for (name, definition) in definitions.iter() {
                     let path = format!("{}/definitions/{}", path, name);

--- a/src/v2/xml.rs
+++ b/src/v2/xml.rs
@@ -4,7 +4,7 @@ use std::ops::Add;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_required_string, validate_url, Context, ValidateWithContext,
+    validate_optional_url, validate_required_string, Context, ValidateWithContext,
 };
 use crate::v2::spec::Spec;
 
@@ -55,6 +55,6 @@ impl ValidateWithContext<Spec> for XML {
         if let Some(name) = &self.name {
             validate_required_string(name, ctx, path.clone().add(".name"));
         }
-        validate_url(&self.namespace, ctx, path.add(".namespace"));
+        validate_optional_url(&self.namespace, ctx, path.add(".namespace"));
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -2,10 +2,6 @@ use std::fmt::Display;
 
 use enumset::{EnumSet, EnumSetType};
 
-use crate::validation::Options::{
-    IgnoreUnusedParameters, IgnoreUnusedResponses, IgnoreUnusedSchemas, IgnoreUnusedTags,
-};
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {
     pub errors: Vec<String>,
@@ -33,8 +29,17 @@ pub enum Options {
 }
 
 impl Options {
+    /// Create an empty (strict) set of options.
+    pub fn new() -> EnumSet<Options> {
+        EnumSet::empty()
+    }
+
+    /// Create options to ignore unused elements.
     pub fn ignore_unused() -> EnumSet<Options> {
-        IgnoreUnusedTags | IgnoreUnusedSchemas | IgnoreUnusedParameters | IgnoreUnusedResponses
+        Options::IgnoreUnusedTags
+            | Options::IgnoreUnusedSchemas
+            | Options::IgnoreUnusedParameters
+            | Options::IgnoreUnusedResponses
     }
 }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use enumset::{EnumSet, EnumSetType};
 
 use crate::validation::Options::{
-    IgnoreUnusedDefinitions, IgnoreUnusedParameters, IgnoreUnusedResponses, IgnoreUnusedTags,
+    IgnoreUnusedParameters, IgnoreUnusedResponses, IgnoreUnusedSchemas, IgnoreUnusedTags,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -27,14 +27,14 @@ pub enum Options {
     IgnoreExternalReferences,
     IgnoreNonUniqOperationIDs,
     IgnoreUnusedTags,
-    IgnoreUnusedDefinitions,
+    IgnoreUnusedSchemas,
     IgnoreUnusedParameters,
     IgnoreUnusedResponses,
 }
 
 impl Options {
     pub fn ignore_unused() -> EnumSet<Options> {
-        IgnoreUnusedTags | IgnoreUnusedDefinitions | IgnoreUnusedParameters | IgnoreUnusedResponses
+        IgnoreUnusedTags | IgnoreUnusedSchemas | IgnoreUnusedParameters | IgnoreUnusedResponses
     }
 }
 


### PR DESCRIPTION
* rename `validate_url` function to `validate_optional_url` and add `validate_required_url` function
* rename `paths.rs` to `path_item.rs`, since the module contains the `PathItem` struct only and make the `PathItem.operations` public
* rename `IgnoreUnusedDefinitions` option to `IgnoreUnusedSchemas` for better compatibility with 3.x versions
