### PR TITLE
feat(validation): add option to ignore invalid URL errors

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -27,6 +27,10 @@ pub enum Options {
     /// Applies for v2.0, v3.0
     IgnoreExternalReferences,
 
+    /// Ignore invalid URLs.
+    /// Applies for v2.0, v3.0
+    IgnoreInvalidUrls,
+
     /// Ignore non-unique operation IDs.
     /// Applies for v2.0, v3.0
     IgnoreNonUniqOperationIDs,


### PR DESCRIPTION
Introduce IgnoreInvalidUrls option to skip URL validation errors
in validate_required_url. This allows users to bypass strict URL
checks when necessary, improving flexibility in validation.  
Add a TODO to consider using a more robust URL validation library
for future improvements.