### PR TITLE
chore(ci): add toml formatting check and improve caching

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
 [alias]
-install-license = "install cargo-license@0.6.1"
-install-test-tools = "install cargo-llvm-cov@0.6.16 cargo-nextest@0.9.94"
-install-dependency-check-tools = "install cargo-deny@0.18.2 cargo-machete@0.8.0"
-update-tools = "install cargo-deny cargo-license cargo-llvm-cov cargo-machete cargo-nextest"
+tools = "install cargo-deny cargo-license cargo-llvm-cov cargo-machete cargo-nextest taplo-cli cargo-action-fmt"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -23,6 +23,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: cargo build --all-features --verbose
+  Toml-Fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          cache-all-crates: true
+      - run: cargo tools
+      - run: taplo fmt --check
   Format:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +42,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: cargo clippy --all-features --verbose
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          cache-all-crates: true
+      - run: cargo tools
+      - run: cargo clippy --all-features --verbose -- --deny warnings
+      - run: cargo clippy --all-features --quiet --message-format=json | cargo-action-fmt
+        if: failure()
   Tests:
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +58,7 @@ jobs:
         with:
           cache-targets: false
           cache-all-crates: true
-      - run: cargo install-test-tools
+      - run: cargo tools
       - name: Run tests
         run: cargo llvm-cov nextest --all-features --all-targets --no-fail-fast --verbose
       - name: Prepare coverage report
@@ -65,7 +82,7 @@ jobs:
         with:
           cache-targets: false
           cache-all-crates: true
-      - run: cargo install-dependency-check-tools
+      - run: cargo tools
       - name: Machete
         run: cargo machete
       - name: Deny
@@ -78,7 +95,7 @@ jobs:
         with:
           cache-targets: false
           cache-all-crates: true
-      - run: cargo install-license
+      - run: cargo tools
       - name: Dry run publish
         run: |
           cargo license --all-features --avoid-dev-deps --json > dependencies-license.json

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,8 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install tools
-        run: cargo install-license
+      - run: cargo install cargo-license
       - name: Publish
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,14 @@ homepage = "https://github.com/sv-tools/roas"
 repository = "https://github.com/sv-tools/roas"
 keywords = ["openapi", "swagger"]
 categories = ["web-programming", "parser-implementations"]
-include = ["src", "Cargo.toml", "README.md", "LICENSE-APACHE", "LICENSE-MIT", "dependencies-license.json"]
+include = [
+  "src",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE-APACHE",
+  "LICENSE-MIT",
+  "dependencies-license.json",
+]
 
 [package.metadata]
 dependencies-license-file = "dependencies-license.json"

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  #"x86_64-unknown-linux-musl",
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -70,10 +70,10 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
-    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+  #"RUSTSEC-0000-0000",
+  #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+  #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+  #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -88,11 +88,7 @@ ignore = [
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = [
-    "MIT",
-    "Apache-2.0",
-    "Unicode-3.0",
-]
+allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -101,9 +97,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], crate = "adler32" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -134,7 +130,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -161,16 +157,16 @@ workspace-default-features = "allow"
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
 # List of crates to deny
 deny = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
 ]
 
 # List of features to allow/deny
@@ -198,16 +194,16 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-    #{ crate = "ansi_term@0.11.0", depth = 20 },
+  #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+  #{ crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
Add a new GitHub Actions job to check TOML formatting using taplo.
Refactor existing workflows to use cargo tools instead of install-test-tools.
Enable rust-cache action for better caching of dependencies.
Add conditional formatting on clippy failure to improve feedback.
Clean up deny.toml formatting and align allow/deny lists for clarity.
Update Cargo.toml include array formatting for consistency.
Fix cargo-license installation command in publish workflow.