### PR TITLE
feat(validation): enforce non-empty and valid URLs in external docs

### DIFF
--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -114,7 +114,11 @@ pub fn validate_optional_url<T>(url: &Option<String>, ctx: &mut Context<T>, path
 /// Validates that the given URL string starts with "http://" or "https://".
 /// If the URL is invalid, records an error in the context.
 pub fn validate_required_url<T>(url: &String, ctx: &mut Context<T>, path: String) {
-    if ctx.is_option(Options::IgnoreInvalidUrls) {
+    if !ctx.is_option(Options::IgnoreEmptyExternalDocumentationUrl) {
+        validate_required_string(url, ctx, path.clone());
+    }
+    // If the URL is empty or the ignore option is set, skip validation.
+    if url.is_empty() || ctx.is_option(Options::IgnoreInvalidUrls) {
         return;
     }
 

--- a/src/v3_0/external_documentation.rs
+++ b/src/v3_0/external_documentation.rs
@@ -1,6 +1,6 @@
 //! References an external resource for extended documentation.
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
+use crate::common::helpers::{Context, ValidateWithContext, validate_required_url};
 use crate::v3_0::spec::Spec;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -35,24 +35,25 @@ pub struct ExternalDocumentation {
 
 impl ValidateWithContext<Spec> for ExternalDocumentation {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&Some(self.url.clone()), ctx, format!("{path}.url"));
+        validate_required_url(&self.url, ctx, format!("{path}.url"));
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::Options;
 
     #[test]
     fn test_external_documentation_deserialize() {
         assert_eq!(
             serde_json::from_value::<ExternalDocumentation>(serde_json::json!({
-                    "url": "https://example.com",
+                    "url": "https://swagger.io",
                     "description": "Find more info here"
             }))
             .unwrap(),
             ExternalDocumentation {
-                url: String::from("https://example.com"),
+                url: String::from("https://swagger.io"),
                 description: Some(String::from("Find more info here")),
                 ..Default::default()
             },
@@ -64,16 +65,89 @@ mod tests {
     fn test_external_documentation_serialize() {
         assert_eq!(
             serde_json::to_value(ExternalDocumentation {
-                url: String::from("https://example.com"),
+                url: String::from("https://swagger.io"),
                 description: Some(String::from("Find more info here")),
                 ..Default::default()
             })
             .unwrap(),
             serde_json::json!({
-                "url": "https://example.com",
+                "url": "https://swagger.io",
                 "description": "Find more info here"
             }),
             "serialize",
+        );
+    }
+
+    #[test]
+    fn test_external_documentation_validate() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::empty());
+        let ed = ExternalDocumentation {
+            url: String::from("https://swagger.io"),
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.is_empty(),
+            "Validation should pass: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, Options::empty());
+        let ed = ExternalDocumentation {
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors
+                .contains(&"externalDocs.url: must not be empty".to_string()),
+            "Validation should fail: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, Options::empty());
+        let ed = ExternalDocumentation {
+            url: String::from("invalid-url"),
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.contains(
+                &"externalDocs.url: must be a valid URL, found `invalid-url`".to_string()
+            ),
+            "Validation should fail: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(
+            &spec,
+            Options::only(&Options::IgnoreEmptyExternalDocumentationUrl),
+        );
+        let ed = ExternalDocumentation {
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.is_empty(),
+            "Validation should pass: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, Options::only(&Options::IgnoreInvalidUrls));
+        let ed = ExternalDocumentation {
+            url: String::from("invalid-url"),
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.is_empty(),
+            "Validation should pass: {:?}",
+            ctx.errors
         );
     }
 }

--- a/src/v3_1/external_documentation.rs
+++ b/src/v3_1/external_documentation.rs
@@ -1,6 +1,6 @@
 //! References an external resource for extended documentation.
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
+use crate::common::helpers::{Context, ValidateWithContext, validate_required_url};
 use crate::v3_1::spec::Spec;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -35,24 +35,25 @@ pub struct ExternalDocumentation {
 
 impl ValidateWithContext<Spec> for ExternalDocumentation {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&Some(self.url.clone()), ctx, format!("{path}.url"));
+        validate_required_url(&self.url, ctx, format!("{path}.url"));
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::Options;
 
     #[test]
     fn test_external_documentation_deserialize() {
         assert_eq!(
             serde_json::from_value::<ExternalDocumentation>(serde_json::json!({
-                    "url": "https://example.com",
+                    "url": "https://swagger.io",
                     "description": "Find more info here"
             }))
             .unwrap(),
             ExternalDocumentation {
-                url: String::from("https://example.com"),
+                url: String::from("https://swagger.io"),
                 description: Some(String::from("Find more info here")),
                 ..Default::default()
             },
@@ -64,16 +65,89 @@ mod tests {
     fn test_external_documentation_serialize() {
         assert_eq!(
             serde_json::to_value(ExternalDocumentation {
-                url: String::from("https://example.com"),
+                url: String::from("https://swagger.io"),
                 description: Some(String::from("Find more info here")),
                 ..Default::default()
             })
             .unwrap(),
             serde_json::json!({
-                "url": "https://example.com",
+                "url": "https://swagger.io",
                 "description": "Find more info here"
             }),
             "serialize",
+        );
+    }
+
+    #[test]
+    fn test_external_documentation_validate() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::empty());
+        let ed = ExternalDocumentation {
+            url: String::from("https://swagger.io"),
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.is_empty(),
+            "Validation should pass: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, Options::empty());
+        let ed = ExternalDocumentation {
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors
+                .contains(&"externalDocs.url: must not be empty".to_string()),
+            "Validation should fail: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, Options::empty());
+        let ed = ExternalDocumentation {
+            url: String::from("invalid-url"),
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.contains(
+                &"externalDocs.url: must be a valid URL, found `invalid-url`".to_string()
+            ),
+            "Validation should fail: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(
+            &spec,
+            Options::only(&Options::IgnoreEmptyExternalDocumentationUrl),
+        );
+        let ed = ExternalDocumentation {
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.is_empty(),
+            "Validation should pass: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, Options::only(&Options::IgnoreInvalidUrls));
+        let ed = ExternalDocumentation {
+            url: String::from("invalid-url"),
+            description: Some(String::from("Find more info here")),
+            ..Default::default()
+        };
+        ed.validate_with_context(&mut ctx, String::from("externalDocs"));
+        assert!(
+            ctx.errors.is_empty(),
+            "Validation should pass: {:?}",
+            ctx.errors
         );
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -93,6 +93,10 @@ pub enum Options {
     /// Ignore empty Response.Description field.
     /// Applies for v2.0, v3.0, v3.1
     IgnoreEmptyResponseDescription,
+
+    /// Ignore empty ExternalDocumentation.URL field.
+    /// Applies for v2.0, v3.0, v3.1
+    IgnoreEmptyExternalDocumentationUrl,
 }
 
 /// A set of options to ignore unused objects.
@@ -115,6 +119,7 @@ pub const IGNORE_EMPTY_REQUIRED_FIELDS: EnumSet<Options> = enum_set!(
     Options::IgnoreEmptyInfoTitle
         | Options::IgnoreEmptyInfoVersion
         | Options::IgnoreEmptyResponseDescription
+        | Options::IgnoreEmptyExternalDocumentationUrl
 );
 
 impl Options {


### PR DESCRIPTION
Enhance validation for ExternalDocumentation in all v2, v3_0 and v3_1 specs by checking that the URL is a non-empty string unless explicitly ignored via options. Also validate that the URL is well-formed if present. Add tests to cover these validation rules. This improves spec correctness and prevents empty or invalid URLs from passing unnoticed.