### PR TITLE
refactor: simplify nested if-let chains using let-else patterns

### DIFF
--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -66,7 +66,7 @@ impl<T> Context<'_, T> {
 }
 
 impl Context<'_, ()> {
-    pub fn new<T>(spec: &T, options: EnumSet<Options>) -> Context<T> {
+    pub fn new<T>(spec: &T, options: EnumSet<Options>) -> Context<'_, T> {
         Context {
             spec,
             visited: HashSet::new(),
@@ -89,13 +89,13 @@ impl<'a, T> From<Context<'a, T>> for Result<(), Error> {
 /// Validates that the given optional email string contains an '@' character.
 /// If the email is present and invalid, records an error in the context.
 pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: String) {
-    if let Some(email) = email {
-        if !email.contains('@') {
-            ctx.error(
-                path,
-                format_args!("must be a valid email address, found `{email}`"),
-            );
-        }
+    if let Some(email) = email
+        && !email.contains('@')
+    {
+        ctx.error(
+            path,
+            format_args!("must be a valid email address, found `{email}`"),
+        );
     }
 }
 

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -98,16 +98,15 @@ pub struct Operation {
 
 impl ValidateWithContext<Spec> for Operation {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        if let Some(operation_id) = &self.operation_id {
-            if !ctx
+        if let Some(operation_id) = &self.operation_id
+            && !ctx
                 .visited
                 .insert(format!("#/paths/operations/{operation_id}"))
-            {
-                ctx.error(
-                    path.clone(),
-                    format_args!("operationId `{operation_id}` already exists"),
-                );
-            }
+        {
+            ctx.error(
+                path.clone(),
+                format_args!("operationId `{operation_id}` already exists"),
+            );
         }
         if let Some(tags) = &self.tags {
             for (i, tag) in tags.iter().enumerate() {

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -293,13 +293,13 @@ impl Validate for Spec {
         let re = Regex::new(r"^[^{}/ :\\]+(?::\d+)?$").unwrap();
         validate_optional_string_matches(&self.host, &re, &mut ctx, "#.host".to_owned());
 
-        if let Some(base_path) = &self.base_path {
-            if !base_path.starts_with('/') {
-                ctx.error(
-                    "#.basePath".to_owned(),
-                    format_args!("must start with `/`, found `{base_path}`"),
-                );
-            }
+        if let Some(base_path) = &self.base_path
+            && !base_path.starts_with('/')
+        {
+            ctx.error(
+                "#.basePath".to_owned(),
+                format_args!("must start with `/`, found `{base_path}`"),
+            );
         }
 
         // validate paths operations

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -147,15 +147,15 @@ impl ValidateWithContext<Spec> for Components {
                 }
                 validate_string_matches(name, &re, ctx, format!("{path}.securitySchemes[<name>]"));
                 obj.validate_with_context(ctx, format!("{path}.securitySchemes[{name}]"));
-                if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec) {
-                    if let Some(flow) = &oauth2.flows.implicit {
-                        for scope in flow.scopes.keys() {
-                            let reference = format!("{reference}/{scope}");
-                            if !ctx.is_visited(&reference)
-                                && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
-                            {
-                                ctx.error(reference, "unused");
-                            }
+                if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec)
+                    && let Some(flow) = &oauth2.flows.implicit
+                {
+                    for scope in flow.scopes.keys() {
+                        let reference = format!("{reference}/{scope}");
+                        if !ctx.is_visited(&reference)
+                            && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
+                        {
+                            ctx.error(reference, "unused");
                         }
                     }
                 }

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -66,16 +66,15 @@ pub struct Link {
 
 impl ValidateWithContext<Spec> for Link {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        if let Some(operation_id) = &self.operation_id {
-            if !ctx
+        if let Some(operation_id) = &self.operation_id
+            && !ctx
                 .visited
                 .contains(format!("#/paths/operations/{operation_id}").as_str())
-            {
-                ctx.error(
-                    path.clone(),
-                    format_args!(".operationId: missing operation with id `{operation_id}`"),
-                );
-            }
+        {
+            ctx.error(
+                path.clone(),
+                format_args!(".operationId: missing operation with id `{operation_id}`"),
+            );
         }
         if let Some(server) = &self.server {
             server.validate_with_context(ctx, format!("{path}.server"));

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -161,37 +161,31 @@ impl ValidateWithContext<Spec> for Operation {
                     let reference = format!("#/components/securitySchemes/{name}");
                     let spec_ref = RefOr::<SecurityScheme>::new_ref(reference.clone());
                     spec_ref.validate_with_context(ctx, path.clone());
-                    if !scopes.is_empty() {
-                        if let Ok(SecurityScheme::OAuth2(oauth2)) = spec_ref.get_item(ctx.spec) {
-                            for scope in scopes {
-                                ctx.visit(format!("{reference}/{scope}"));
-                                let mut found = false;
-                                if let Some(flow) = &oauth2.flows.implicit {
-                                    found = found || flow.scopes.contains_key(scope)
-                                }
-                                if !found {
-                                    if let Some(flow) = &oauth2.flows.password {
-                                        found = found || flow.scopes.contains_key(scope)
-                                    }
-                                }
-                                if !found {
-                                    if let Some(flow) = &oauth2.flows.client_credentials {
-                                        found = found || flow.scopes.contains_key(scope)
-                                    }
-                                }
-                                if !found {
-                                    if let Some(flow) = &oauth2.flows.authorization_code {
-                                        found = found || flow.scopes.contains_key(scope)
-                                    }
-                                }
-                                if !found {
-                                    ctx.error(
+                    if !scopes.is_empty()
+                        && let Ok(SecurityScheme::OAuth2(oauth2)) = spec_ref.get_item(ctx.spec)
+                    {
+                        for scope in scopes {
+                            ctx.visit(format!("{reference}/{scope}"));
+                            let mut found = false;
+                            if let Some(flow) = &oauth2.flows.implicit {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found && let Some(flow) = &oauth2.flows.password {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found && let Some(flow) = &oauth2.flows.client_credentials {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found && let Some(flow) = &oauth2.flows.authorization_code {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found {
+                                ctx.error(
                                         path.clone(),
                                         format_args!(
                                             "scope `{scope}` not found in spec by reference `{reference}`"
                                         ),
                                     );
-                                }
                             }
                         }
                     }

--- a/src/v3_0/security_scheme.rs
+++ b/src/v3_0/security_scheme.rs
@@ -442,13 +442,14 @@ impl ValidateWithContext<Spec> for SecurityScheme {
 
 impl ValidateWithContext<Spec> for HttpSecurityScheme {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        if let Some(bearer_format) = &self.bearer_format {
-            if !bearer_format.is_empty() && self.scheme != HttpScheme::Bearer {
-                ctx.error(
-                    path,
-                    format_args!(".bearerFormat: must be empty for scheme `{}`", self.scheme,),
-                );
-            }
+        if let Some(bearer_format) = &self.bearer_format
+            && !bearer_format.is_empty()
+            && self.scheme != HttpScheme::Bearer
+        {
+            ctx.error(
+                path,
+                format_args!(".bearerFormat: must be empty for scheme `{}`", self.scheme,),
+            );
         }
     }
 }

--- a/src/v3_0/server.rs
+++ b/src/v3_0/server.rs
@@ -128,16 +128,16 @@ impl ValidateWithContext<Spec> for Server {
 impl ValidateWithContext<Spec> for ServerVariable {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         validate_required_string(&self.default, ctx, format!("{path}.default"));
-        if let Some(enum_values) = &self.enum_values {
-            if !enum_values.contains(&self.default) {
-                ctx.error(
-                    path,
-                    format!(
-                        ".default: `{}` must be in enum values: {:?}",
-                        self.default, enum_values,
-                    ),
-                );
-            }
+        if let Some(enum_values) = &self.enum_values
+            && !enum_values.contains(&self.default)
+        {
+            ctx.error(
+                path,
+                format!(
+                    ".default: `{}` must be in enum values: {:?}",
+                    self.default, enum_values,
+                ),
+            );
         }
     }
 }

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -387,18 +387,17 @@ impl Validate for Spec {
         for (name, item) in self.paths.iter() {
             if let Some(operations) = &item.operations {
                 for (method, operation) in operations.iter() {
-                    if let Some(operation_id) = &operation.operation_id {
-                        if !ctx
+                    if let Some(operation_id) = &operation.operation_id
+                        && !ctx
                             .visited
                             .insert(format!("#/paths/operations/{operation_id}"))
-                        {
-                            ctx.error(
+                    {
+                        ctx.error(
                                 "#".to_owned(),
                                 format!(
                                     ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
                                 ),
                             );
-                        }
                     }
                 }
             }

--- a/src/v3_1/components.rs
+++ b/src/v3_1/components.rs
@@ -151,15 +151,15 @@ impl ValidateWithContext<Spec> for Components {
                 }
                 validate_string_matches(name, &re, ctx, format!("{path}.securitySchemes[<name>]"));
                 obj.validate_with_context(ctx, format!("{path}.securitySchemes[{name}]"));
-                if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec) {
-                    if let Some(flow) = &oauth2.flows.implicit {
-                        for scope in flow.scopes.keys() {
-                            let reference = format!("{reference}/{scope}");
-                            if !ctx.is_visited(&reference)
-                                && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
-                            {
-                                ctx.error(reference, "unused");
-                            }
+                if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec)
+                    && let Some(flow) = &oauth2.flows.implicit
+                {
+                    for scope in flow.scopes.keys() {
+                        let reference = format!("{reference}/{scope}");
+                        if !ctx.is_visited(&reference)
+                            && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
+                        {
+                            ctx.error(reference, "unused");
                         }
                     }
                 }
@@ -177,18 +177,17 @@ impl ValidateWithContext<Spec> for Components {
                 };
                 if let Some(operations) = &item.operations {
                     for (method, operation) in operations.iter() {
-                        if let Some(operation_id) = &operation.operation_id {
-                            if !ctx
+                        if let Some(operation_id) = &operation.operation_id
+                            && !ctx
                                 .visited
                                 .insert(format!("#/paths/operations/{operation_id}"))
-                            {
-                                ctx.error(
+                        {
+                            ctx.error(
                                     "#".to_owned(),
                                     format_args!(
                                         ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
                                     ),
                                 );
-                            }
                         }
                     }
                 }

--- a/src/v3_1/link.rs
+++ b/src/v3_1/link.rs
@@ -66,16 +66,15 @@ pub struct Link {
 
 impl ValidateWithContext<Spec> for Link {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        if let Some(operation_id) = &self.operation_id {
-            if !ctx
+        if let Some(operation_id) = &self.operation_id
+            && !ctx
                 .visited
                 .contains(format!("#/paths/operations/{operation_id}").as_str())
-            {
-                ctx.error(
-                    path.clone(),
-                    format_args!(".operationId: missing operation with id `{operation_id}`"),
-                );
-            }
+        {
+            ctx.error(
+                path.clone(),
+                format_args!(".operationId: missing operation with id `{operation_id}`"),
+            );
         }
         if let Some(server) = &self.server {
             server.validate_with_context(ctx, format!("{path}.server"));

--- a/src/v3_1/operation.rs
+++ b/src/v3_1/operation.rs
@@ -163,37 +163,31 @@ impl ValidateWithContext<Spec> for Operation {
                     let reference = format!("#/components/securitySchemes/{name}");
                     let spec_ref = RefOr::<SecurityScheme>::new_ref(reference.clone());
                     spec_ref.validate_with_context(ctx, path.clone());
-                    if !scopes.is_empty() {
-                        if let Ok(SecurityScheme::OAuth2(oauth2)) = spec_ref.get_item(ctx.spec) {
-                            for scope in scopes {
-                                ctx.visit(format!("{reference}/{scope}"));
-                                let mut found = false;
-                                if let Some(flow) = &oauth2.flows.implicit {
-                                    found = found || flow.scopes.contains_key(scope)
-                                }
-                                if !found {
-                                    if let Some(flow) = &oauth2.flows.password {
-                                        found = found || flow.scopes.contains_key(scope)
-                                    }
-                                }
-                                if !found {
-                                    if let Some(flow) = &oauth2.flows.client_credentials {
-                                        found = found || flow.scopes.contains_key(scope)
-                                    }
-                                }
-                                if !found {
-                                    if let Some(flow) = &oauth2.flows.authorization_code {
-                                        found = found || flow.scopes.contains_key(scope)
-                                    }
-                                }
-                                if !found {
-                                    ctx.error(
+                    if !scopes.is_empty()
+                        && let Ok(SecurityScheme::OAuth2(oauth2)) = spec_ref.get_item(ctx.spec)
+                    {
+                        for scope in scopes {
+                            ctx.visit(format!("{reference}/{scope}"));
+                            let mut found = false;
+                            if let Some(flow) = &oauth2.flows.implicit {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found && let Some(flow) = &oauth2.flows.password {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found && let Some(flow) = &oauth2.flows.client_credentials {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found && let Some(flow) = &oauth2.flows.authorization_code {
+                                found = found || flow.scopes.contains_key(scope)
+                            }
+                            if !found {
+                                ctx.error(
                                         path.clone(),
                                         format_args!(
                                             "scope `{scope}` not found in spec by reference `{reference}`"
                                         ),
                                     );
-                                }
                             }
                         }
                     }

--- a/src/v3_1/security_scheme.rs
+++ b/src/v3_1/security_scheme.rs
@@ -442,13 +442,14 @@ impl ValidateWithContext<Spec> for SecurityScheme {
 
 impl ValidateWithContext<Spec> for HttpSecurityScheme {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        if let Some(bearer_format) = &self.bearer_format {
-            if !bearer_format.is_empty() && self.scheme != HttpScheme::Bearer {
-                ctx.error(
-                    path,
-                    format_args!(".bearerFormat: must be empty for scheme `{}`", self.scheme,),
-                );
-            }
+        if let Some(bearer_format) = &self.bearer_format
+            && !bearer_format.is_empty()
+            && self.scheme != HttpScheme::Bearer
+        {
+            ctx.error(
+                path,
+                format_args!(".bearerFormat: must be empty for scheme `{}`", self.scheme,),
+            );
         }
     }
 }

--- a/src/v3_1/server.rs
+++ b/src/v3_1/server.rs
@@ -128,16 +128,16 @@ impl ValidateWithContext<Spec> for Server {
 impl ValidateWithContext<Spec> for ServerVariable {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         validate_required_string(&self.default, ctx, format!("{path}.default"));
-        if let Some(enum_values) = &self.enum_values {
-            if !enum_values.contains(&self.default) {
-                ctx.error(
-                    path,
-                    format!(
-                        ".default: `{}` must be in enum values: {:?}",
-                        self.default, enum_values,
-                    ),
-                );
-            }
+        if let Some(enum_values) = &self.enum_values
+            && !enum_values.contains(&self.default)
+        {
+            ctx.error(
+                path,
+                format!(
+                    ".default: `{}` must be in enum values: {:?}",
+                    self.default, enum_values,
+                ),
+            );
         }
     }
 }

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -421,18 +421,17 @@ impl Validate for Spec {
                 };
                 if let Some(operations) = &item.operations {
                     for (method, operation) in operations.iter() {
-                        if let Some(operation_id) = &operation.operation_id {
-                            if !ctx
+                        if let Some(operation_id) = &operation.operation_id
+                            && !ctx
                                 .visited
                                 .insert(format!("#/paths/operations/{operation_id}"))
-                            {
-                                ctx.error(
+                        {
+                            ctx.error(
                                     "#".to_owned(),
                                     format_args!(
                                         ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
                                     ),
                                 );
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
line validation code by collapsing nested `if let` checks and
separate inner conditionals into single combined boolean guards using
Rust's inline `let ... &&` pattern. This reduces indentation and
removes redundant braces in several modules:

- v2/spec.rs: simplify base_path presence and starts_with('/') check.
- v3_1/security_scheme.rs: combine bearer_format presence and emptiness
  check with scheme comparison.
- v3_0/operation.rs: merge multiple nested scope/flow existence checks
  into combined conditions to reduce nesting while preserving logic.
- v3_0/components.rs: collapse OAuth2 flow extraction and scope
  iteration into a single conditional.
- v3_1/link.rs: (trivial formatting alignment changed alongside other
  edits)

These changes improve readability and conciseness without altering
validation behavior.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #68 
- <kbd>&nbsp;2&nbsp;</kbd> #69 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #67 
<!-- GitButler Footer Boundary Bottom -->

