### PR TITLE
chore: update dependencies, tools, and project metadata

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 install-license = "install cargo-license@0.6.1"
-install-test-tools = "install cargo-llvm-cov@0.6.7 cargo-nextest@0.9.67"
-install-dependency-check-tools = "install cargo-deny@0.14.17 cargo-machete@0.6.1"
+install-test-tools = "install cargo-llvm-cov@0.6.16 cargo-nextest@0.9.94"
+install-dependency-check-tools = "install cargo-deny@0.18.2 cargo-machete@0.8.0"
 update-tools = "install cargo-deny cargo-license cargo-llvm-cov cargo-machete cargo-nextest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "roas"
-version = "0.2.3"
-edition = "2021"
+version = "0.2.4"
+edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"
 readme = "README.md"
@@ -21,9 +21,9 @@ v2 = []
 v3_0 = []
 
 [dependencies]
-enumset = "1.1.3"
-monostate = "0.1.11"
-regex = "1.10.3"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
-thiserror = "1.0.58"
+enumset = "1.1.5"
+monostate = "0.1.14"
+regex = "1.11.1"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+thiserror = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Parsing and generating OpenAPI Specification:
 
 * [x] OpenAPI Specification v2.0
 * [x] OpenAPI Specification v3.0.X
-* [ ] OpenAPI Specification v3.0.0
+* [ ] OpenAPI Specification v3.1.X
 
 ## Usage
 

--- a/deny.toml
+++ b/deny.toml
@@ -91,8 +91,7 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
-    "Unicode-DFS-2016",
-    #"Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/src/common/formats.rs
+++ b/src/common/formats.rs
@@ -125,7 +125,7 @@ impl<'de> Deserialize<'de> for StringFormat {
     {
         struct StringFormatVisitor;
 
-        impl<'de> Visitor<'de> for StringFormatVisitor {
+        impl Visitor<'_> for StringFormatVisitor {
             type Value = StringFormat;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -22,7 +22,7 @@ pub trait PushError<T> {
     fn error(&mut self, path: String, args: T);
 }
 
-impl<'a, T> PushError<&str> for Context<'a, T> {
+impl<T> PushError<&str> for Context<'_, T> {
     fn error(&mut self, path: String, msg: &str) {
         if msg.starts_with('.') {
             self.errors.push(format!("{}{}", path, msg));
@@ -32,19 +32,19 @@ impl<'a, T> PushError<&str> for Context<'a, T> {
     }
 }
 
-impl<'a, T> PushError<String> for Context<'a, T> {
+impl<T> PushError<String> for Context<'_, T> {
     fn error(&mut self, path: String, msg: String) {
         self.error(path, msg.as_str());
     }
 }
 
-impl<'a, T> PushError<fmt::Arguments<'_>> for Context<'a, T> {
+impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
     fn error(&mut self, path: String, args: fmt::Arguments<'_>) {
         self.error(path, args.to_string().as_str());
     }
 }
 
-impl<'a, T> Context<'a, T> {
+impl<T> Context<'_, T> {
     pub fn reset(&mut self) {
         self.visited.clear();
         self.errors.clear();

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -127,7 +127,7 @@ impl<D> RefOr<D> {
     }
 
     /// Get the item from the RefOr by returning the Item or resolving a reference.
-    pub fn get_item<'a, T>(&'a self, spec: &'a T) -> Result<&D, ResolveError>
+    pub fn get_item<'a, T>(&'a self, spec: &'a T) -> Result<&'a D, ResolveError>
     where
         T: ResolveReference<D>,
     {

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_url, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_required_url};
 use crate::v2::spec::Spec;
 
 /// Allows referencing an external resource for extended documentation.

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{validate_pattern, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
 use crate::v2::items::Items;
 use crate::v2::spec::Spec;
 

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_email, validate_optional_url, validate_required_string, Context, ValidateWithContext,
+    Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
 };
 use crate::v2::spec::Spec;
 

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{validate_pattern, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
 use crate::v2::spec::Spec;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_string, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::parameter::Parameter;

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{
-    validate_pattern, validate_required_string, Context, ValidateWithContext,
+    Context, ValidateWithContext, validate_pattern, validate_required_string,
 };
 use crate::common::reference::RefOr;
 use crate::v2::items::Items;

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -7,7 +7,7 @@ use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::common::helpers::{validate_required_string, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v2::header::Header;
 use crate::v2::schema::Schema;
@@ -487,8 +487,8 @@ mod tests {
                     "description": "A simple response",
                 },
             }))
-                .unwrap_err()
-                .to_string(),
+            .unwrap_err()
+            .to_string(),
             "unknown field `foo`, expected one of `default`, `x-...`, `1xx`, `2xx`, `3xx`, `4xx`, `5xx`",
             "responses deserialization with invalid status code",
         );
@@ -499,8 +499,8 @@ mod tests {
                     "description": "A simple response",
                 },
             }))
-                .unwrap_err()
-                .to_string(),
+            .unwrap_err()
+            .to_string(),
             "unknown field `600`, expected one of `default`, `x-...`, `1xx`, `2xx`, `3xx`, `4xx`, `5xx`",
             "responses deserialization with 600 as status code",
         );
