### PR TITLE
chore: update validation to allow ignoring empty required fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"
@@ -28,7 +28,7 @@ v2 = []
 v3_0 = []
 
 [dependencies]
-enumset = "1.1.5"
+enumset = "1.1.6"
 monostate = "0.1.14"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-roas = { version = "0.2", features = ["v3_0"] } 
+roas = { version = "0.3", features = ["v3_0"] } 
 ```
 
 ## Examples

--- a/src/common/extensions.rs
+++ b/src/common/extensions.rs
@@ -55,7 +55,7 @@ where
             while let Some(key) = map.next_key::<String>()? {
                 if key.starts_with("x-") {
                     if ext.contains_key(key.as_str()) {
-                        return Err(Error::custom(format_args!("duplicate field `{}`", key)));
+                        return Err(Error::custom(format_args!("duplicate field `{key}`")));
                     }
                     let value: serde_json::Value = map.next_value()?;
                     ext.insert(key, value);

--- a/src/common/formats.rs
+++ b/src/common/formats.rs
@@ -37,7 +37,7 @@ impl Display for StringFormat {
             StringFormat::DateTime => write!(f, "date-time"),
             StringFormat::Password => write!(f, "password"),
             StringFormat::UUID => write!(f, "uuid"),
-            StringFormat::Custom(s) => write!(f, "{}", s),
+            StringFormat::Custom(s) => write!(f, "{s}"),
         }
     }
 }

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -25,9 +25,9 @@ pub trait PushError<T> {
 impl<T> PushError<&str> for Context<'_, T> {
     fn error(&mut self, path: String, msg: &str) {
         if msg.starts_with('.') {
-            self.errors.push(format!("{}{}", path, msg));
+            self.errors.push(format!("{path}{msg}"));
         } else {
-            self.errors.push(format!("{}: {}", path, msg));
+            self.errors.push(format!("{path}: {msg}"));
         }
     }
 }
@@ -89,7 +89,7 @@ pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: Str
         if !email.contains('@') {
             ctx.error(
                 path,
-                format_args!("must be a valid email address, found `{}`", email),
+                format_args!("must be a valid email address, found `{email}`"),
             );
         }
     }
@@ -106,7 +106,7 @@ pub fn validate_optional_url<T>(url: &Option<String>, ctx: &mut Context<T>, path
 
 pub fn validate_required_url<T>(url: &String, ctx: &mut Context<T>, path: String) {
     if !url.starts_with(HTTP) && !url.starts_with(HTTPS) {
-        ctx.error(path, format_args!("must be a valid URL, found `{}`", url));
+        ctx.error(path, format_args!("must be a valid URL, found `{url}`"));
     }
 }
 
@@ -120,7 +120,7 @@ pub fn validate_string_matches<T>(s: &str, pattern: &Regex, ctx: &mut Context<T>
     if !pattern.is_match(s) {
         ctx.error(
             path,
-            format_args!("must match pattern `{}`, found `{}`", pattern, s),
+            format_args!("must match pattern `{pattern}`, found `{s}`"),
         );
     }
 }
@@ -141,7 +141,7 @@ pub fn validate_pattern<T>(pattern: &str, ctx: &mut Context<T>, path: String) {
         Ok(_) => {}
         Err(e) => ctx.error(
             path,
-            format_args!("pattern `{}` is invalid: {}", pattern, e),
+            format_args!("pattern `{pattern}` is invalid: {e}"),
         ),
     }
 }

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -139,9 +139,6 @@ pub fn validate_optional_string_matches<T>(
 pub fn validate_pattern<T>(pattern: &str, ctx: &mut Context<T>, path: String) {
     match Regex::new(pattern) {
         Ok(_) => {}
-        Err(e) => ctx.error(
-            path,
-            format_args!("pattern `{pattern}` is invalid: {e}"),
-        ),
+        Err(e) => ctx.error(path, format_args!("pattern `{pattern}` is invalid: {e}")),
     }
 }

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -99,11 +99,11 @@ impl<D> RefOr<D> {
                         }
                         Err(e) => match e {
                             ResolveError::NotFound(r) => {
-                                ctx.error(path, format_args!(".$ref: `{}` not found", r));
+                                ctx.error(path, format_args!(".$ref: `{r}` not found"));
                             }
                             ResolveError::ExternalUnsupported(_) => {
                                 if !ctx.is_option(Options::IgnoreExternalReferences) {
-                                    ctx.error(path, format_args!(".$ref: {}", e));
+                                    ctx.error(path, format_args!(".$ref: {e}"));
                                 }
                             }
                         },

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -36,7 +36,7 @@ pub struct ExternalDocumentation {
 
 impl ValidateWithContext<Spec> for ExternalDocumentation {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(&self.url, ctx, format!("{}.url", path));
+        validate_required_url(&self.url, ctx, format!("{path}.url"));
     }
 }
 

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -255,7 +255,7 @@ impl ValidateWithContext<Spec> for Header {
 impl ValidateWithContext<Spec> for StringHeader {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(pattern) = &self.pattern {
-            validate_pattern(pattern, ctx, format!("{}.pattern", path));
+            validate_pattern(pattern, ctx, format!("{path}.pattern"));
         }
     }
 }
@@ -275,7 +275,7 @@ impl ValidateWithContext<Spec> for BooleanHeader {
 impl ValidateWithContext<Spec> for ArrayHeader {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         self.items
-            .validate_with_context(ctx, format!("{}.items", path));
+            .validate_with_context(ctx, format!("{path}.items"));
     }
 }
 

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -130,33 +130,33 @@ pub struct License {
 impl ValidateWithContext<Spec> for Info {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if !ctx.is_option(Options::IgnoreEmptyInfoTitle) {
-            validate_required_string(&self.title, ctx, format!("{}.title", path));
+            validate_required_string(&self.title, ctx, format!("{path}.title"));
         }
         if !ctx.is_option(Options::IgnoreEmptyInfoVersion) {
-            validate_required_string(&self.version, ctx, format!("{}.version", path));
+            validate_required_string(&self.version, ctx, format!("{path}.version"));
         }
 
         if let Some(contact) = &self.contact {
-            contact.validate_with_context(ctx, format!("{}.contact", path));
+            contact.validate_with_context(ctx, format!("{path}.contact"));
         }
 
         if let Some(license) = &self.license {
-            license.validate_with_context(ctx, format!("{}.license", path));
+            license.validate_with_context(ctx, format!("{path}.license"));
         }
     }
 }
 
 impl ValidateWithContext<Spec> for Contact {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&self.url, ctx, format!("{}.url", path));
-        validate_email(&self.email, ctx, format!("{}.email", path));
+        validate_optional_url(&self.url, ctx, format!("{path}.url"));
+        validate_email(&self.email, ctx, format!("{path}.email"));
     }
 }
 
 impl ValidateWithContext<Spec> for License {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
-        validate_optional_url(&self.url, ctx, format!("{}.url", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+        validate_optional_url(&self.url, ctx, format!("{path}.url"));
     }
 }
 

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -172,11 +172,11 @@ mod tests {
             serde_json::from_value::<Info>(json!({
               "title": "Swagger Sample App",
               "description": "This is a sample server Petstore server.",
-              "termsOfService": "https://swagger.io/terms/",
+              "termsOfService": "https://example.com/terms/",
               "contact": {
                 "name": "API Support",
-                "url": "https://www.swagger.io/support",
-                "email": "support@swagger.io"
+                "url": "https://www.example.com/support",
+                "email": "support@example.com"
               },
               "license": {
                 "name": "Apache 2.0",
@@ -188,11 +188,11 @@ mod tests {
             Info {
                 title: String::from("Swagger Sample App"),
                 description: Some(String::from("This is a sample server Petstore server.")),
-                terms_of_service: Some(String::from("https://swagger.io/terms/")),
+                terms_of_service: Some(String::from("https://example.com/terms/")),
                 contact: Some(Contact {
                     name: Some(String::from("API Support")),
-                    url: Some(String::from("https://www.swagger.io/support")),
-                    email: Some(String::from("support@swagger.io")),
+                    url: Some(String::from("https://www.example.com/support")),
+                    email: Some(String::from("support@example.com")),
                     ..Default::default()
                 }),
                 license: Some(License {
@@ -207,6 +207,48 @@ mod tests {
             },
             "deserialize",
         );
+
+        assert_eq!(
+            serde_json::from_value::<Info>(json!({
+              "title": "Swagger Sample App",
+              "description": "This is a sample server Petstore server.",
+              "termsOfService": "https://example.com/terms/",
+              "version": "1.0.1"
+            }))
+            .unwrap(),
+            Info {
+                title: String::from("Swagger Sample App"),
+                description: Some(String::from("This is a sample server Petstore server.")),
+                terms_of_service: Some(String::from("https://example.com/terms/")),
+                version: "1.0.1".to_owned(),
+                ..Default::default()
+            },
+            "deserialize",
+        );
+
+        assert_eq!(
+            serde_json::from_value::<Info>(json!({
+              "title": "Swagger Sample App",
+              "version": "1.0.1"
+            }))
+            .unwrap(),
+            Info {
+                title: String::from("Swagger Sample App"),
+                version: "1.0.1".to_owned(),
+                ..Default::default()
+            },
+            "deserialize",
+        );
+
+        assert_eq!(
+            serde_json::from_value::<Info>(json!({
+              "title": "",
+              "version": ""
+            }))
+            .unwrap(),
+            Info::default(),
+            "deserialize",
+        );
     }
 
     #[test]
@@ -215,11 +257,11 @@ mod tests {
             serde_json::to_value(Info {
                 title: String::from("Swagger Sample App"),
                 description: Some(String::from("This is a sample server Petstore server.")),
-                terms_of_service: Some(String::from("https://swagger.io/terms/")),
+                terms_of_service: Some(String::from("https://example.com/terms/")),
                 contact: Some(Contact {
                     name: Some(String::from("API Support")),
-                    url: Some(String::from("https://www.swagger.io/support")),
-                    email: Some(String::from("support@swagger.io")),
+                    url: Some(String::from("https://www.example.com/support")),
+                    email: Some(String::from("support@example.com")),
                     ..Default::default()
                 }),
                 license: Some(License {
@@ -236,11 +278,11 @@ mod tests {
             json!({
               "title": "Swagger Sample App",
               "description": "This is a sample server Petstore server.",
-              "termsOfService": "https://swagger.io/terms/",
+              "termsOfService": "https://example.com/terms/",
               "contact": {
                 "name": "API Support",
-                "url": "https://www.swagger.io/support",
-                "email": "support@swagger.io"
+                "url": "https://www.example.com/support",
+                "email": "support@example.com"
               },
               "license": {
                 "name": "Apache 2.0",
@@ -250,5 +292,275 @@ mod tests {
             }),
             "serialize",
         );
+
+        assert_eq!(
+            serde_json::to_value(Info {
+                title: String::from("Swagger Sample App"),
+                description: Some(String::from("This is a sample server Petstore server.")),
+                terms_of_service: Some(String::from("https://example.com/terms/")),
+                version: "1.0.1".to_owned(),
+                ..Default::default()
+            })
+            .unwrap(),
+            json!({
+              "title": "Swagger Sample App",
+              "description": "This is a sample server Petstore server.",
+              "termsOfService": "https://example.com/terms/",
+              "version": "1.0.1"
+            }),
+            "serialize",
+        );
+
+        assert_eq!(
+            serde_json::to_value(Info {
+                title: String::from("Swagger Sample App"),
+                version: "1.0.1".to_owned(),
+                ..Default::default()
+            })
+            .unwrap(),
+            json!({
+              "title": "Swagger Sample App",
+              "version": "1.0.1"
+            }),
+            "serialize",
+        );
+        assert_eq!(
+            serde_json::to_value(Info::default()).unwrap(),
+            json!({}),
+            "serialize",
+        );
+    }
+
+    #[test]
+    fn test_contact_deserialize() {
+        assert_eq!(
+            serde_json::from_value::<Contact>(json!({
+                "name": "API Support",
+                "url": "https://www.example.com/support",
+                "email": "support@example.com"
+            }))
+            .unwrap(),
+            Contact {
+                name: Some(String::from("API Support")),
+                url: Some(String::from("https://www.example.com/support")),
+                email: Some(String::from("support@example.com")),
+                ..Default::default()
+            },
+            "deserialize",
+        );
+    }
+
+    #[test]
+    fn test_contact_serialize() {
+        assert_eq!(
+            serde_json::to_value(Contact {
+                name: Some(String::from("API Support")),
+                url: Some(String::from("https://www.example.com/support")),
+                email: Some(String::from("support@example.com")),
+                ..Default::default()
+            })
+            .unwrap(),
+            json!({
+                "name": "API Support",
+                "url": "https://www.example.com/support",
+                "email": "support@example.com"
+            }),
+            "serialize",
+        );
+    }
+
+    #[test]
+    fn test_license_deserialize() {
+        assert_eq!(
+            serde_json::from_value::<License>(json!({
+                "name": "Apache 2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+            }))
+            .unwrap(),
+            License {
+                name: String::from("Apache 2.0"),
+                url: Some(String::from(
+                    "https://www.apache.org/licenses/LICENSE-2.0.html"
+                )),
+                ..Default::default()
+            },
+            "deserialize",
+        );
+    }
+
+    #[test]
+    fn test_license_serialize() {
+        assert_eq!(
+            serde_json::to_value(License {
+                name: String::from("Apache 2.0"),
+                url: Some(String::from(
+                    "https://www.apache.org/licenses/LICENSE-2.0.html"
+                )),
+                ..Default::default()
+            })
+            .unwrap(),
+            json!({
+                "name": "Apache 2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+            }),
+            "serialize",
+        );
+    }
+
+    #[test]
+    fn test_contact_validate() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Default::default());
+        Contact {
+            name: Some(String::from("API Support")),
+            url: Some(String::from("https://www.example.com/support")),
+            email: Some(String::from("support@example.com")),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("contact"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        Contact {
+            url: Some(String::from("https://www.example.com/support")),
+            email: Some(String::from("support@example.com")),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("contact"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        Contact {
+            url: Some(String::from("foo - bar")),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("contact"));
+        assert_eq!(ctx.errors.len(), 1, "incorrect url: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Default::default());
+        Contact {
+            email: Some(String::from("foo - bar")),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("contact"));
+        assert_eq!(ctx.errors.len(), 1, "incorrect email: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn test_license_validate() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Default::default());
+        License {
+            name: String::from("Apache 2.0"),
+            url: Some(String::from(
+                "https://www.apache.org/licenses/LICENSE-2.0.html",
+            )),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("license"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        License {
+            name: String::from("Apache 2.0"),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("license"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Default::default());
+        License {
+            name: String::from(""),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("license"));
+        assert_eq!(ctx.errors.len(), 1, "empty name: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Default::default());
+        License {
+            name: String::from("Apache 2.0"),
+            url: Some(String::from("foo - bar")),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("license"));
+        assert_eq!(ctx.errors.len(), 1, "incorrect url: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn test_info_validate() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Default::default());
+        Info {
+            title: String::from("Swagger Sample App"),
+            description: Some(String::from("This is a sample server Petstore server.")),
+            terms_of_service: Some(String::from("https://example.com/terms/")),
+            contact: Some(Contact {
+                name: Some(String::from("API Support")),
+                url: Some(String::from("https://www.example.com/support")),
+                email: Some(String::from("support@example.com")),
+                ..Default::default()
+            }),
+            license: Some(License {
+                name: String::from("Apache 2.0"),
+                url: Some(String::from(
+                    "https://www.apache.org/licenses/LICENSE-2.0.html",
+                )),
+                ..Default::default()
+            }),
+            version: "1.0.1".to_owned(),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        Info {
+            title: String::from("Swagger Sample App"),
+            description: Some(String::from("This is a sample server Petstore server.")),
+            terms_of_service: Some(String::from("https://example.com/terms/")),
+            version: "1.0.1".to_owned(),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        Info {
+            title: String::from("Swagger Sample App"),
+            version: "1.0.1".to_owned(),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        Info {
+            title: String::from("Swagger Sample App"),
+            version: String::from(""),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert_eq!(ctx.errors.len(), 1, "empty version: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Default::default());
+        Info {
+            title: String::from(""),
+            version: String::from("1.0.1"),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert_eq!(ctx.errors.len(), 1, "empty title: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Options::only(&Options::IgnoreEmptyInfoTitle));
+        Info {
+            title: String::from(""),
+            version: String::from("1.0.1"),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Options::only(&Options::IgnoreEmptyInfoVersion));
+        Info {
+            title: String::from("Swagger Sample App"),
+            version: String::from(""),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
     }
 }

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -8,6 +8,7 @@ use crate::common::helpers::{
     Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
 };
 use crate::v2::spec::Spec;
+use crate::validation::Options;
 
 /// The object provides metadata about the API.
 /// The metadata can be used by the clients if needed, and can be presented in the Swagger-UI for convenience.
@@ -29,6 +30,7 @@ use crate::v2::spec::Spec;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Info {
     /// **Required** The title of the application.
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub title: String,
 
     /// A short description of the application.
@@ -50,6 +52,7 @@ pub struct Info {
     pub license: Option<License>,
 
     /// **Required** Provides the version of the application API (not to be confused with the specification version).
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub version: String,
 
     /// Allows extensions to the Swagger Schema.
@@ -126,8 +129,12 @@ pub struct License {
 
 impl ValidateWithContext<Spec> for Info {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.title, ctx, format!("{}.title", path));
-        validate_required_string(&self.version, ctx, format!("{}.version", path));
+        if !ctx.is_option(Options::IgnoreEmptyInfoTitle) {
+            validate_required_string(&self.title, ctx, format!("{}.title", path));
+        }
+        if !ctx.is_option(Options::IgnoreEmptyInfoVersion) {
+            validate_required_string(&self.version, ctx, format!("{}.version", path));
+        }
 
         if let Some(contact) = &self.contact {
             contact.validate_with_context(ctx, format!("{}.contact", path));

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -241,7 +241,7 @@ impl ValidateWithContext<Spec> for Items {
 impl ValidateWithContext<Spec> for StringItem {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(pattern) = &self.pattern {
-            validate_pattern(pattern, ctx, format!("{}.pattern", path));
+            validate_pattern(pattern, ctx, format!("{path}.pattern"));
         }
     }
 }
@@ -261,7 +261,7 @@ impl ValidateWithContext<Spec> for BooleanItem {
 impl ValidateWithContext<Spec> for ArrayItem {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         self.items
-            .validate_with_context(ctx, format!("{}.items", path));
+            .validate_with_context(ctx, format!("{path}.items"));
     }
 }
 
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn test_string_items_serialize() {
         assert_eq!(
-            serde_json::to_value(&Items::String(StringItem {
+            serde_json::to_value(Items::String(StringItem {
                 format: Some(StringFormat::Byte),
                 default: Some(String::from("default")),
                 enum_values: Some(vec![String::from("enum1"), String::from("enum2")]),
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn test_integer_items_serialize() {
         assert_eq!(
-            serde_json::to_value(&Items::Integer(IntegerItem {
+            serde_json::to_value(Items::Integer(IntegerItem {
                 format: Some(IntegerFormat::Int64),
                 default: Some(42),
                 enum_values: Some(vec![42, 105]),
@@ -439,7 +439,7 @@ mod tests {
     #[test]
     fn test_number_items_serialize() {
         assert_eq!(
-            serde_json::to_value(&Items::Number(NumberItem {
+            serde_json::to_value(Items::Number(NumberItem {
                 format: Some(NumberFormat::Double),
                 default: Some(42.0),
                 enum_values: Some(vec![42.0, 105.0]),
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn test_boolean_items_serialize() {
         assert_eq!(
-            serde_json::to_value(&Items::Boolean(BooleanItem {
+            serde_json::to_value(Items::Boolean(BooleanItem {
                 default: Some(true),
                 extensions: Some({
                     let mut map = BTreeMap::new();
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn test_array_items_serialize() {
         assert_eq!(
-            serde_json::to_value(&Items::Array(ArrayItem {
+            serde_json::to_value(Items::Array(ArrayItem {
                 items: Box::new(Items::Number(NumberItem {
                     format: Some(NumberFormat::Double),
                     ..Default::default()

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -235,12 +235,12 @@ mod tests {
                     "application/xml".to_owned(),
                 ]),
                 parameters: Some(vec![
-                    RefOr::new_item(Parameter::Path(InPath::String(StringParameter {
+                    RefOr::new_item(Parameter::Path(Box::new(InPath::String(StringParameter {
                         name: "petId".to_owned(),
                         description: Some("ID of pet that needs to be updated".to_owned()),
                         required: Some(true),
                         ..Default::default()
-                    }))),
+                    })))),
                     RefOr::new_ref("#/definitions/Pet".to_owned()),
                 ]),
                 responses: Responses {
@@ -305,12 +305,12 @@ mod tests {
                     "application/xml".to_owned(),
                 ]),
                 parameters: Some(vec![
-                    RefOr::new_item(Parameter::Path(InPath::String(StringParameter {
+                    RefOr::new_item(Parameter::Path(Box::new(InPath::String(StringParameter {
                         name: "petId".to_owned(),
                         description: Some("ID of pet that needs to be updated".to_owned()),
                         required: Some(true),
                         ..Default::default()
-                    }))),
+                    })))),
                     RefOr::new_ref("#/definitions/Pet".to_owned()),
                 ]),
                 responses: Responses {

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -103,22 +103,22 @@ impl ValidateWithContext<Spec> for Operation {
         if let Some(operation_id) = &self.operation_id {
             if !ctx
                 .visited
-                .insert(format!("#/paths/operations/{}", operation_id))
+                .insert(format!("#/paths/operations/{operation_id}"))
             {
                 ctx.error(
                     path.clone(),
-                    format_args!("operationId `{}` already exists", operation_id),
+                    format_args!("operationId `{operation_id}` already exists"),
                 );
             }
         }
         if let Some(tags) = &self.tags {
             for (i, tag) in tags.iter().enumerate() {
-                validate_required_string(tag, ctx, format!("{}.tags[{}]", path, i));
+                validate_required_string(tag, ctx, format!("{path}.tags[{i}]"));
                 if tag.is_empty() {
                     continue;
                 }
 
-                let reference = format!("#/tags/{}", tag);
+                let reference = format!("#/tags/{tag}");
                 if let Ok(spec_tag) = RefOr::<Tag>::new_ref(reference.clone()).get_item(ctx.spec) {
                     if ctx.visit(reference.clone()) {
                         spec_tag.validate_with_context(ctx, reference);
@@ -126,7 +126,7 @@ impl ValidateWithContext<Spec> for Operation {
                 } else if !ctx.is_option(Options::IgnoreMissingTags) {
                     ctx.error(
                         path.clone(),
-                        format_args!(".tags[{}]: `{}` not found in spec", i, tag),
+                        format_args!(".tags[{i}]: `{tag}` not found in spec"),
                     );
                 }
             }
@@ -135,7 +135,7 @@ impl ValidateWithContext<Spec> for Operation {
         if let Some(parameters) = &self.parameters {
             let mut body_count = 0;
             for (i, parameter) in parameters.clone().iter().enumerate() {
-                parameter.validate_with_context(ctx, format!("{}.parameters[{}]", path, i));
+                parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
                 if let RefOr::Item(Parameter::Body(_)) = parameter {
                     body_count += 1;
                 }
@@ -144,15 +144,14 @@ impl ValidateWithContext<Spec> for Operation {
                 ctx.error(
                     path.clone(),
                     format_args!(
-                        ".parameters: only one body parameter allowed, found {}",
-                        body_count,
+                        ".parameters: only one body parameter allowed, found {body_count}",
                     ),
                 );
             }
         }
 
         self.responses
-            .validate_with_context(ctx, format!("{}.responses", path));
+            .validate_with_context(ctx, format!("{path}.responses"));
     }
 }
 

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -17,19 +17,19 @@ use crate::v2::spec::Spec;
 #[serde(tag = "in")]
 pub enum Parameter {
     #[serde(rename = "body")]
-    Body(InBody),
+    Body(Box<InBody>),
 
     #[serde(rename = "header")]
-    Header(InHeader),
+    Header(Box<InHeader>),
 
     #[serde(rename = "query")]
-    Query(InQuery),
+    Query(Box<InQuery>),
 
     #[serde(rename = "path")]
-    Path(InPath),
+    Path(Box<InPath>),
 
     #[serde(rename = "formData")]
-    FormData(InFormData),
+    FormData(Box<InFormData>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -630,8 +630,7 @@ impl ValidateWithContext<Spec> for FileParameter {
 
 fn must_be_required(p: &Option<bool>, ctx: &mut Context<Spec>, path: String, name: String) {
     if !p.is_some_and(|x| x) {
-        ctx.errors
-            .push(format!("{path}.{name}: must be required"));
+        ctx.errors.push(format!("{path}.{name}: must be required"));
     }
 }
 

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -482,9 +482,9 @@ impl ValidateWithContext<Spec> for Parameter {
 
 impl ValidateWithContext<Spec> for InBody {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}name", path));
+        validate_required_string(&self.name, ctx, format!("{path}name"));
         self.schema
-            .validate_with_context(ctx, format!("{}.schema", path));
+            .validate_with_context(ctx, format!("{path}.schema"));
     }
 }
 
@@ -495,7 +495,7 @@ impl ValidateWithContext<Spec> for InHeader {
                 p.validate_with_context(ctx, path.clone());
                 must_not_allow_empty_value(&p.allow_empty_value, ctx, path.clone(), p.name.clone());
                 if let Some(pattern) = &p.pattern {
-                    validate_pattern(pattern, ctx, format!("{}.pattern", path));
+                    validate_pattern(pattern, ctx, format!("{path}.pattern"));
                 }
             }
             InHeader::Integer(p) => {
@@ -594,44 +594,44 @@ impl ValidateWithContext<Spec> for InFormData {
 
 impl ValidateWithContext<Spec> for StringParameter {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
 impl ValidateWithContext<Spec> for IntegerParameter {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
 impl ValidateWithContext<Spec> for NumberParameter {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
 impl ValidateWithContext<Spec> for BooleanParameter {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
 impl ValidateWithContext<Spec> for ArrayParameter {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
 impl ValidateWithContext<Spec> for FileParameter {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
 fn must_be_required(p: &Option<bool>, ctx: &mut Context<Spec>, path: String, name: String) {
     if !p.is_some_and(|x| x) {
         ctx.errors
-            .push(format!("{}.{}: must be required", path, name));
+            .push(format!("{path}.{name}: must be required"));
     }
 }
 
@@ -643,6 +643,6 @@ fn must_not_allow_empty_value(
 ) {
     if p.is_some_and(|x| x) {
         ctx.errors
-            .push(format!("{}.{}: must not allow empty value", path, name));
+            .push(format!("{path}.{name}: must not allow empty value"));
     }
 }

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -624,8 +624,8 @@ mod tests {
                     );
                     operations
                 }),
-                parameters: Some(vec![RefOr::new_item(Parameter::Path(InPath::Array(
-                    ArrayParameter {
+                parameters: Some(vec![RefOr::new_item(Parameter::Path(Box::new(
+                    InPath::Array(ArrayParameter {
                         name: String::from("id"),
                         description: Some(String::from("ID of pet to use")),
                         required: Some(true),
@@ -634,7 +634,7 @@ mod tests {
                         }),
                         collection_format: Some(CollectionFormat::CSV),
                         ..Default::default()
-                    }
+                    })
                 )))]),
                 extensions: Some({
                     let mut map = BTreeMap::new();

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -163,13 +163,13 @@ impl<'de> Deserialize<'de> for PathItem {
                         res.parameters = Some(map.next_value()?);
                     } else if key.starts_with("x-") {
                         if extensions.contains_key(key.clone().as_str()) {
-                            return Err(Error::custom(format!("duplicate field '{}'", key)));
+                            return Err(Error::custom(format!("duplicate field '{key}'")));
                         }
                         extensions.insert(key, map.next_value()?);
                     } else {
                         let key = key.to_lowercase();
                         if operations.contains_key(key.as_str()) {
-                            return Err(Error::custom(format!("duplicate field '{}'", key)));
+                            return Err(Error::custom(format!("duplicate field '{key}'")));
                         }
                         operations.insert(key, map.next_value()?);
                     }
@@ -192,13 +192,13 @@ impl ValidateWithContext<Spec> for PathItem {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(other) = &self.operations {
             for (method, operation) in other.iter() {
-                operation.validate_with_context(ctx, format!("{}.{}", path, method));
+                operation.validate_with_context(ctx, format!("{path}.{method}"));
             }
         }
 
         if let Some(parameters) = &self.parameters {
             for (i, parameter) in parameters.iter().enumerate() {
-                parameter.validate_with_context(ctx, format!("{}.parameters[{}]", path, i));
+                parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
             }
         }
     }

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -12,6 +12,7 @@ use crate::common::reference::RefOr;
 use crate::v2::header::Header;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
+use crate::validation::Options;
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Responses {
@@ -37,6 +38,7 @@ pub struct Responses {
 pub struct Response {
     /// **Required** A short description of the response.
     /// [GFM](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#-git-hub-flavored-markdown) syntax can be used for rich text representation.
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub description: String,
 
     /// A definition of the response structure.
@@ -158,7 +160,9 @@ impl<'de> Deserialize<'de> for Responses {
 
 impl ValidateWithContext<Spec> for Response {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.description, ctx, format!("{}.description", path));
+        if !ctx.is_option(Options::IgnoreEmptyResponseDescription) {
+            validate_required_string(&self.description, ctx, format!("{}.description", path));
+        }
         if let Some(schema) = &self.schema {
             schema.validate_with_context(ctx, format!("{}.schema", path));
         }

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -126,7 +126,7 @@ impl<'de> Deserialize<'de> for Responses {
                         res.default = Some(map.next_value()?);
                     } else if key.starts_with("x-") {
                         if extensions.contains_key(key.as_str()) {
-                            return Err(Error::custom(format_args!("duplicate field `{}`", key)));
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
                         }
                         extensions.insert(key, map.next_value()?);
                     } else {
@@ -134,8 +134,7 @@ impl<'de> Deserialize<'de> for Responses {
                             Ok(100..=599) => {
                                 if responses.contains_key(key.as_str()) {
                                     return Err(Error::custom(format_args!(
-                                        "duplicate field `{}`",
-                                        key
+                                        "duplicate field `{key}`"
                                     )));
                                 }
                                 responses.insert(key, map.next_value()?);
@@ -161,14 +160,14 @@ impl<'de> Deserialize<'de> for Responses {
 impl ValidateWithContext<Spec> for Response {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if !ctx.is_option(Options::IgnoreEmptyResponseDescription) {
-            validate_required_string(&self.description, ctx, format!("{}.description", path));
+            validate_required_string(&self.description, ctx, format!("{path}.description"));
         }
         if let Some(schema) = &self.schema {
-            schema.validate_with_context(ctx, format!("{}.schema", path));
+            schema.validate_with_context(ctx, format!("{path}.schema"));
         }
         if let Some(headers) = &self.headers {
             for (name, header) in headers {
-                header.validate_with_context(ctx, format!("{}.headers.{}", path, name));
+                header.validate_with_context(ctx, format!("{path}.headers.{name}"));
             }
         }
     }
@@ -177,7 +176,7 @@ impl ValidateWithContext<Spec> for Response {
 impl ValidateWithContext<Spec> for Responses {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(response) = &self.default {
-            response.validate_with_context(ctx, format!("{}.default", path));
+            response.validate_with_context(ctx, format!("{path}.default"));
         }
         if let Some(responses) = &self.responses {
             for (name, response) in responses {
@@ -187,13 +186,12 @@ impl ValidateWithContext<Spec> for Responses {
                         ctx.error(
                             path.clone(),
                             format!(
-                                "name must be an integer within [100..599] range, found `{}`",
-                                name
+                                "name must be an integer within [100..599] range, found `{name}`"
                             ),
                         );
                     }
                 }
-                response.validate_with_context(ctx, format!("{}.{}", path, name));
+                response.validate_with_context(ctx, format!("{path}.{name}"));
             }
         }
     }

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -614,13 +614,13 @@ impl ValidateWithContext<Spec> for Schema {
 impl ValidateWithContext<Spec> for StringSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
         if let Some(pattern) = &self.pattern {
-            validate_pattern(pattern, ctx, format!("{}.pattern", path));
+            validate_pattern(pattern, ctx, format!("{path}.pattern"));
         }
     }
 }
@@ -628,10 +628,10 @@ impl ValidateWithContext<Spec> for StringSchema {
 impl ValidateWithContext<Spec> for IntegerSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }
@@ -639,10 +639,10 @@ impl ValidateWithContext<Spec> for IntegerSchema {
 impl ValidateWithContext<Spec> for NumberSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }
@@ -650,10 +650,10 @@ impl ValidateWithContext<Spec> for NumberSchema {
 impl ValidateWithContext<Spec> for BooleanSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }
@@ -661,14 +661,14 @@ impl ValidateWithContext<Spec> for BooleanSchema {
 impl ValidateWithContext<Spec> for ArraySchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
 
         if let Some(items) = &self.items {
-            items.validate_with_context_boxed(ctx, format!("{}.items", path));
+            items.validate_with_context_boxed(ctx, format!("{path}.items"));
         }
     }
 }
@@ -676,15 +676,15 @@ impl ValidateWithContext<Spec> for ArraySchema {
 impl ValidateWithContext<Spec> for ObjectSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
 
         if let Some(properties) = &self.properties {
             for (name, schema) in properties {
-                schema.validate_with_context_boxed(ctx, format!("{}.properties.{}", path, name));
+                schema.validate_with_context_boxed(ctx, format!("{path}.properties.{name}"));
             }
         }
 
@@ -693,13 +693,13 @@ impl ValidateWithContext<Spec> for ObjectSchema {
                 BoolOr::Bool(_) => {}
                 BoolOr::Item(schema) => {
                     schema
-                        .validate_with_context_boxed(ctx, format!("{}.additionalProperties", path));
+                        .validate_with_context_boxed(ctx, format!("{path}.additionalProperties"));
                 }
             }
         }
         if let Some(all_of) = &self.all_of {
             for (i, schema) in all_of.iter().enumerate() {
-                schema.validate_with_context(ctx, format!("{}.allOf[{}]", path, i));
+                schema.validate_with_context(ctx, format!("{path}.allOf[{i}]"));
             }
         }
     }
@@ -708,10 +708,10 @@ impl ValidateWithContext<Spec> for ObjectSchema {
 impl ValidateWithContext<Spec> for NullSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -62,7 +62,7 @@ impl Display for Schema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct StringSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("string"),
+    pub schema_type: MustBe!("string"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -139,7 +139,7 @@ pub struct StringSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct IntegerSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("integer"),
+    pub schema_type: MustBe!("integer"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -225,7 +225,7 @@ pub struct IntegerSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct NumberSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("number"),
+    pub schema_type: MustBe!("number"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -311,7 +311,7 @@ pub struct NumberSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct BooleanSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("boolean"),
+    pub schema_type: MustBe!("boolean"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -365,7 +365,7 @@ pub struct BooleanSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ArraySchema {
     #[serde(rename = "type")]
-    _type: MustBe!("array"),
+    pub schema_type: MustBe!("array"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -433,11 +433,11 @@ pub struct ArraySchema {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ObjectSchema {
     #[serde(rename = "type")]
     #[serde(default)]
-    _type: String,
+    pub schema_type: MustBe!("object"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -526,33 +526,10 @@ pub struct ObjectSchema {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-impl Default for ObjectSchema {
-    fn default() -> Self {
-        ObjectSchema {
-            _type: "object".to_owned(),
-            title: None,
-            description: None,
-            properties: None,
-            default: None,
-            max_properties: None,
-            min_properties: None,
-            additional_properties: None,
-            required: None,
-            discriminator: None,
-            read_only: None,
-            xml: None,
-            external_docs: None,
-            example: None,
-            all_of: None,
-            extensions: None,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct NullSchema {
-    #[serde(rename = "null")]
-    _type: MustBe!("string"),
+    #[serde(rename = "type")]
+    pub schema_type: MustBe!("null"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -692,8 +692,7 @@ impl ValidateWithContext<Spec> for ObjectSchema {
             match additional_properties {
                 BoolOr::Bool(_) => {}
                 BoolOr::Item(schema) => {
-                    schema
-                        .validate_with_context_boxed(ctx, format!("{path}.additionalProperties"));
+                    schema.validate_with_context_boxed(ctx, format!("{path}.additionalProperties"));
                 }
             }
         }

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -171,7 +171,7 @@ impl ValidateWithContext<Spec> for BasicSecurityScheme {
 
 impl ValidateWithContext<Spec> for ApiKeySecurityScheme {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
@@ -195,7 +195,7 @@ impl ValidateWithContext<Spec> for OAuth2SecurityScheme {
             validate_optional_url(
                 &self.authorization_url,
                 ctx,
-                format!("{}.authorizationUrl", path),
+                format!("{path}.authorizationUrl"),
             );
         }
     }

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -299,14 +299,14 @@ impl Validate for Spec {
             if !base_path.starts_with('/') {
                 ctx.error(
                     "#.basePath".to_owned(),
-                    format_args!("must start with `/`, found `{}`", base_path),
+                    format_args!("must start with `/`, found `{base_path}`"),
                 );
             }
         }
 
         // validate paths operations
         for (name, item) in self.paths.iter() {
-            let path = format!("#.paths[{}]", name);
+            let path = format!("#.paths[{name}]");
             if !name.starts_with('/') {
                 ctx.error(path.clone(), "must start with `/`");
             }
@@ -333,7 +333,7 @@ impl Validate for Spec {
         if !ctx.is_option(Options::IgnoreUnusedSchemas) {
             if let Some(definitions) = &self.definitions {
                 for (name, definition) in definitions.iter() {
-                    let path = format!("#/definitions/{}", name);
+                    let path = format!("#/definitions/{name}");
                     if ctx.visit(path.clone()) {
                         ctx.error(path.clone(), "unused");
                         definition.validate_with_context(&mut ctx, path);
@@ -345,7 +345,7 @@ impl Validate for Spec {
         if !ctx.is_option(Options::IgnoreUnusedParameters) {
             if let Some(parameters) = &self.parameters {
                 for (name, parameter) in parameters.iter() {
-                    let path = format!("#/parameters/{}", name);
+                    let path = format!("#/parameters/{name}");
                     if ctx.visit(path.clone()) {
                         ctx.error(path.clone(), "unused");
                         parameter.validate_with_context(&mut ctx, path);
@@ -357,7 +357,7 @@ impl Validate for Spec {
         if !ctx.is_option(Options::IgnoreUnusedResponses) {
             if let Some(responses) = &self.responses {
                 for (name, response) in responses.iter() {
-                    let path = format!("#/responses/{}", name);
+                    let path = format!("#/responses/{name}");
                     if ctx.visit(path.clone()) {
                         ctx.error(path.clone(), "unused");
                         response.validate_with_context(&mut ctx, path);

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -44,9 +44,9 @@ pub struct Tag {
 
 impl ValidateWithContext<Spec> for Tag {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
         if let Some(doc) = &self.external_docs {
-            doc.validate_with_context(ctx, format!("{}.externalDocs", path));
+            doc.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
     }
 }

--- a/src/v2/xml.rs
+++ b/src/v2/xml.rs
@@ -120,9 +120,9 @@ pub struct XML {
 impl ValidateWithContext<Spec> for XML {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(name) = &self.name {
-            validate_required_string(name, ctx, format!("{}.name", path));
+            validate_required_string(name, ctx, format!("{path}.name"));
         }
-        validate_optional_url(&self.namespace, ctx, format!("{}.namespace", path));
+        validate_optional_url(&self.namespace, ctx, format!("{path}.namespace"));
     }
 }
 

--- a/src/v3_0/callback.rs
+++ b/src/v3_0/callback.rs
@@ -111,12 +111,12 @@ impl<'de> Deserialize<'de> for Callback {
                 while let Some(key) = map.next_key::<String>()? {
                     if key.starts_with("x-") {
                         if extensions.contains_key(key.as_str()) {
-                            return Err(Error::custom(format_args!("duplicate field `{}`", key)));
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
                         }
                         extensions.insert(key, map.next_value()?);
                     } else {
                         if res.paths.contains_key(key.as_str()) {
-                            return Err(Error::custom(format_args!("duplicate field `{}`", key)));
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
                         }
                         res.paths.insert(key, map.next_value()?);
                     }
@@ -135,7 +135,7 @@ impl<'de> Deserialize<'de> for Callback {
 impl ValidateWithContext<Spec> for Callback {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         for (name, path_item) in &self.paths {
-            path_item.validate_with_context(ctx, format!("{}[{}]", path, name));
+            path_item.validate_with_context(ctx, format!("{path}[{name}]"));
         }
     }
 }

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -74,74 +74,74 @@ impl ValidateWithContext<Spec> for Components {
 
         if let Some(objs) = &self.schemas {
             for (name, obj) in objs {
-                let reference = format!("#/components/schemas/{}", name);
+                let reference = format!("#/components/schemas/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedSchemas) {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.schemas[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.schemas[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.schemas[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.schemas[{name}]"));
             }
         }
 
         if let Some(objs) = &self.responses {
             for (name, obj) in objs {
-                let reference = format!("#/components/responses/{}", name);
+                let reference = format!("#/components/responses/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedResponses) {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.responses[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.responses[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.responses[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.responses[{name}]"));
             }
         }
 
         if let Some(objs) = &self.parameters {
             for (name, obj) in objs {
-                let reference = format!("#/components/parameters/{}", name);
+                let reference = format!("#/components/parameters/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedParameters) {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.parameters[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.parameters[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.parameters[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.parameters[{name}]"));
             }
         }
 
         if let Some(objs) = &self.examples {
             for (name, obj) in objs {
-                let reference = format!("#/components/examples/{}", name);
+                let reference = format!("#/components/examples/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedExamples) {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.examples[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.examples[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.examples[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.examples[{name}]"));
             }
         }
 
         if let Some(objs) = &self.request_bodies {
             for (name, obj) in objs {
-                let reference = format!("#/components/requestBodies/{}", name);
+                let reference = format!("#/components/requestBodies/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedRequestBodies)
                 {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.requestBodies[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.requestBodies[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.requestBodies[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.requestBodies[{name}]"));
             }
         }
 
         if let Some(objs) = &self.headers {
             for (name, obj) in objs {
-                let reference = format!("#/components/headers/{}", name);
+                let reference = format!("#/components/headers/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedHeaders) {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.headers[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.headers[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.headers[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.headers[{name}]"));
             }
         }
 
         if let Some(objs) = &self.security_schemes {
             for (name, obj) in objs {
-                let reference = format!("#/components/securitySchemes/{}", name);
+                let reference = format!("#/components/securitySchemes/{name}");
                 if !ctx.is_visited(&reference)
                     && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
                 {
@@ -151,13 +151,13 @@ impl ValidateWithContext<Spec> for Components {
                     name,
                     &re,
                     ctx,
-                    format!("{}.securitySchemes[<name>]", path),
+                    format!("{path}.securitySchemes[<name>]"),
                 );
-                obj.validate_with_context(ctx, format!("{}.securitySchemes[{}]", path, name));
+                obj.validate_with_context(ctx, format!("{path}.securitySchemes[{name}]"));
                 if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec) {
                     if let Some(flow) = &oauth2.flows.implicit {
                         for scope in flow.scopes.keys() {
-                            let reference = format!("{}/{}", reference, scope);
+                            let reference = format!("{reference}/{scope}");
                             if !ctx.is_visited(&reference)
                                 && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
                             {
@@ -171,23 +171,23 @@ impl ValidateWithContext<Spec> for Components {
 
         if let Some(objs) = &self.links {
             for (name, obj) in objs {
-                let reference = format!("#/components/links/{}", name);
+                let reference = format!("#/components/links/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedLinks) {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.links[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.links[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.links[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.links[{name}]"));
             }
         }
 
         if let Some(objs) = &self.callbacks {
             for (name, obj) in objs {
-                let reference = format!("#/components/callbacks/{}", name);
+                let reference = format!("#/components/callbacks/{name}");
                 if !ctx.is_visited(&reference) && !ctx.is_option(Options::IgnoreUnusedCallbacks) {
                     ctx.error(reference, "unused");
                 }
-                validate_string_matches(name, &re, ctx, format!("{}.callbacks[<name>]", path));
-                obj.validate_with_context(ctx, format!("{}.callbacks[{}]", path, name));
+                validate_string_matches(name, &re, ctx, format!("{path}.callbacks[<name>]"));
+                obj.validate_with_context(ctx, format!("{path}.callbacks[{name}]"));
             }
         }
     }

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -147,12 +147,7 @@ impl ValidateWithContext<Spec> for Components {
                 {
                     ctx.error(reference.clone(), "unused");
                 }
-                validate_string_matches(
-                    name,
-                    &re,
-                    ctx,
-                    format!("{path}.securitySchemes[<name>]"),
-                );
+                validate_string_matches(name, &re, ctx, format!("{path}.securitySchemes[<name>]"));
                 obj.validate_with_context(ctx, format!("{path}.securitySchemes[{name}]"));
                 if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec) {
                     if let Some(flow) = &oauth2.flows.implicit {

--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -28,12 +28,12 @@ pub struct Discriminator {
 
 impl ValidateWithContext<Spec> for Discriminator {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.property_name, ctx, format!("{}.propertyName", path));
+        validate_required_string(&self.property_name, ctx, format!("{path}.propertyName"));
 
         if let Some(mapping) = &self.mapping {
             for (k, v) in mapping {
-                let schema_ref = RefOr::<Schema>::new_ref(format!("#/components/schemas/{}", v));
-                schema_ref.validate_with_context(ctx, format!("{}.mapping[{}]", path, k));
+                let schema_ref = RefOr::<Schema>::new_ref(format!("#/components/schemas/{v}"));
+                schema_ref.validate_with_context(ctx, format!("{path}.mapping[{k}]"));
             }
         }
     }

--- a/src/v3_0/example.rs
+++ b/src/v3_0/example.rs
@@ -51,6 +51,6 @@ impl ValidateWithContext<Spec> for Example {
                 "value and externalValue are mutually exclusive",
             );
         }
-        validate_optional_url(&self.external_value, ctx, format!("{}.externalValue", path));
+        validate_optional_url(&self.external_value, ctx, format!("{path}.externalValue"));
     }
 }

--- a/src/v3_0/external_documentation.rs
+++ b/src/v3_0/external_documentation.rs
@@ -37,7 +37,7 @@ pub struct ExternalDocumentation {
 
 impl ValidateWithContext<Spec> for ExternalDocumentation {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&Some(self.url.clone()), ctx, format!("{}.url", path));
+        validate_optional_url(&Some(self.url.clone()), ctx, format!("{path}.url"));
     }
 }
 

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -91,12 +91,12 @@ impl ValidateWithContext<Spec> for Header {
         }
         if let Some(examples) = &self.examples {
             for (k, v) in examples {
-                v.validate_with_context(ctx, format!("{}.examples[{}]", path, k));
+                v.validate_with_context(ctx, format!("{path}.examples[{k}]"));
             }
         }
         if let Some(content) = &self.content {
             for (k, v) in content {
-                v.validate_with_context(ctx, format!("{}.content[{}]", path, k));
+                v.validate_with_context(ctx, format!("{path}.content[{k}]"));
             }
         }
     }

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -8,6 +8,7 @@ use crate::common::helpers::{
     Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
 };
 use crate::v3_0::spec::Spec;
+use crate::validation::Options;
 
 /// The object provides metadata about the API.
 /// The metadata MAY be used by the clients if needed,
@@ -30,6 +31,7 @@ use crate::v3_0::spec::Spec;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Info {
     /// **Required** The title of the API.
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub title: String,
 
     /// A short description of the API.
@@ -52,6 +54,7 @@ pub struct Info {
 
     /// **Required** The version of the OpenAPI document
     /// (which is distinct from the OpenAPI Specification version or the API implementation version).
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub version: String,
 
     /// This object MAY be extended with Specification Extensions.
@@ -128,8 +131,12 @@ pub struct License {
 
 impl ValidateWithContext<Spec> for Info {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.title, ctx, format!("{}.title", path));
-        validate_required_string(&self.version, ctx, format!("{}.version", path));
+        if !ctx.is_option(Options::IgnoreEmptyInfoTitle) {
+            validate_required_string(&self.title, ctx, format!("{}.title", path));
+        }
+        if !ctx.is_option(Options::IgnoreEmptyInfoVersion) {
+            validate_required_string(&self.version, ctx, format!("{}.version", path));
+        }
 
         if let Some(contact) = &self.contact {
             contact.validate_with_context(ctx, format!("{}.contact", path));

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -241,6 +241,16 @@ mod tests {
             },
             "deserialize",
         );
+
+        assert_eq!(
+            serde_json::from_value::<Info>(json!({
+              "title": "",
+              "version": ""
+            }))
+            .unwrap(),
+            Info::default(),
+            "deserialize",
+        );
     }
 
     #[test]
@@ -314,6 +324,11 @@ mod tests {
               "title": "Swagger Sample App",
               "version": "1.0.1"
             }),
+            "serialize",
+        );
+        assert_eq!(
+            serde_json::to_value(Info::default()).unwrap(),
+            json!({}),
             "serialize",
         );
     }
@@ -405,7 +420,7 @@ mod tests {
             ..Default::default()
         }
         .validate_with_context(&mut ctx, String::from("contact"));
-        assert_eq!(ctx.errors.len(), 0, "no errors: {:?}", ctx.errors);
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
         Contact {
             url: Some(String::from("https://www.example.com/support")),
@@ -413,7 +428,7 @@ mod tests {
             ..Default::default()
         }
         .validate_with_context(&mut ctx, String::from("contact"));
-        assert_eq!(ctx.errors.len(), 0, "no errors: {:?}", ctx.errors);
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
         Contact {
             url: Some(String::from("foo - bar")),
@@ -443,14 +458,14 @@ mod tests {
             ..Default::default()
         }
         .validate_with_context(&mut ctx, String::from("license"));
-        assert_eq!(ctx.errors.len(), 0, "no errors: {:?}", ctx.errors);
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
         License {
             name: String::from("Apache 2.0"),
             ..Default::default()
         }
         .validate_with_context(&mut ctx, String::from("license"));
-        assert_eq!(ctx.errors.len(), 0, "no errors: {:?}", ctx.errors);
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
         ctx = Context::new(&spec, Default::default());
         License {
@@ -495,7 +510,7 @@ mod tests {
             ..Default::default()
         }
         .validate_with_context(&mut ctx, String::from("info"));
-        assert_eq!(ctx.errors.len(), 0, "no errors: {:?}", ctx.errors);
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
         Info {
             title: String::from("Swagger Sample App"),
@@ -505,7 +520,7 @@ mod tests {
             ..Default::default()
         }
         .validate_with_context(&mut ctx, String::from("info"));
-        assert_eq!(ctx.errors.len(), 0, "no errors: {:?}", ctx.errors);
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
         Info {
             title: String::from("Swagger Sample App"),
@@ -513,7 +528,7 @@ mod tests {
             ..Default::default()
         }
         .validate_with_context(&mut ctx, String::from("info"));
-        assert_eq!(ctx.errors.len(), 0, "no errors: {:?}", ctx.errors);
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
         Info {
             title: String::from("Swagger Sample App"),
@@ -531,5 +546,23 @@ mod tests {
         }
         .validate_with_context(&mut ctx, String::from("info"));
         assert_eq!(ctx.errors.len(), 1, "empty title: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Options::only(&Options::IgnoreEmptyInfoTitle));
+        Info {
+            title: String::from(""),
+            version: String::from("1.0.1"),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        ctx = Context::new(&spec, Options::only(&Options::IgnoreEmptyInfoVersion));
+        Info {
+            title: String::from("Swagger Sample App"),
+            version: String::from(""),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, String::from("info"));
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
     }
 }

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -132,33 +132,33 @@ pub struct License {
 impl ValidateWithContext<Spec> for Info {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if !ctx.is_option(Options::IgnoreEmptyInfoTitle) {
-            validate_required_string(&self.title, ctx, format!("{}.title", path));
+            validate_required_string(&self.title, ctx, format!("{path}.title"));
         }
         if !ctx.is_option(Options::IgnoreEmptyInfoVersion) {
-            validate_required_string(&self.version, ctx, format!("{}.version", path));
+            validate_required_string(&self.version, ctx, format!("{path}.version"));
         }
 
         if let Some(contact) = &self.contact {
-            contact.validate_with_context(ctx, format!("{}.contact", path));
+            contact.validate_with_context(ctx, format!("{path}.contact"));
         }
 
         if let Some(license) = &self.license {
-            license.validate_with_context(ctx, format!("{}.license", path));
+            license.validate_with_context(ctx, format!("{path}.license"));
         }
     }
 }
 
 impl ValidateWithContext<Spec> for Contact {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&self.url, ctx, format!("{}.url", path));
-        validate_email(&self.email, ctx, format!("{}.email", path));
+        validate_optional_url(&self.url, ctx, format!("{path}.url"));
+        validate_email(&self.email, ctx, format!("{path}.email"));
     }
 }
 
 impl ValidateWithContext<Spec> for License {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
-        validate_optional_url(&self.url, ctx, format!("{}.url", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+        validate_optional_url(&self.url, ctx, format!("{path}.url"));
     }
 }
 

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -71,16 +71,16 @@ impl ValidateWithContext<Spec> for Link {
         if let Some(operation_id) = &self.operation_id {
             if !ctx
                 .visited
-                .contains(format!("#/paths/operations/{}", operation_id).as_str())
+                .contains(format!("#/paths/operations/{operation_id}").as_str())
             {
                 ctx.error(
                     path.clone(),
-                    format_args!(".operationId: missing operation with id `{}`", operation_id),
+                    format_args!(".operationId: missing operation with id `{operation_id}`"),
                 );
             }
         }
         if let Some(server) = &self.server {
-            server.validate_with_context(ctx, format!("{}.server", path));
+            server.validate_with_context(ctx, format!("{path}.server"));
         }
     }
 }

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -178,16 +178,16 @@ pub struct Encoding {
 impl ValidateWithContext<Spec> for MediaType {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(schema) = &self.schema {
-            schema.validate_with_context(ctx, format!("{}.schema", path));
+            schema.validate_with_context(ctx, format!("{path}.schema"));
         }
         if let Some(examples) = &self.examples {
             for (name, example) in examples {
-                example.validate_with_context(ctx, format!("{}.examples[{}]", path, name));
+                example.validate_with_context(ctx, format!("{path}.examples[{name}]"));
             }
         }
         if let Some(encoding) = &self.encoding {
             for (name, encoding) in encoding {
-                encoding.validate_with_context(ctx, format!("{}.encoding[{}]", path, name));
+                encoding.validate_with_context(ctx, format!("{path}.encoding[{name}]"));
             }
         }
     }
@@ -197,7 +197,7 @@ impl ValidateWithContext<Spec> for Encoding {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(headers) = &self.headers {
             for (name, header) in headers {
-                header.validate_with_context(ctx, format!("{}.headers[{}]", path, name));
+                header.validate_with_context(ctx, format!("{path}.headers[{name}]"));
             }
         }
     }

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -39,7 +39,7 @@ use crate::v3_0::spec::Spec;
 ///     frog:
 ///       $ref: "#/components/examples/frog-example"
 /// ```
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct MediaType {
     /// The schema defining the content of the request, response, or parameter.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -122,10 +122,7 @@ impl ValidateWithContext<Spec> for Operation {
                         spec_tag.validate_with_context(ctx, reference);
                     }
                 } else if !ctx.is_option(Options::IgnoreMissingTags) {
-                    ctx.error(
-                        path,
-                        format_args!(".tags[{i}]: `{tag}` not found in spec"),
-                    );
+                    ctx.error(path, format_args!(".tags[{i}]: `{tag}` not found in spec"));
                 }
             }
         }

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -111,12 +111,12 @@ impl ValidateWithContext<Spec> for Operation {
 
         if let Some(tags) = &self.tags {
             for (i, tag) in tags.iter().enumerate() {
-                let path = format!("{}.tags[{}]", path, i);
+                let path = format!("{path}.tags[{i}]");
                 validate_required_string(tag, ctx, path.clone());
                 if tag.is_empty() {
                     continue;
                 }
-                let reference = format!("#/tags/{}", tag);
+                let reference = format!("#/tags/{tag}");
                 if let Ok(spec_tag) = RefOr::<Tag>::new_ref(reference.clone()).get_item(ctx.spec) {
                     if ctx.visit(reference.clone()) {
                         spec_tag.validate_with_context(ctx, reference);
@@ -124,7 +124,7 @@ impl ValidateWithContext<Spec> for Operation {
                 } else if !ctx.is_option(Options::IgnoreMissingTags) {
                     ctx.error(
                         path,
-                        format_args!(".tags[{}]: `{}` not found in spec", i, tag),
+                        format_args!(".tags[{i}]: `{tag}` not found in spec"),
                     );
                 }
             }
@@ -132,44 +132,44 @@ impl ValidateWithContext<Spec> for Operation {
 
         if let Some(parameters) = &self.parameters {
             for (i, parameter) in parameters.clone().iter().enumerate() {
-                parameter.validate_with_context(ctx, format!("{}.parameters[{}]", path, i));
+                parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
             }
         }
 
         if let Some(request_body) = &self.request_body {
-            request_body.validate_with_context(ctx, format!("{}.requestBody", path));
+            request_body.validate_with_context(ctx, format!("{path}.requestBody"));
         }
 
         if let Some(servers) = &self.servers {
             for (i, server) in servers.iter().enumerate() {
-                server.validate_with_context(ctx, format!("{}.servers[{}]", path, i));
+                server.validate_with_context(ctx, format!("{path}.servers[{i}]"));
             }
         }
 
         if let Some(callbacks) = &self.callbacks {
             for (k, v) in callbacks {
-                v.validate_with_context(ctx, format!("{}.callbacks[{}]", path, k));
+                v.validate_with_context(ctx, format!("{path}.callbacks[{k}]"));
             }
         }
 
         self.responses
-            .validate_with_context(ctx, format!("{}.responses", path));
+            .validate_with_context(ctx, format!("{path}.responses"));
 
         if let Some(external_doc) = &self.external_docs {
-            external_doc.validate_with_context(ctx, format!("{}.externalDocs", path));
+            external_doc.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
 
         if let Some(security) = &self.security {
             for (i, security) in security.iter().enumerate() {
                 for (name, scopes) in security {
-                    let path = format!("{}.security[{}][{}]", path, i, name);
-                    let reference = format!("#/components/securitySchemes/{}", name);
+                    let path = format!("{path}.security[{i}][{name}]");
+                    let reference = format!("#/components/securitySchemes/{name}");
                     let spec_ref = RefOr::<SecurityScheme>::new_ref(reference.clone());
                     spec_ref.validate_with_context(ctx, path.clone());
                     if !scopes.is_empty() {
                         if let Ok(SecurityScheme::OAuth2(oauth2)) = spec_ref.get_item(ctx.spec) {
                             for scope in scopes {
-                                ctx.visit(format!("{}/{}", reference, scope));
+                                ctx.visit(format!("{reference}/{scope}"));
                                 let mut found = false;
                                 if let Some(flow) = &oauth2.flows.implicit {
                                     found = found || flow.scopes.contains_key(scope)
@@ -193,8 +193,7 @@ impl ValidateWithContext<Spec> for Operation {
                                     ctx.error(
                                         path.clone(),
                                         format_args!(
-                                            "scope `{}` not found in spec by reference `{}`",
-                                            scope, reference
+                                            "scope `{scope}` not found in spec by reference `{reference}`"
                                         ),
                                     );
                                 }

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -425,7 +425,7 @@ impl ValidateWithContext<Spec> for Parameter {
 
 impl ValidateWithContext<Spec> for InPath {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
         must_be_required(&Some(self.required), ctx, path.clone(), self.name.clone());
         either_example_or_examples(ctx, &self.example, &self.examples, path.clone());
         either_schema_or_content(ctx, &self.schema, &self.content, path.clone());
@@ -434,7 +434,7 @@ impl ValidateWithContext<Spec> for InPath {
 
 impl ValidateWithContext<Spec> for InQuery {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
         either_example_or_examples(ctx, &self.example, &self.examples, path.clone());
         either_schema_or_content(ctx, &self.schema, &self.content, path.clone());
     }
@@ -442,7 +442,7 @@ impl ValidateWithContext<Spec> for InQuery {
 
 impl ValidateWithContext<Spec> for InHeader {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
         either_example_or_examples(ctx, &self.example, &self.examples, path.clone());
         either_schema_or_content(ctx, &self.schema, &self.content, path.clone());
     }
@@ -450,7 +450,7 @@ impl ValidateWithContext<Spec> for InHeader {
 
 impl ValidateWithContext<Spec> for InCookie {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
         either_example_or_examples(ctx, &self.example, &self.examples, path.clone());
         either_schema_or_content(ctx, &self.schema, &self.content, path.clone());
     }
@@ -458,7 +458,7 @@ impl ValidateWithContext<Spec> for InCookie {
 
 fn must_be_required(p: &Option<bool>, ctx: &mut Context<Spec>, path: String, name: String) {
     if !p.is_some_and(|x| x) {
-        ctx.error(path, format_args!(".{}: must be required", name));
+        ctx.error(path, format_args!(".{name}: must be required"));
     }
 }
 

--- a/src/v3_0/path_item.rs
+++ b/src/v3_0/path_item.rs
@@ -161,13 +161,13 @@ impl<'de> Deserialize<'de> for PathItem {
                         res.parameters = Some(map.next_value()?);
                     } else if key.starts_with("x-") {
                         if extensions.contains_key(key.clone().as_str()) {
-                            return Err(Error::custom(format!("duplicate field '{}'", key)));
+                            return Err(Error::custom(format!("duplicate field '{key}'")));
                         }
                         extensions.insert(key, map.next_value()?);
                     } else {
                         let key = key.to_lowercase();
                         if operations.contains_key(key.as_str()) {
-                            return Err(Error::custom(format!("duplicate field '{}'", key)));
+                            return Err(Error::custom(format!("duplicate field '{key}'")));
                         }
                         operations.insert(key, map.next_value()?);
                     }
@@ -190,19 +190,19 @@ impl ValidateWithContext<Spec> for PathItem {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(operations) = &self.operations {
             for (method, operation) in operations.iter() {
-                operation.validate_with_context(ctx, format!("{}.{}", path, method));
+                operation.validate_with_context(ctx, format!("{path}.{method}"));
             }
         }
 
         if let Some(servers) = &self.servers {
             for (i, server) in servers.iter().enumerate() {
-                server.validate_with_context(ctx, format!("{}.servers[{}]", path, i));
+                server.validate_with_context(ctx, format!("{path}.servers[{i}]"));
             }
         }
 
         if let Some(parameters) = &self.parameters {
             for (i, parameter) in parameters.iter().enumerate() {
-                parameter.validate_with_context(ctx, format!("{}.parameters[{}]", path, i));
+                parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
             }
         }
     }

--- a/src/v3_0/request_body.rs
+++ b/src/v3_0/request_body.rs
@@ -62,7 +62,7 @@ pub struct RequestBody {
 impl ValidateWithContext<Spec> for RequestBody {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         for (k, v) in &self.content {
-            v.validate_with_context(ctx, format!("{}.content[{}]", path, k));
+            v.validate_with_context(ctx, format!("{path}.content[{k}]"));
         }
     }
 }

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -166,7 +166,7 @@ impl<'de> Deserialize<'de> for Responses {
                         res.default = Some(map.next_value()?);
                     } else if key.starts_with("x-") {
                         if extensions.contains_key(key.as_str()) {
-                            return Err(Error::custom(format_args!("duplicate field `{}`", key)));
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
                         }
                         extensions.insert(key, map.next_value()?);
                     } else {
@@ -174,8 +174,7 @@ impl<'de> Deserialize<'de> for Responses {
                             Ok(100..=599) => {
                                 if responses.contains_key(key.as_str()) {
                                     return Err(Error::custom(format_args!(
-                                        "duplicate field `{}`",
-                                        key
+                                        "duplicate field `{key}`"
                                     )));
                                 }
                                 responses.insert(key, map.next_value()?);
@@ -201,21 +200,21 @@ impl<'de> Deserialize<'de> for Responses {
 impl ValidateWithContext<Spec> for Response {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if !ctx.is_option(Options::IgnoreEmptyResponseDescription) {
-            validate_required_string(&self.description, ctx, format!("{}.description", path));
+            validate_required_string(&self.description, ctx, format!("{path}.description"));
         }
         if let Some(headers) = &self.headers {
             for (name, header) in headers {
-                header.validate_with_context(ctx, format!("{}.headers[{}]", path, name));
+                header.validate_with_context(ctx, format!("{path}.headers[{name}]"));
             }
         }
         if let Some(media_types) = &self.content {
             for (name, media_type) in media_types {
-                media_type.validate_with_context(ctx, format!("{}.mediaTypes[{}]", path, name));
+                media_type.validate_with_context(ctx, format!("{path}.mediaTypes[{name}]"));
             }
         }
         if let Some(links) = &self.links {
             for (name, link) in links {
-                link.validate_with_context(ctx, format!("{}.links[{}]", path, name));
+                link.validate_with_context(ctx, format!("{path}.links[{name}]"));
             }
         }
     }
@@ -224,7 +223,7 @@ impl ValidateWithContext<Spec> for Response {
 impl ValidateWithContext<Spec> for Responses {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(response) = &self.default {
-            response.validate_with_context(ctx, format!("{}.default", path));
+            response.validate_with_context(ctx, format!("{path}.default"));
         }
         if let Some(responses) = &self.responses {
             for (name, response) in responses {
@@ -234,13 +233,12 @@ impl ValidateWithContext<Spec> for Responses {
                         ctx.error(
                             path.clone(),
                             format_args!(
-                                "name must be an integer within [100..599] range, found `{}`",
-                                name
+                                "name must be an integer within [100..599] range, found `{name}`"
                             ),
                         );
                     }
                 }
-                response.validate_with_context(ctx, format!("{}.{}", path, name));
+                response.validate_with_context(ctx, format!("{path}.{name}"));
             }
         }
     }

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -243,3 +243,468 @@ impl ValidateWithContext<Spec> for Responses {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v3_0::parameter::InHeaderStyle;
+    use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+
+    #[test]
+    fn test_response_deserialize() {
+        assert_eq!(
+            serde_json::from_value::<Response>(serde_json::json!({
+                "description": "A simple response",
+                "headers": {
+                    "Authorization": {
+                        "description": "A short description of the header.",
+                        "style": "simple",
+                        "required": true,
+                    },
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "foo"
+                        }
+                    }
+                },
+                "links": {
+                    "next": {
+                        "operationRef": "getNextPage",
+                        "description": "Get the next page of results"
+                    }
+                },
+                "x-extra": "extension",
+            }))
+            .unwrap(),
+            Response {
+                description: "A simple response".to_owned(),
+                headers: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "Authorization".to_owned(),
+                        RefOr::new_item(Header {
+                            description: Some("A short description of the header.".to_owned()),
+                            required: Some(true),
+                            style: Some(InHeaderStyle::Simple),
+                            ..Default::default()
+                        }),
+                    );
+                    map
+                }),
+                content: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "application/json".to_owned(),
+                        MediaType {
+                            schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                                SingleSchema::Object(ObjectSchema {
+                                    title: Some("foo".to_owned()),
+                                    ..Default::default()
+                                }),
+                            )))),
+                            ..Default::default()
+                        },
+                    );
+                    map
+                }),
+                links: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "next".to_owned(),
+                        RefOr::new_item(Link {
+                            operation_ref: Some("getNextPage".to_owned()),
+                            description: Some("Get the next page of results".to_owned()),
+                            ..Default::default()
+                        }),
+                    );
+                    map
+                }),
+                extensions: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert("x-extra".to_owned(), serde_json::json!("extension"));
+                    map
+                }),
+            },
+            "response deserialization",
+        );
+    }
+
+    #[test]
+    fn test_response_serialization() {
+        assert_eq!(
+            serde_json::to_value(Response {
+                description: "A simple response".to_owned(),
+                headers: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "Authorization".to_owned(),
+                        RefOr::new_item(Header {
+                            description: Some("A short description of the header.".to_owned()),
+                            required: Some(true),
+                            style: Some(InHeaderStyle::Simple),
+                            ..Default::default()
+                        }),
+                    );
+                    map
+                }),
+                content: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "application/json".to_owned(),
+                        MediaType {
+                            schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                                SingleSchema::Object(ObjectSchema {
+                                    title: Some("foo".to_owned()),
+                                    ..Default::default()
+                                }),
+                            )))),
+                            ..Default::default()
+                        },
+                    );
+                    map
+                }),
+                links: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "next".to_owned(),
+                        RefOr::new_item(Link {
+                            operation_ref: Some("getNextPage".to_owned()),
+                            description: Some("Get the next page of results".to_owned()),
+                            ..Default::default()
+                        }),
+                    );
+                    map
+                }),
+                extensions: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert("x-extra".to_owned(), serde_json::json!("extension"));
+                    map
+                }),
+            })
+            .unwrap(),
+            serde_json::json!({
+                "description": "A simple response",
+                "headers": {
+                    "Authorization": {
+                        "description": "A short description of the header.",
+                        "style": "simple",
+                        "required": true,
+                    },
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "title": "foo"
+                        }
+                    }
+                },
+                "links": {
+                    "next": {
+                        "operationRef": "getNextPage",
+                        "description": "Get the next page of results"
+                    }
+                },
+                "x-extra": "extension",
+            }),
+            "response serialization",
+        );
+    }
+
+    #[test]
+    fn test_responses_deserialize() {
+        assert_eq!(
+            serde_json::from_value::<Responses>(serde_json::json!({
+                "default": {
+                    "description": "A simple response",
+                    "headers": {
+                        "Authorization": {
+                            "description": "A short description of the header.",
+                            "style": "simple",
+                            "required": true,
+                        },
+                    },
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "title": "foo"
+                            }
+                        }
+                    },
+                    "links": {
+                        "next": {
+                            "operationRef": "getNextPage",
+                            "description": "Get the next page of results"
+                        }
+                    },
+                    "x-extra": "extension",
+                },
+                "200": {
+                    "description": "200 OK"
+                },
+                "x-extra": "extension",
+            }))
+            .unwrap(),
+            Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "A simple response".to_owned(),
+                    headers: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "Authorization".to_owned(),
+                            RefOr::new_item(Header {
+                                description: Some("A short description of the header.".to_owned()),
+                                required: Some(true),
+                                style: Some(InHeaderStyle::Simple),
+                                ..Default::default()
+                            }),
+                        );
+                        map
+                    }),
+                    content: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "application/json".to_owned(),
+                            MediaType {
+                                schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                                    SingleSchema::Object(ObjectSchema {
+                                        title: Some("foo".to_owned()),
+                                        ..Default::default()
+                                    }),
+                                )))),
+                                ..Default::default()
+                            },
+                        );
+                        map
+                    }),
+                    links: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "next".to_owned(),
+                            RefOr::new_item(Link {
+                                operation_ref: Some("getNextPage".to_owned()),
+                                description: Some("Get the next page of results".to_owned()),
+                                ..Default::default()
+                            }),
+                        );
+                        map
+                    }),
+                    extensions: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert("x-extra".to_owned(), serde_json::json!("extension"));
+                        map
+                    }),
+                })),
+                responses: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "200".to_owned(),
+                        RefOr::new_item(Response {
+                            description: "200 OK".to_owned(),
+                            ..Default::default()
+                        }),
+                    );
+                    map
+                }),
+                extensions: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert("x-extra".to_owned(), serde_json::json!("extension"));
+                    map
+                }),
+            },
+            "responses deserialization",
+        );
+    }
+
+    #[test]
+    fn test_responses_serialization() {
+        assert_eq!(
+            serde_json::to_value(Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "A simple response".to_owned(),
+                    headers: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "Authorization".to_owned(),
+                            RefOr::new_item(Header {
+                                description: Some("A short description of the header.".to_owned()),
+                                required: Some(true),
+                                style: Some(InHeaderStyle::Simple),
+                                ..Default::default()
+                            }),
+                        );
+                        map
+                    }),
+                    content: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "application/json".to_owned(),
+                            MediaType {
+                                schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                                    SingleSchema::Object(ObjectSchema {
+                                        title: Some("foo".to_owned()),
+                                        ..Default::default()
+                                    }),
+                                )))),
+                                ..Default::default()
+                            },
+                        );
+                        map
+                    }),
+                    links: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert(
+                            "next".to_owned(),
+                            RefOr::new_item(Link {
+                                operation_ref: Some("getNextPage".to_owned()),
+                                description: Some("Get the next page of results".to_owned()),
+                                ..Default::default()
+                            }),
+                        );
+                        map
+                    }),
+                    extensions: Some({
+                        let mut map = BTreeMap::new();
+                        map.insert("x-extra".to_owned(), serde_json::json!("extension"));
+                        map
+                    }),
+                })),
+                responses: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert(
+                        "200".to_owned(),
+                        RefOr::new_item(Response {
+                            description: "200 OK".to_owned(),
+                            ..Default::default()
+                        }),
+                    );
+                    map
+                }),
+                extensions: Some({
+                    let mut map = BTreeMap::new();
+                    map.insert("x-extra".to_owned(), serde_json::json!("extension"));
+                    map
+                }),
+            })
+            .unwrap(),
+            serde_json::json!({
+                "default": {
+                    "description": "A simple response",
+                    "headers": {
+                        "Authorization": {
+                            "description": "A short description of the header.",
+                            "style": "simple",
+                            "required": true,
+                        },
+                    },
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "title": "foo"
+                            }
+                        }
+                    },
+                    "links": {
+                        "next": {
+                            "operationRef": "getNextPage",
+                            "description": "Get the next page of results"
+                        }
+                    },
+                    "x-extra": "extension",
+                },
+                "200": {
+                    "description": "200 OK"
+                },
+                "x-extra": "extension",
+            }),
+            "response serialization",
+        );
+    }
+
+    #[test]
+    fn test_response_validate() {
+        let spec = Spec::default();
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Response {
+            description: "A simple response".to_owned(),
+            headers: Some({
+                let mut map = BTreeMap::new();
+                map.insert(
+                    "Authorization".to_owned(),
+                    RefOr::new_item(Header {
+                        description: Some("A short description of the header.".to_owned()),
+                        required: Some(true),
+                        style: Some(InHeaderStyle::Simple),
+                        ..Default::default()
+                    }),
+                );
+                map
+            }),
+            content: Some({
+                let mut map = BTreeMap::new();
+                map.insert(
+                    "application/json".to_owned(),
+                    MediaType {
+                        schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                            SingleSchema::Object(ObjectSchema {
+                                title: Some("foo".to_owned()),
+                                ..Default::default()
+                            }),
+                        )))),
+                        ..Default::default()
+                    },
+                );
+                map
+            }),
+            links: Some({
+                let mut map = BTreeMap::new();
+                map.insert(
+                    "next".to_owned(),
+                    RefOr::new_item(Link {
+                        operation_ref: Some("getNextPage".to_owned()),
+                        description: Some("Get the next page of results".to_owned()),
+                        ..Default::default()
+                    }),
+                );
+                map
+            }),
+            extensions: Some({
+                let mut map = BTreeMap::new();
+                map.insert("x-extra".to_owned(), serde_json::json!("extension"));
+                map
+            }),
+        }
+        .validate_with_context(&mut ctx, "response".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Response {
+            description: "A simple response".to_owned(),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "response".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Response::default().validate_with_context(&mut ctx, "response".to_owned());
+        assert!(
+            ctx.errors
+                .contains(&"response.description: must not be empty".to_string()),
+            "expected error: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(
+            &spec,
+            Options::only(&Options::IgnoreEmptyResponseDescription),
+        );
+        Response::default().validate_with_context(&mut ctx, "response".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+    }
+}

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -684,31 +684,31 @@ impl ValidateWithContext<Spec> for Schema {
             Schema::Single(s) => s.validate_with_context(ctx, path),
             Schema::AllOf(s) => {
                 for (i, schema) in s.all_of.iter().enumerate() {
-                    schema.validate_with_context_boxed(ctx, format!("{}.allOf[{}]", path, i));
+                    schema.validate_with_context_boxed(ctx, format!("{path}.allOf[{i}]"));
                 }
                 if let Some(discriminator) = &s.discriminator {
-                    discriminator.validate_with_context(ctx, format!("{}.discriminator", path));
+                    discriminator.validate_with_context(ctx, format!("{path}.discriminator"));
                 }
             }
             Schema::AnyOf(s) => {
                 for (i, schema) in s.any_of.iter().enumerate() {
-                    schema.validate_with_context_boxed(ctx, format!("{}.anyOf[{}]", path, i));
+                    schema.validate_with_context_boxed(ctx, format!("{path}.anyOf[{i}]"));
                 }
                 if let Some(discriminator) = &s.discriminator {
-                    discriminator.validate_with_context(ctx, format!("{}.discriminator", path));
+                    discriminator.validate_with_context(ctx, format!("{path}.discriminator"));
                 }
             }
             Schema::OneOf(s) => {
                 for (i, schema) in s.one_of.iter().enumerate() {
-                    schema.validate_with_context_boxed(ctx, format!("{}.oneOf[{}]", path, i));
+                    schema.validate_with_context_boxed(ctx, format!("{path}.oneOf[{i}]"));
                 }
                 if let Some(discriminator) = &s.discriminator {
-                    discriminator.validate_with_context(ctx, format!("{}.discriminator", path));
+                    discriminator.validate_with_context(ctx, format!("{path}.discriminator"));
                 }
             }
             Schema::Not(s) => {
                 s.not
-                    .validate_with_context_boxed(ctx, format!("{}.not", path));
+                    .validate_with_context_boxed(ctx, format!("{path}.not"));
             }
         }
     }
