### PR TITLE
chore(re): bump crate version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"


### PR DESCRIPTION
Update package version in Cargo.toml from 0.4.0 to 0.5.0 to mark the
new release. This aligns manifest metadata with the latest changes and
prepares the crate for publishing with the updated API and features.