### PR TITLE
feat(spec): add support for OpenAPI version 3.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -31,7 +31,7 @@ use crate::validation::{Error, Options, Validate};
 /// Specification example:
 ///
 /// ```yaml
-/// openapi: "3.0.3"
+/// openapi: "3.0.4"
 /// info:
 ///   version: 1.0.0
 ///   title: Swagger Petstore
@@ -154,7 +154,7 @@ pub struct Spec {
     /// the OpenAPI document.
     /// This is not related to the API info.version string.
     ///
-    /// The value MUST be one of ["3.0.0", "3.0.1", "3.0.2", "3.0.3"].
+    /// The value MUST be one of ["3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4"].
     pub openapi: Version,
 
     /// **Required** Provides metadata about the API.
@@ -260,9 +260,13 @@ pub enum Version {
     V3_0_2,
 
     /// `3.0.3` version
-    #[default]
     #[serde(rename = "3.0.3")]
     V3_0_3,
+
+    /// `3.0.4` version
+    #[default]
+    #[serde(rename = "3.0.4")]
+    V3_0_4,
 }
 
 impl Display for Version {
@@ -272,6 +276,7 @@ impl Display for Version {
             Self::V3_0_1 => write!(f, "3.0.1"),
             Self::V3_0_2 => write!(f, "3.0.2"),
             Self::V3_0_3 => write!(f, "3.0.3"),
+            Self::V3_0_4 => write!(f, "3.0.4"),
         }
     }
 }


### PR DESCRIPTION
Update the specification example and version enum to include OpenAPI 3.0.4.
Set 3.0.4 as the new default version to reflect the latest standard.
This ensures compatibility with the most recent OpenAPI specification.