@@ -511,8 +511,8 @@ mod tests {
                     "description": "A simple response",
                 },
             }))
-                .unwrap_err()
-                .to_string(),
+            .unwrap_err()
+            .to_string(),
             "unknown field `42`, expected one of `default`, `x-...`, `1xx`, `2xx`, `3xx`, `4xx`, `5xx`",
             "responses deserialization with 42 as status code",
         );

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{validate_pattern, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
 use crate::common::reference::RefOr;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::spec::Spec;

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_optional_url, validate_required_string, Context, PushError, ValidateWithContext,
+    Context, PushError, ValidateWithContext, validate_optional_url, validate_required_string,
 };
 use crate::v2::spec::Spec;
 

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -240,7 +240,7 @@ impl ResolveReference<Schema> for Spec {
 
 impl ResolveReference<ObjectSchema> for Spec {
     fn resolve_reference(&self, reference: &str) -> Option<&ObjectSchema> {
-        if let Schema::Object(ref schema) = self
+        if let Schema::Object(schema) = self
             .definitions
             .as_ref()
             .and_then(|x| x.get(reference.trim_start_matches("#/definitions/")))?

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_optional_string_matches, Context, PushError, ValidateWithContext,
+    Context, PushError, ValidateWithContext, validate_optional_string_matches,
 };
 use crate::common::reference::ResolveReference;
 use crate::v2::external_documentation::ExternalDocumentation;

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::spec::Spec;
 

--- a/src/v2/xml.rs
+++ b/src/v2/xml.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_optional_url, validate_required_string, Context, ValidateWithContext,
+    Context, ValidateWithContext, validate_optional_url, validate_required_string,
 };
 use crate::v2::spec::Spec;
 

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_string_matches, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_string_matches};
 use crate::common::reference::RefOr;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::example::Example;

--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;

--- a/src/v3_0/example.rs
+++ b/src/v3_0/example.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_optional_url, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_url};
 use crate::v3_0::spec::Spec;
 
 /// Example object.

--- a/src/v3_0/external_documentation.rs
+++ b/src/v3_0/external_documentation.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_optional_url, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
 use crate::v3_0::spec::Spec;
 
 /// Allows referencing an external resource for extended documentation.

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_email, validate_optional_url, validate_required_string, Context, ValidateWithContext,
+    Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
 };
 use crate::v3_0::spec::Spec;
 

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -127,6 +127,7 @@ pub struct Encoding {
     /// - for other primitive types – `text/plain`;
     /// - for `object` - `application/json`;
     /// - for `array` – the default is defined based on the inner type.
+    ///
     /// The value can be a specific media type (e.g. `application/json`),
     /// a wildcard media type (e.g. `image/*`),
     /// or a comma-separated list of the two types.

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_string, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::external_documentation::ExternalDocumentation;

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_string, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -7,7 +7,7 @@ use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::common::helpers::{validate_required_string, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::header::Header;
 use crate::v3_0::link::Link;

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{validate_pattern, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
 use crate::common::reference::RefOr;
 use crate::v3_0::discriminator::Discriminator;
 use crate::v3_0::external_documentation::ExternalDocumentation;

--- a/src/v3_0/security_scheme.rs
+++ b/src/v3_0/security_scheme.rs
@@ -6,8 +6,8 @@ use std::fmt::{Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    validate_optional_url, validate_required_string, validate_required_url, Context, PushError,
-    ValidateWithContext,
+    Context, PushError, ValidateWithContext, validate_optional_url, validate_required_string,
+    validate_required_url,
 };
 use crate::v3_0::spec::Spec;
 

--- a/src/v3_0/server.rs
+++ b/src/v3_0/server.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashSet};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_string, Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
 

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -8,7 +8,7 @@ use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
-use crate::common::reference::{resolve_in_map, ResolveReference};
+use crate::common::reference::{ResolveReference, resolve_in_map};
 use crate::v3_0::callback::Callback;
 use crate::v3_0::components::Components;
 use crate::v3_0::example::Example;

--- a/src/v3_0/tag.rs
+++ b/src/v3_0/tag.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_required_string, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::spec::Spec;
 

--- a/src/v3_0/xml.rs
+++ b/src/v3_0/xml.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{validate_optional_url, Context, ValidateWithContext};
+use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
 use crate::v3_0::spec::Spec;
 
 /// A metadata object that allows for more fine-tuned XML model definitions.


### PR DESCRIPTION
Upgrade Cargo tool aliases to install newer versions of cargo-llvm-cov,
cargo-nextest, cargo-deny, and cargo-machete for improved functionality
and bug fixes. Bump project version to 0.2.4 and update Rust edition to
2024 to leverage latest language features. Update dependencies to their
latest versions to ensure compatibility and benefit from recent
improvements. Adjust README to reflect support for OpenAPI Specification
v3.1.X.