### PR TITLE
refactor: reorder imports for consistency across modules

### DIFF
--- a/src/common/extensions.rs
+++ b/src/common/extensions.rs
@@ -26,12 +26,11 @@
 //!     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 //! }
 //! ```
-use std::collections::BTreeMap;
-use std::fmt;
-
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
 
 pub fn deserialize<'de, D>(
     deserializer: D,
@@ -91,9 +90,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
-
     use super::*;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
     pub struct TestExtensions {

--- a/src/common/formats.rs
+++ b/src/common/formats.rs
@@ -1,8 +1,7 @@
-use std::fmt;
-use std::fmt::Display;
-
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
+use std::fmt::Display;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum StringFormat {

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -1,8 +1,7 @@
-use std::collections::HashSet;
-use std::fmt;
-
 use enumset::EnumSet;
 use regex::Regex;
+use std::collections::HashSet;
+use std::fmt;
 
 use crate::validation::{Error, Options};
 

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -1,8 +1,7 @@
 //! Reference Object
 
-use std::collections::BTreeMap;
-
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext};

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -1,11 +1,9 @@
 //! External Documentation Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext, validate_required_url};
 use crate::v2::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Allows referencing an external resource for extended documentation.
 ///

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -1,8 +1,7 @@
 //! Header Object
 
-use std::collections::BTreeMap;
-
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
@@ -281,9 +280,8 @@ impl ValidateWithContext<Spec> for ArrayHeader {
 
 #[cfg(test)]
 mod tests {
-    use crate::v2::items::StringItem;
-
     use super::*;
+    use crate::v2::items::StringItem;
 
     #[test]
     fn test_header_deserialize() {

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -1,14 +1,12 @@
 //! Metadata about the API.
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{
     Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
 };
 use crate::v2::spec::Spec;
 use crate::validation::Options;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// The object provides metadata about the API.
 /// The metadata can be used by the clients if needed, and can be presented in the Swagger-UI for convenience.
@@ -162,9 +160,8 @@ impl ValidateWithContext<Spec> for License {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_info_deserialize() {

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -1,12 +1,10 @@
 //! Item Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
 use crate::v2::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -1,9 +1,5 @@
 //! Operation Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v2::external_documentation::ExternalDocumentation;
@@ -12,6 +8,8 @@ use crate::v2::response::Responses;
 use crate::v2::spec::{Scheme, Spec};
 use crate::v2::tag::Tag;
 use crate::validation::Options;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Operation {
@@ -157,10 +155,9 @@ impl ValidateWithContext<Spec> for Operation {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::v2::parameter::{InPath, StringParameter};
     use crate::v2::response::Response;
-
-    use super::*;
 
     #[test]
     fn deserialize() {

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -1,9 +1,5 @@
 //! Parameter Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{
     Context, ValidateWithContext, validate_pattern, validate_required_string,
@@ -12,6 +8,8 @@ use crate::common::reference::RefOr;
 use crate::v2::items::Items;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "in")]

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -1,17 +1,15 @@
 //! Path Items
 
-use std::collections::BTreeMap;
-use std::fmt;
-
-use serde::de::{Error, MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::common::helpers::{Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v2::operation::Operation;
 use crate::v2::parameter::Parameter;
 use crate::v2::spec::Spec;
+use serde::de::{Error, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
 
 /// Describes the operations available on a single path.
 /// A Path Item may be empty, due to [ACL constraints](https://swagger.io/specification/v2/#security-filtering).
@@ -206,12 +204,11 @@ impl ValidateWithContext<Spec> for PathItem {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::common::formats::CollectionFormat;
     use crate::v2::items::{Items, StringItem};
     use crate::v2::parameter::{ArrayParameter, InPath};
     use crate::v2::response::{Response, Responses};
-
-    use super::*;
 
     #[test]
     fn test_path_item_deserialize() {

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -1,18 +1,16 @@
 //! Response Object
 
-use std::collections::BTreeMap;
-use std::fmt;
-
-use serde::de::{Error, MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v2::header::Header;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
 use crate::validation::Options;
+use serde::de::{Error, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Responses {

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -1,11 +1,5 @@
 //! Schema Object
 
-use monostate::MustBe;
-use std::collections::BTreeMap;
-use std::fmt::{Display, Formatter};
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
@@ -13,6 +7,10 @@ use crate::common::reference::RefOr;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::spec::Spec;
 use crate::v2::xml::XML;
+use monostate::MustBe;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
@@ -436,7 +434,6 @@ pub struct ArraySchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ObjectSchema {
     #[serde(rename = "type")]
-    #[serde(default)]
     pub schema_type: MustBe!("object"),
 
     /// A title to explain the purpose of the schema.

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -1,14 +1,12 @@
 //! Security Scheme Object
 
-use std::collections::BTreeMap;
-use std::fmt::{Display, Formatter};
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{
     Context, PushError, ValidateWithContext, validate_optional_url, validate_required_string,
 };
 use crate::v2::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
 
 /// Allows the definition of a security scheme that can be used by the operations.
 /// Supported schemes are basic authentication, an API key (either as a header or as a query parameter)
@@ -203,9 +201,8 @@ impl ValidateWithContext<Spec> for OAuth2SecurityScheme {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_security_scheme_basic_deserialize() {

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -1,13 +1,5 @@
 //! The root document object of the OpenAPI v2.0 specification.
 
-use std::collections::BTreeMap;
-use std::fmt;
-use std::fmt::{Display, Formatter};
-
-use enumset::EnumSet;
-use regex::Regex;
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{
     Context, PushError, ValidateWithContext, validate_not_visited, validate_optional_string_matches,
 };
@@ -21,6 +13,12 @@ use crate::v2::schema::{ObjectSchema, Schema};
 use crate::v2::security_scheme::SecurityScheme;
 use crate::v2::tag::Tag;
 use crate::validation::{Error, Options, Validate};
+use enumset::EnumSet;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// This is the root document object for the API specification.
 /// It combines what previously was the Resource Listing and API Declaration (version 1.2 and earlier) together into one document.

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -1,12 +1,10 @@
 //! Tag Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Allows adding meta data to a single tag that is used by the Operation Object.
 /// It is not mandatory to have a Tag Object per tag used there.

--- a/src/v2/xml.rs
+++ b/src/v2/xml.rs
@@ -1,13 +1,11 @@
 //! XML Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{
     Context, ValidateWithContext, validate_optional_url, validate_required_string,
 };
 use crate::v2::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// A metadata object that allows for more fine-tuned XML model definitions.
 ///
@@ -128,9 +126,8 @@ impl ValidateWithContext<Spec> for XML {
 
 #[cfg(test)]
 mod tests {
-    use crate::validation::Options;
-
     use super::*;
+    use crate::validation::Options;
 
     #[test]
     fn serialize() {

--- a/src/v3_0/callback.rs
+++ b/src/v3_0/callback.rs
@@ -1,13 +1,11 @@
-use std::collections::BTreeMap;
-use std::fmt;
-
-use serde::de::{Error, MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v3_0::path_item::PathItem;
 use crate::v3_0::spec::Spec;
+use serde::de::{Error, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
 
 /// A map of possible out-of band callbacks related to the parent operation.
 /// Each value in the map is a Path Item Object that describes a set of requests

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -1,10 +1,5 @@
 //! Holds a set of reusable objects for different aspects of the OAS.
 
-use std::collections::BTreeMap;
-
-use regex::Regex;
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_string_matches};
 use crate::common::reference::RefOr;
 use crate::v3_0::callback::Callback;
@@ -18,6 +13,9 @@ use crate::v3_0::schema::Schema;
 use crate::v3_0::security_scheme::SecurityScheme;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Components {

--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -1,13 +1,11 @@
 //! Discriminator Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// When request bodies or response payloads may be one of a number of different schemas,
 /// a discriminator object can be used to aid in serialization, deserialization, and validation.

--- a/src/v3_0/example.rs
+++ b/src/v3_0/example.rs
@@ -1,11 +1,9 @@
 //! Example object.
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_url};
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Example object.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]

--- a/src/v3_0/external_documentation.rs
+++ b/src/v3_0/external_documentation.rs
@@ -1,11 +1,9 @@
 //! References an external resource for extended documentation.
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Allows referencing an external resource for extended documentation.
 ///

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -1,9 +1,5 @@
 //! Header Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_0::example::Example;
@@ -11,6 +7,8 @@ use crate::v3_0::media_type::MediaType;
 use crate::v3_0::parameter::InHeaderStyle;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Header {

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -1,14 +1,12 @@
 //! Provides metadata about the API.
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{
     Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
 };
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// The object provides metadata about the API.
 /// The metadata MAY be used by the clients if needed,
@@ -164,9 +162,8 @@ impl ValidateWithContext<Spec> for License {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_info_deserialize() {

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -1,12 +1,10 @@
 //! Represents a possible design-time link for a response
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// The Link object represents a possible design-time link for a response.
 /// The presence of a link does not guarantee the caller’s ability to successfully invoke it,

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -1,9 +1,5 @@
 //! Provides schema and examples for the media type
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_0::example::Example;
@@ -11,6 +7,8 @@ use crate::v3_0::header::Header;
 use crate::v3_0::parameter::InQueryStyle;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Each Media Type Object provides schema and examples for the media type identified by its key.
 ///

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -1,9 +1,5 @@
 //! Operation Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::callback::Callback;
@@ -16,6 +12,8 @@ use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
 use crate::v3_0::tag::Tag;
 use crate::validation::Options;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Operation {

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -1,15 +1,13 @@
 //! Describes a single operation parameter.
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Describes a single operation parameter.
 ///

--- a/src/v3_0/path_item.rs
+++ b/src/v3_0/path_item.rs
@@ -1,18 +1,16 @@
 //! Path Items
 
-use std::collections::BTreeMap;
-use std::fmt;
-
-use serde::de::{Error, MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::common::helpers::{Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_0::operation::Operation;
 use crate::v3_0::parameter::Parameter;
 use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
+use serde::de::{Error, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
 
 /// Describes the operations available on a single path.
 /// A Path Item may be empty, due to [ACL constraints](https://spec.openapis.org/oas/v3.0.3#securityFiltering).

--- a/src/v3_0/request_body.rs
+++ b/src/v3_0/request_body.rs
@@ -1,12 +1,10 @@
 //! Request Body Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Describes a single request body.
 ///

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -1,12 +1,5 @@
 //! Response Object
 
-use std::collections::BTreeMap;
-use std::fmt;
-
-use serde::de::{Error, MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_0::header::Header;
@@ -14,6 +7,11 @@ use crate::v3_0::link::Link;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use serde::de::{Error, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
 
 /// A container for the expected responses of an operation.
 /// The container maps a HTTP response code to the expected response.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -534,7 +534,6 @@ pub struct ArraySchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ObjectSchema {
     #[serde(rename = "type")]
-    #[serde(default)]
     pub schema_type: MustBe!("object"),
 
     /// A title to explain the purpose of the schema.

--- a/src/v3_0/security_scheme.rs
+++ b/src/v3_0/security_scheme.rs
@@ -1,15 +1,13 @@
 //! Security Scheme Object
 
-use std::collections::BTreeMap;
-use std::fmt::{Display, Formatter};
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{
     Context, PushError, ValidateWithContext, validate_optional_url, validate_required_string,
     validate_required_url,
 };
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
 
 /// Defines a security scheme that can be used by the operations.
 /// Supported schemes are HTTP authentication, an API key (either as a header,
@@ -534,11 +532,9 @@ impl ValidateWithContext<Spec> for OpenIdConnectSecurityScheme {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
-    use crate::validation::Options;
-
     use super::*;
+    use crate::validation::Options;
+    use serde_json::json;
 
     #[test]
     fn test_security_scheme_http_deserialize() {

--- a/src/v3_0/server.rs
+++ b/src/v3_0/server.rs
@@ -1,13 +1,11 @@
 //! Representing a Server.
 
-use std::collections::{BTreeMap, HashSet};
-
-use regex::Regex;
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashSet};
 
 /// An object representing a Server.
 ///
@@ -146,11 +144,9 @@ impl ValidateWithContext<Spec> for ServerVariable {
 
 #[cfg(test)]
 mod tests {
-    use enumset::EnumSet;
-
-    use crate::validation::Options;
-
     use super::*;
+    use crate::validation::Options;
+    use enumset::EnumSet;
 
     #[test]
     fn test_server_variable_deserialize() {

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -1,12 +1,5 @@
 //! The root document object of the OpenAPI v3.0.X specification.
 
-use std::collections::BTreeMap;
-use std::fmt;
-use std::fmt::{Display, Formatter};
-
-use enumset::EnumSet;
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_not_visited};
 use crate::common::reference::{ResolveReference, resolve_in_map};
 use crate::v3_0::callback::Callback;
@@ -25,6 +18,11 @@ use crate::v3_0::security_scheme::SecurityScheme;
 use crate::v3_0::server::Server;
 use crate::v3_0::tag::Tag;
 use crate::validation::{Error, Options, Validate};
+use enumset::EnumSet;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fmt::{Display, Formatter};
 
 /// This is the root document object of the OpenAPI document.
 ///

--- a/src/v3_0/tag.rs
+++ b/src/v3_0/tag.rs
@@ -1,12 +1,10 @@
 //! Tag Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Adds metadata to a single tag that is used by the Operation Object.
 /// It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.

--- a/src/v3_0/xml.rs
+++ b/src/v3_0/xml.rs
@@ -1,11 +1,9 @@
 //! XML Object
 
-use std::collections::BTreeMap;
-
-use serde::{Deserialize, Serialize};
-
 use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
 use crate::v3_0::spec::Spec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// A metadata object that allows for more fine-tuned XML model definitions.
 ///
@@ -123,9 +121,8 @@ impl ValidateWithContext<Spec> for XML {
 
 #[cfg(test)]
 mod tests {
-    use crate::validation::Options;
-
     use super::*;
+    use crate::validation::Options;
 
     #[test]
     fn serialize() {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,6 +1,5 @@
-use std::fmt::Display;
-
 use enumset::{EnumSet, EnumSetType, enum_set};
+use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {


### PR DESCRIPTION
Move serde and std::collections imports closer to other external crates
to improve readability and maintain a consistent import order in all
modules. This change does not affect functionality but enhances code
organization and maintainability.