### PR TITLE
feat(validation): add helper to simplify unused checks

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,14 +9,19 @@ component_management:
     - component_id: common
       name: common
       paths:
+        - src/common.rs
         - src/common/**
+        - src/lib.rs
+        - src/validation.rs
     - component_id: v2
       name: v2
       paths:
+        - src/v2.rs
         - src/v2/**
         - tests/v2_test.rs
     - component_id: v3_0
       name: v3.0
       paths:
+        - src/v3_0.rs
         - src/v3_0/**
         - tests/v3_0_test.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-roas = { version = "0.3", features = ["v3_0"] } 
+roas = "0.3"  
 ```
 
 ## Examples

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -142,3 +142,19 @@ pub fn validate_pattern<T>(pattern: &str, ctx: &mut Context<T>, path: String) {
         Err(e) => ctx.error(path, format_args!("pattern `{pattern}` is invalid: {e}")),
     }
 }
+
+pub fn validate_not_visited<T, D>(
+    obj: &D,
+    ctx: &mut Context<T>,
+    ignore_option: Options,
+    path: String,
+) where
+    D: ValidateWithContext<T>,
+{
+    if ctx.visit(path.clone()) {
+        if !ctx.is_option(ignore_option) {
+            ctx.error(path.clone(), "unused");
+        }
+        obj.validate_with_context(ctx, path);
+    }
+}

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -6,6 +6,9 @@ use regex::Regex;
 
 use crate::validation::{Error, Options};
 
+/// ValidateWithContext is a trait for validating an object with a context.
+/// It allows the object to be validated with additional context information,
+/// such as the specification and validation options.
 pub trait ValidateWithContext<T> {
     fn validate_with_context(&self, ctx: &mut Context<T>, path: String);
 }
@@ -84,6 +87,8 @@ impl<'a, T> From<Context<'a, T>> for Result<(), Error> {
     }
 }
 
+/// Validates that the given optional email string contains an '@' character.
+/// If the email is present and invalid, records an error in the context.
 pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: String) {
     if let Some(email) = email {
         if !email.contains('@') {
@@ -98,24 +103,33 @@ pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: Str
 const HTTP: &str = "http://";
 const HTTPS: &str = "https://";
 
+/// Validates an optional URL string.
+/// If the URL is present, it checks if it is valid using `validate_required_url`.
+/// Records an error in the context if the URL is invalid.
 pub fn validate_optional_url<T>(url: &Option<String>, ctx: &mut Context<T>, path: String) {
     if let Some(url) = url {
         validate_required_url(url, ctx, path);
     }
 }
 
+/// Validates that the given URL string starts with "http://" or "https://".
+/// If the URL is invalid, records an error in the context.
 pub fn validate_required_url<T>(url: &String, ctx: &mut Context<T>, path: String) {
     if !url.starts_with(HTTP) && !url.starts_with(HTTPS) {
         ctx.error(path, format_args!("must be a valid URL, found `{url}`"));
     }
 }
 
+/// Validates that the given string is not empty.
+/// If the string is empty, records an error in the context.
 pub fn validate_required_string<T>(s: &str, ctx: &mut Context<T>, path: String) {
     if s.is_empty() {
         ctx.error(path, "must not be empty");
     }
 }
 
+/// Validates that the given string matches the provided regex pattern.
+/// If the string does not match, records an error in the context with details.
 pub fn validate_string_matches<T>(s: &str, pattern: &Regex, ctx: &mut Context<T>, path: String) {
     if !pattern.is_match(s) {
         ctx.error(
@@ -125,6 +139,7 @@ pub fn validate_string_matches<T>(s: &str, pattern: &Regex, ctx: &mut Context<T>
     }
 }
 
+// Validates an optional string against a regex pattern if present.
 pub fn validate_optional_string_matches<T>(
     s: &Option<String>,
     pattern: &Regex,
@@ -136,6 +151,8 @@ pub fn validate_optional_string_matches<T>(
     }
 }
 
+/// Validates that the given regex pattern is valid.
+/// If the pattern is invalid, records an error in the context with details.
 pub fn validate_pattern<T>(pattern: &str, ctx: &mut Context<T>, path: String) {
     match Regex::new(pattern) {
         Ok(_) => {}
@@ -143,6 +160,10 @@ pub fn validate_pattern<T>(pattern: &str, ctx: &mut Context<T>, path: String) {
     }
 }
 
+/// Validates that the given object has not been visited before,
+/// optionally ignoring the check based on the provided option.
+/// If the object has already been visited and the ignore option is not set, an error is recorded.
+/// Then, the object's own validation logic is invoked.
 pub fn validate_not_visited<T, D>(
     obj: &D,
     ctx: &mut Context<T>,

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_optional_string_matches,
+    Context, PushError, ValidateWithContext, validate_not_visited, validate_optional_string_matches,
 };
 use crate::common::reference::ResolveReference;
 use crate::v2::external_documentation::ExternalDocumentation;
@@ -317,52 +317,31 @@ impl Validate for Spec {
             docs.validate_with_context(&mut ctx, "#.externalDocs".to_owned())
         }
 
-        // validate unused components
-        if !ctx.is_option(Options::IgnoreUnusedTags) {
-            if let Some(tags) = &self.tags {
-                for tag in tags.iter() {
-                    let path = format!("#/tags/{}", tag.name);
-                    if ctx.visit(path.clone()) {
-                        ctx.error(path.clone(), "unused");
-                        tag.validate_with_context(&mut ctx, path);
-                    }
-                }
+        if let Some(tags) = &self.tags {
+            for tag in tags.iter() {
+                let path = format!("#/tags/{}", tag.name);
+                validate_not_visited(tag, &mut ctx, Options::IgnoreUnusedTags, path);
             }
         }
 
-        if !ctx.is_option(Options::IgnoreUnusedSchemas) {
-            if let Some(definitions) = &self.definitions {
-                for (name, definition) in definitions.iter() {
-                    let path = format!("#/definitions/{name}");
-                    if ctx.visit(path.clone()) {
-                        ctx.error(path.clone(), "unused");
-                        definition.validate_with_context(&mut ctx, path);
-                    }
-                }
+        if let Some(definitions) = &self.definitions {
+            for (name, definition) in definitions.iter() {
+                let path = format!("#/definitions/{name}");
+                validate_not_visited(definition, &mut ctx, Options::IgnoreUnusedSchemas, path);
             }
         }
 
-        if !ctx.is_option(Options::IgnoreUnusedParameters) {
-            if let Some(parameters) = &self.parameters {
-                for (name, parameter) in parameters.iter() {
-                    let path = format!("#/parameters/{name}");
-                    if ctx.visit(path.clone()) {
-                        ctx.error(path.clone(), "unused");
-                        parameter.validate_with_context(&mut ctx, path);
-                    }
-                }
+        if let Some(parameters) = &self.parameters {
+            for (name, parameter) in parameters.iter() {
+                let path = format!("#/parameters/{name}");
+                validate_not_visited(parameter, &mut ctx, Options::IgnoreUnusedParameters, path);
             }
         }
 
-        if !ctx.is_option(Options::IgnoreUnusedResponses) {
-            if let Some(responses) = &self.responses {
-                for (name, response) in responses.iter() {
-                    let path = format!("#/responses/{name}");
-                    if ctx.visit(path.clone()) {
-                        ctx.error(path.clone(), "unused");
-                        response.validate_with_context(&mut ctx, path);
-                    }
-                }
+        if let Some(responses) = &self.responses {
+            for (name, response) in responses.iter() {
+                let path = format!("#/responses/{name}");
+                validate_not_visited(response, &mut ctx, Options::IgnoreUnusedResponses, path);
             }
         }
 

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -7,7 +7,7 @@ use std::fmt::{Display, Formatter};
 use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_not_visited};
 use crate::common::reference::{ResolveReference, resolve_in_map};
 use crate::v3_0::callback::Callback;
 use crate::v3_0::components::Components;
@@ -420,12 +420,7 @@ impl Validate for Spec {
         if let Some(tags) = &self.tags {
             for tag in tags.iter() {
                 let path = format!("#/tags/{}", tag.name);
-                if ctx.visit(path.clone()) {
-                    if !ctx.is_option(Options::IgnoreUnusedTags) {
-                        ctx.error(path.clone(), "unused");
-                    }
-                    tag.validate_with_context(&mut ctx, path)
-                }
+                validate_not_visited(tag, &mut ctx, Options::IgnoreUnusedTags, path);
             }
         }
 


### PR DESCRIPTION
Introduce `validate_not_visited` helper to consolidate logic for
checking if an object has been visited and reporting unused errors
based on context options. Replace repetitive visit and error code
in v2 and v3 specs with this helper to improve code clarity and reduce
duplication while maintaining existing validation behavior.