@@ -731,13 +731,13 @@ impl ValidateWithContext<Spec> for SingleSchema {
 impl ValidateWithContext<Spec> for StringSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
         if let Some(pattern) = &self.pattern {
-            validate_pattern(pattern, ctx, format!("{}.pattern", path));
+            validate_pattern(pattern, ctx, format!("{path}.pattern"));
         }
     }
 }
@@ -745,10 +745,10 @@ impl ValidateWithContext<Spec> for StringSchema {
 impl ValidateWithContext<Spec> for IntegerSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }
@@ -756,10 +756,10 @@ impl ValidateWithContext<Spec> for IntegerSchema {
 impl ValidateWithContext<Spec> for NumberSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }
@@ -767,10 +767,10 @@ impl ValidateWithContext<Spec> for NumberSchema {
 impl ValidateWithContext<Spec> for BooleanSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }
@@ -778,14 +778,14 @@ impl ValidateWithContext<Spec> for BooleanSchema {
 impl ValidateWithContext<Spec> for ArraySchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
 
         if let Some(items) = &self.items {
-            items.validate_with_context_boxed(ctx, format!("{}.items", path));
+            items.validate_with_context_boxed(ctx, format!("{path}.items"));
         }
     }
 }
@@ -793,15 +793,15 @@ impl ValidateWithContext<Spec> for ArraySchema {
 impl ValidateWithContext<Spec> for ObjectSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
 
         if let Some(properties) = &self.properties {
             for (name, schema) in properties {
-                schema.validate_with_context_boxed(ctx, format!("{}.properties.{}", path, name));
+                schema.validate_with_context_boxed(ctx, format!("{path}.properties.{name}"));
             }
         }
 
@@ -810,7 +810,7 @@ impl ValidateWithContext<Spec> for ObjectSchema {
                 BoolOr::Bool(_) => {}
                 BoolOr::Item(schema) => {
                     schema
-                        .validate_with_context_boxed(ctx, format!("{}.additionalProperties", path));
+                        .validate_with_context_boxed(ctx, format!("{path}.additionalProperties"));
                 }
             }
         }
@@ -820,10 +820,10 @@ impl ValidateWithContext<Spec> for ObjectSchema {
 impl ValidateWithContext<Spec> for NullSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(docs) = &self.external_docs {
-            docs.validate_with_context(ctx, format!("{}.externalDocs", path));
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
         if let Some(xml) = &self.xml {
-            xml.validate_with_context(ctx, format!("{}.xml", path));
+            xml.validate_with_context(ctx, format!("{path}.xml"));
         }
     }
 }

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -160,7 +160,7 @@ impl Display for SingleSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct StringSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("string"),
+    pub schema_type: MustBe!("string"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -237,7 +237,7 @@ pub struct StringSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct IntegerSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("integer"),
+    pub schema_type: MustBe!("integer"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -323,7 +323,7 @@ pub struct IntegerSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct NumberSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("number"),
+    pub schema_type: MustBe!("number"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -409,7 +409,7 @@ pub struct NumberSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct BooleanSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("boolean"),
+    pub schema_type: MustBe!("boolean"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -463,7 +463,7 @@ pub struct BooleanSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ArraySchema {
     #[serde(rename = "type")]
-    _type: MustBe!("array"),
+    pub schema_type: MustBe!("array"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -531,11 +531,11 @@ pub struct ArraySchema {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ObjectSchema {
     #[serde(rename = "type")]
     #[serde(default)]
-    _type: String,
+    pub schema_type: MustBe!("object"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -609,31 +609,10 @@ pub struct ObjectSchema {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-impl Default for ObjectSchema {
-    fn default() -> Self {
-        ObjectSchema {
-            _type: "object".to_owned(),
-            title: None,
-            description: None,
-            properties: None,
-            default: None,
-            max_properties: None,
-            min_properties: None,
-            additional_properties: None,
-            required: None,
-            read_only: None,
-            xml: None,
-            external_docs: None,
-            example: None,
-            extensions: None,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct NullSchema {
     #[serde(rename = "type")]
-    _type: MustBe!("null"),
+    pub schema_type: MustBe!("null"),
 
     /// A title to explain the purpose of the schema.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v3_0/security_scheme.rs
+++ b/src/v3_0/security_scheme.rs
@@ -457,30 +457,30 @@ impl ValidateWithContext<Spec> for HttpSecurityScheme {
 
 impl ValidateWithContext<Spec> for ApiKeySecurityScheme {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
     }
 }
 
 impl ValidateWithContext<Spec> for OAuth2SecurityScheme {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         self.flows
-            .validate_with_context(ctx, format!("{}.flow", path));
+            .validate_with_context(ctx, format!("{path}.flow"));
     }
 }
 
 impl ValidateWithContext<Spec> for OAuth2Flows {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if let Some(flow) = &self.implicit {
-            flow.validate_with_context(ctx, format!("{}.implicit", path));
+            flow.validate_with_context(ctx, format!("{path}.implicit"));
         }
         if let Some(flow) = &self.password {
-            flow.validate_with_context(ctx, format!("{}.password", path));
+            flow.validate_with_context(ctx, format!("{path}.password"));
         }
         if let Some(flow) = &self.client_credentials {
-            flow.validate_with_context(ctx, format!("{}.clientCredentials", path));
+            flow.validate_with_context(ctx, format!("{path}.clientCredentials"));
         }
         if let Some(flow) = &self.authorization_code {
-            flow.validate_with_context(ctx, format!("{}.authorizationCode", path));
+            flow.validate_with_context(ctx, format!("{path}.authorizationCode"));
         }
     }
 }
@@ -490,23 +490,23 @@ impl ValidateWithContext<Spec> for ImplicitOAuth2Flow {
         validate_required_url(
             &self.authorization_url,
             ctx,
-            format!("{}.authorizationUrl", path),
+            format!("{path}.authorizationUrl"),
         );
-        validate_optional_url(&self.refresh_url, ctx, format!("{}.refreshUrl", path));
+        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
 impl ValidateWithContext<Spec> for PasswordOAuth2Flow {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(&self.token_url, ctx, format!("{}.tokenUrl", path));
-        validate_optional_url(&self.refresh_url, ctx, format!("{}.refreshUrl", path));
+        validate_required_url(&self.token_url, ctx, format!("{path}.tokenUrl"));
+        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
 impl ValidateWithContext<Spec> for ClientCredentialsOAuth2Flow {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(&self.token_url, ctx, format!("{}.tokenUrl", path));
-        validate_optional_url(&self.refresh_url, ctx, format!("{}.refreshUrl", path));
+        validate_required_url(&self.token_url, ctx, format!("{path}.tokenUrl"));
+        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
@@ -515,10 +515,10 @@ impl ValidateWithContext<Spec> for AuthorizationCodeOAuth2Flow {
         validate_required_url(
             &self.authorization_url,
             ctx,
-            format!("{}.authorizationUrl", path),
+            format!("{path}.authorizationUrl"),
         );
-        validate_required_url(&self.token_url, ctx, format!("{}.tokenUrl", path));
-        validate_optional_url(&self.refresh_url, ctx, format!("{}.refreshUrl", path));
+        validate_required_url(&self.token_url, ctx, format!("{path}.tokenUrl"));
+        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
@@ -527,7 +527,7 @@ impl ValidateWithContext<Spec> for OpenIdConnectSecurityScheme {
         validate_required_url(
             &self.open_id_connect_url,
             ctx,
-            format!("{}.openIdConnectUrl", path),
+            format!("{path}.openIdConnectUrl"),
         );
     }
 }

--- a/src/v3_0/security_scheme.rs
+++ b/src/v3_0/security_scheme.rs
@@ -55,19 +55,19 @@ use crate::v3_0::spec::Spec;
 pub enum SecurityScheme {
     /// Basic Authentication Type
     #[serde(rename = "http")]
-    HTTP(HttpSecurityScheme),
+    HTTP(Box<HttpSecurityScheme>),
 
     /// API Key Authentication Type
     #[serde(rename = "apiKey")]
-    ApiKey(ApiKeySecurityScheme),
+    ApiKey(Box<ApiKeySecurityScheme>),
 
     /// OAuth2 Authentication Type
     #[serde(rename = "oauth2")]
-    OAuth2(OAuth2SecurityScheme),
+    OAuth2(Box<OAuth2SecurityScheme>),
 
     /// OpenIdConnect Authentication Type
     #[serde(rename = "openIdConnect")]
-    OpenIdConnect(OpenIdConnectSecurityScheme),
+    OpenIdConnect(Box<OpenIdConnectSecurityScheme>),
 }
 
 impl Display for SecurityScheme {
@@ -549,11 +549,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Basic,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = basic",
         );
         assert_eq!(
@@ -563,11 +563,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Bearer,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = bearer",
         );
         assert_eq!(
@@ -577,11 +577,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Digest,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = digest",
         );
         assert_eq!(
@@ -591,11 +591,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::DPoP,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = dpop",
         );
         assert_eq!(
@@ -605,11 +605,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::HOBA,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = hoba",
         );
         assert_eq!(
@@ -619,11 +619,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Mutual,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = mutual",
         );
         assert_eq!(
@@ -633,11 +633,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Negotiate,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = negotiate",
         );
         assert_eq!(
@@ -647,11 +647,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::OAuth,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = oauth",
         );
         assert_eq!(
@@ -661,11 +661,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::SCRAMSHA1,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = scram-sha-1",
         );
         assert_eq!(
@@ -675,11 +675,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::SCRAMSHA256,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = scram-sha-2256",
         );
         assert_eq!(
@@ -689,11 +689,11 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::HTTP(HttpSecurityScheme {
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Vapid,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize scheme = vapid",
         );
     }
@@ -701,11 +701,11 @@ mod tests {
     #[test]
     fn test_security_scheme_http_serialize() {
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Basic,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -715,11 +715,11 @@ mod tests {
             "serialize scheme = basic",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Bearer,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -729,11 +729,11 @@ mod tests {
             "serialize scheme = bearer",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Digest,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -743,11 +743,11 @@ mod tests {
             "serialize scheme = digest",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::DPoP,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -757,11 +757,11 @@ mod tests {
             "serialize scheme = dpop",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::HOBA,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -771,11 +771,11 @@ mod tests {
             "serialize scheme = hoba",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Mutual,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -785,11 +785,11 @@ mod tests {
             "serialize scheme = mutual",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Negotiate,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -799,11 +799,11 @@ mod tests {
             "serialize scheme = negotiate",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::OAuth,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -813,11 +813,11 @@ mod tests {
             "serialize scheme = oauth",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::SCRAMSHA1,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -827,11 +827,11 @@ mod tests {
             "serialize scheme = scram-sha-1",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::SCRAMSHA256,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -841,11 +841,11 @@ mod tests {
             "serialize scheme = scram-sha-256",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::HTTP(HttpSecurityScheme {
+            serde_json::to_value(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
                 scheme: HttpScheme::Vapid,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "http",
@@ -866,12 +866,12 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::ApiKey(ApiKeySecurityScheme {
+            SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
                 name: String::from("api_key"),
                 location: ApiKeyLocation::Header,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize in = header",
         );
         assert_eq!(
@@ -882,12 +882,12 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::ApiKey(ApiKeySecurityScheme {
+            SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
                 name: String::from("api_key"),
                 location: ApiKeyLocation::Query,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize in = query",
         );
         assert_eq!(
@@ -898,12 +898,12 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::ApiKey(ApiKeySecurityScheme {
+            SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
                 name: String::from("api_key"),
                 location: ApiKeyLocation::Cookie,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize in = cookie",
         );
     }
@@ -911,12 +911,12 @@ mod tests {
     #[test]
     fn test_security_scheme_api_key_serialize() {
         assert_eq!(
-            serde_json::to_value(SecurityScheme::ApiKey(ApiKeySecurityScheme {
+            serde_json::to_value(SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
                 name: String::from("api_key"),
                 location: ApiKeyLocation::Header,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "apiKey",
@@ -927,12 +927,12 @@ mod tests {
             "serialize location = header",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::ApiKey(ApiKeySecurityScheme {
+            serde_json::to_value(SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
                 name: String::from("api_key"),
                 location: ApiKeyLocation::Query,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "apiKey",
@@ -943,12 +943,12 @@ mod tests {
             "serialize location = query",
         );
         assert_eq!(
-            serde_json::to_value(SecurityScheme::ApiKey(ApiKeySecurityScheme {
+            serde_json::to_value(SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
                 name: String::from("api_key"),
                 location: ApiKeyLocation::Cookie,
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "apiKey",
@@ -1000,7 +1000,7 @@ mod tests {
                 "x-tra": "custom",
             }))
             .unwrap(),
-            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+            SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
                 flows: OAuth2Flows {
                     implicit: Some(ImplicitOAuth2Flow {
                         authorization_url: String::from("https://example.com/api/oauth/dialog"),
@@ -1058,7 +1058,7 @@ mod tests {
                     );
                     map
                 }),
-            }),
+            })),
             "deserialize",
         );
     }
@@ -1066,7 +1066,7 @@ mod tests {
     #[test]
     fn test_security_scheme_oauth2_serialize() {
         assert_eq!(
-            serde_json::to_value(SecurityScheme::OAuth2(OAuth2SecurityScheme {
+            serde_json::to_value(SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
                 flows: OAuth2Flows {
                     implicit: Some(ImplicitOAuth2Flow {
                         authorization_url: String::from("https://example.com/api/oauth/dialog"),
@@ -1117,7 +1117,7 @@ mod tests {
                 },
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }))
+            })))
             .unwrap(),
             json!({
                 "type": "oauth2",
@@ -1167,13 +1167,13 @@ mod tests {
                 "description": "A short description for security scheme.",
             }))
             .unwrap(),
-            SecurityScheme::OpenIdConnect(OpenIdConnectSecurityScheme {
+            SecurityScheme::OpenIdConnect(Box::new(OpenIdConnectSecurityScheme {
                 open_id_connect_url: String::from(
                     "https://example.com/.well-known/openid-configuration"
                 ),
                 description: Some(String::from("A short description for security scheme.")),
                 ..Default::default()
-            }),
+            })),
             "deserialize",
         );
     }
@@ -1181,13 +1181,15 @@ mod tests {
     #[test]
     fn test_security_scheme_open_id_connect_serialize() {
         assert_eq!(
-            serde_json::to_value(SecurityScheme::OpenIdConnect(OpenIdConnectSecurityScheme {
-                open_id_connect_url: String::from(
-                    "https://example.com/.well-known/openid-configuration"
-                ),
-                description: Some(String::from("A short description for security scheme.")),
-                ..Default::default()
-            }))
+            serde_json::to_value(SecurityScheme::OpenIdConnect(Box::new(
+                OpenIdConnectSecurityScheme {
+                    open_id_connect_url: String::from(
+                        "https://example.com/.well-known/openid-configuration"
+                    ),
+                    description: Some(String::from("A short description for security scheme.")),
+                    ..Default::default()
+                }
+            )))
             .unwrap(),
             json!({
                 "type": "openIdConnect",
@@ -1203,13 +1205,13 @@ mod tests {
         let spec = Spec::default();
         let mut ctx = Context::new(&spec, Options::new());
 
-        SecurityScheme::OpenIdConnect(OpenIdConnectSecurityScheme {
+        SecurityScheme::OpenIdConnect(Box::new(OpenIdConnectSecurityScheme {
             open_id_connect_url: String::from(
                 "https://example.com/.well-known/openid-configuration",
             ),
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert!(
             ctx.errors.is_empty(),
@@ -1217,11 +1219,11 @@ mod tests {
             ctx.errors
         );
 
-        SecurityScheme::OpenIdConnect(OpenIdConnectSecurityScheme {
+        SecurityScheme::OpenIdConnect(Box::new(OpenIdConnectSecurityScheme {
             open_id_connect_url: String::from(""),
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert_eq!(
             ctx.errors.len(),
@@ -1231,11 +1233,11 @@ mod tests {
         );
 
         ctx = Context::new(&spec, Options::new());
-        SecurityScheme::HTTP(HttpSecurityScheme {
+        SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
             scheme: HttpScheme::Basic,
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert!(
             ctx.errors.is_empty(),
@@ -1243,12 +1245,12 @@ mod tests {
             ctx.errors
         );
 
-        SecurityScheme::HTTP(HttpSecurityScheme {
+        SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
             scheme: HttpScheme::Bearer,
             bearer_format: Some(String::from("fooo")),
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert!(
             ctx.errors.is_empty(),
@@ -1256,12 +1258,12 @@ mod tests {
             ctx.errors
         );
 
-        SecurityScheme::HTTP(HttpSecurityScheme {
+        SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
             scheme: HttpScheme::Basic,
             bearer_format: Some(String::from("fooo")),
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert_eq!(
             ctx.errors.len(),
@@ -1271,34 +1273,34 @@ mod tests {
         );
 
         ctx = Context::new(&spec, Options::new());
-        SecurityScheme::ApiKey(ApiKeySecurityScheme {
+        SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
             name: String::from("api_key"),
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert!(ctx.errors.is_empty(), "ApiKey: no errors: {:?}", ctx.errors);
 
-        SecurityScheme::ApiKey(ApiKeySecurityScheme {
+        SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
             name: String::from(""),
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert_eq!(ctx.errors.len(), 1, "ApiKey: one error: {:?}", ctx.errors);
 
         ctx = Context::new(&spec, Options::new());
-        SecurityScheme::OAuth2(OAuth2SecurityScheme {
+        SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 ..Default::default()
             },
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert!(ctx.errors.is_empty(), "OAuth2: no errors: {:?}", ctx.errors);
 
-        SecurityScheme::OAuth2(OAuth2SecurityScheme {
+        SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 implicit: Some(ImplicitOAuth2Flow {
                     authorization_url: String::from("foo"),
@@ -1309,7 +1311,7 @@ mod tests {
             },
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert_eq!(
             ctx.errors.len(),
@@ -1319,7 +1321,7 @@ mod tests {
         );
 
         ctx = Context::new(&spec, Options::new());
-        SecurityScheme::OAuth2(OAuth2SecurityScheme {
+        SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 password: Some(PasswordOAuth2Flow {
                     token_url: String::from("foo"),
@@ -1330,7 +1332,7 @@ mod tests {
             },
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert_eq!(
             ctx.errors.len(),
@@ -1340,7 +1342,7 @@ mod tests {
         );
 
         ctx = Context::new(&spec, Options::new());
-        SecurityScheme::OAuth2(OAuth2SecurityScheme {
+        SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 client_credentials: Some(ClientCredentialsOAuth2Flow {
                     token_url: String::from("foo"),
@@ -1351,7 +1353,7 @@ mod tests {
             },
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert_eq!(
             ctx.errors.len(),
@@ -1361,7 +1363,7 @@ mod tests {
         );
 
         ctx = Context::new(&spec, Options::new());
-        SecurityScheme::OAuth2(OAuth2SecurityScheme {
+        SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 authorization_code: Some(AuthorizationCodeOAuth2Flow {
                     authorization_url: String::from("xyz"),
@@ -1373,7 +1375,7 @@ mod tests {
             },
             description: Some(String::from("A short description for security scheme.")),
             ..Default::default()
-        })
+        }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
         assert_eq!(
             ctx.errors.len(),

--- a/src/v3_0/server.rs
+++ b/src/v3_0/server.rs
@@ -99,11 +99,11 @@ pub struct ServerVariable {
 
 impl ValidateWithContext<Spec> for Server {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.url, ctx, format!("{}.url", path));
+        validate_required_string(&self.url, ctx, format!("{path}.url"));
         let mut visited = HashSet::<String>::new();
         if let Some(variables) = &self.variables {
             for (name, variable) in variables {
-                variable.validate_with_context(ctx, format!("{}.variables[{}]", path, name));
+                variable.validate_with_context(ctx, format!("{path}.variables[{name}]"));
                 visited.insert(name.clone());
             }
         };
@@ -112,7 +112,7 @@ impl ValidateWithContext<Spec> for Server {
             if !visited.remove(name) {
                 ctx.error(
                     path.clone(),
-                    format_args!(".url: `{}` is not defined in `variables`", name),
+                    format_args!(".url: `{name}` is not defined in `variables`"),
                 );
             }
         }
@@ -120,7 +120,7 @@ impl ValidateWithContext<Spec> for Server {
             for name in visited {
                 ctx.error(
                     path.clone(),
-                    format_args!(".variables[{}]: unused in `url`", name),
+                    format_args!(".variables[{name}]: unused in `url`"),
                 );
             }
         }
@@ -129,7 +129,7 @@ impl ValidateWithContext<Spec> for Server {
 
 impl ValidateWithContext<Spec> for ServerVariable {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.default, ctx, format!("{}.default", path));
+        validate_required_string(&self.default, ctx, format!("{path}.default"));
         if let Some(enum_values) = &self.enum_values {
             if !enum_values.contains(&self.default) {
                 ctx.error(

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -376,7 +376,7 @@ impl Validate for Spec {
 
         if let Some(servers) = &self.servers {
             for (i, server) in servers.iter().enumerate() {
-                server.validate_with_context(&mut ctx, format!("#.servers[{}]", i))
+                server.validate_with_context(&mut ctx, format!("#.servers[{i}]"))
             }
         }
 
@@ -387,13 +387,12 @@ impl Validate for Spec {
                     if let Some(operation_id) = &operation.operation_id {
                         if !ctx
                             .visited
-                            .insert(format!("#/paths/operations/{}", operation_id))
+                            .insert(format!("#/paths/operations/{operation_id}"))
                         {
                             ctx.error(
                                 "#".to_owned(),
                                 format!(
-                                    ".paths[{}].{}.operationId: `{}` already in use",
-                                    name, method, operation_id
+                                    ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
                                 ),
                             );
                         }
@@ -403,7 +402,7 @@ impl Validate for Spec {
         }
 
         for (name, item) in self.paths.iter() {
-            let path = format!("#.paths[{}]", name);
+            let path = format!("#.paths[{name}]");
             if !name.starts_with('/') {
                 ctx.error(path.clone(), "must start with `/`");
             }

--- a/src/v3_0/tag.rs
+++ b/src/v3_0/tag.rs
@@ -43,9 +43,9 @@ pub struct Tag {
 
 impl ValidateWithContext<Spec> for Tag {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_string(&self.name, ctx, format!("{}.name", path));
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
         if let Some(doc) = &self.external_docs {
-            doc.validate_with_context(ctx, format!("{}.externalDocs", path));
+            doc.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
     }
 }

--- a/src/v3_0/xml.rs
+++ b/src/v3_0/xml.rs
@@ -117,7 +117,7 @@ pub struct XML {
 
 impl ValidateWithContext<Spec> for XML {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&self.namespace, ctx, format!("{}.namespace", path));
+        validate_optional_url(&self.namespace, ctx, format!("{path}.namespace"));
     }
 }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -11,7 +11,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{} errors found:", self.errors.len())?;
         for error in &self.errors {
-            writeln!(f, "- {}", error)?;
+            writeln!(f, "- {error}")?;
         }
         Ok(())
     }
@@ -111,12 +111,12 @@ pub const IGNORE_EMPTY_REQUIRED_FIELDS: EnumSet<Options> = enum_set!(
 );
 
 impl Options {
-    /// Creates an empty (strict) set of options.
+    /// /// Creates an empty set of options, representing the strictest validation.
     pub fn new() -> EnumSet<Options> {
         EnumSet::empty()
     }
 
-    /// Creates a set of options for only one option (self).
+    /// Creates a set containing only given option.
     pub fn only(&self) -> EnumSet<Options> {
         EnumSet::only(*self)
     }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -111,7 +111,7 @@ pub const IGNORE_EMPTY_REQUIRED_FIELDS: EnumSet<Options> = enum_set!(
 );
 
 impl Options {
-    /// /// Creates an empty set of options, representing the strictest validation.
+    /// Creates an empty set of options, representing the strictest validation.
     pub fn new() -> EnumSet<Options> {
         EnumSet::empty()
     }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use enumset::{EnumSet, EnumSetType};
+use enumset::{EnumSet, EnumSetType, enum_set};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {
@@ -74,35 +74,55 @@ pub enum Options {
     /// Ignore unused callbacks.
     /// Applies for v3.0
     IgnoreUnusedCallbacks,
+
+    /// Ignore empty Info.Title field.
+    /// Applies for v2.0, v3.0
+    IgnoreEmptyInfoTitle,
+
+    /// Ignore empty Info.Version field.
+    /// Applies for v2.0, v3.0
+    IgnoreEmptyInfoVersion,
+
+    /// Ignore empty Response.Description field.
+    /// Applies for v2.0, v3.0
+    IgnoreEmptyResponseDescription,
 }
 
+/// A set of options to ignore unused objects.
+pub const IGNORE_UNUSED: EnumSet<Options> = enum_set!(
+    Options::IgnoreUnusedTags
+        | Options::IgnoreUnusedSchemas
+        | Options::IgnoreUnusedParameters
+        | Options::IgnoreUnusedResponses
+        | Options::IgnoreUnusedServerVariables
+        | Options::IgnoreUnusedExamples
+        | Options::IgnoreUnusedRequestBodies
+        | Options::IgnoreUnusedHeaders
+        | Options::IgnoreUnusedSecuritySchemes
+        | Options::IgnoreUnusedLinks
+        | Options::IgnoreUnusedCallbacks
+);
+
+/// A predefined set of options to ignore required fields that are empty.
+pub const IGNORE_EMPTY_REQUIRED_FIELDS: EnumSet<Options> = enum_set!(
+    Options::IgnoreEmptyInfoTitle
+        | Options::IgnoreEmptyInfoVersion
+        | Options::IgnoreEmptyResponseDescription
+);
+
 impl Options {
-    /// Create an empty (strict) set of options.
+    /// Creates an empty (strict) set of options.
     pub fn new() -> EnumSet<Options> {
         EnumSet::empty()
     }
 
-    /// Create options to ignore unused elements.
-    pub fn ignore_unused() -> EnumSet<Options> {
-        Options::IgnoreUnusedTags
-            | Options::IgnoreUnusedSchemas
-            | Options::IgnoreUnusedParameters
-            | Options::IgnoreUnusedResponses
-            | Options::IgnoreUnusedServerVariables
-            | Options::IgnoreUnusedExamples
-            | Options::IgnoreUnusedRequestBodies
-            | Options::IgnoreUnusedHeaders
-            | Options::IgnoreUnusedSecuritySchemes
-            | Options::IgnoreUnusedLinks
-            | Options::IgnoreUnusedCallbacks
-    }
-
+    /// Creates a set of options for only one option (self).
     pub fn only(&self) -> EnumSet<Options> {
         EnumSet::only(*self)
     }
 }
 
-/// Validate a OpenAPI specification.
+/// Validates the OpenAPI specification.
 pub trait Validate {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error>;
 }

--- a/tests/v2_test.rs
+++ b/tests/v2_test.rs
@@ -9,7 +9,7 @@ mod v2_tests {
     fn files() {
         for path in fs::read_dir("tests/v2_data").unwrap() {
             let path_buf = path.unwrap().path();
-            println!("validating: {:?}", path_buf);
+            println!("validating: {path_buf:?}");
             let json_spec = fs::read_to_string(&path_buf).unwrap();
             let spec = serde_json::from_str::<Spec>(&json_spec).unwrap();
             spec.validate(Options::IgnoreMissingTags | Options::IgnoreExternalReferences)

--- a/tests/v3_0_test.rs
+++ b/tests/v3_0_test.rs
@@ -9,13 +9,13 @@ mod v3_0_tests {
     fn files() {
         for path in fs::read_dir("tests/v3_0_data").unwrap() {
             let path_buf = path.unwrap().path();
-            println!("validating: {:?}", path_buf);
+            println!("validating: {path_buf:?}");
             let json_spec = fs::read_to_string(&path_buf).unwrap();
             let spec = serde_json::from_str::<Spec>(&json_spec).unwrap();
             match spec.validate(Options::IgnoreMissingTags.only()) {
                 Ok(_) => {}
                 Err(err) => {
-                    panic!("validation failed: {}", err);
+                    panic!("validation failed: {err}");
                 }
             }
             assert_eq!(


### PR DESCRIPTION
Add options to skip validation of empty required strings in Info and Response
objects. Use serde's skip_serializing_if to omit empty strings during
serialization for title, version, and description fields. This improves
flexibility by allowing clients to opt out of strict validation for these fields.

Bump enumset dependency to 1.1.6 and update package version to 0.3.0.