### PR TITLE
ci: use crates-io-auth-action and precompute licenses

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
       - run: cargo install cargo-license
+      - run: cargo license --all-features --avoid-dev-deps --json > dependencies-license.json
+      - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879 # v1.0.1
+        id: auth
       - name: Publish
-        run: |
-          cargo login ${{ secrets.CRATES_IO_TOKEN }}
-          cargo license --all-features --avoid-dev-deps --json > dependencies-license.json
-          cargo publish --all-features --allow-dirty --verbose
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --all-features --allow-dirty --verbose


### PR DESCRIPTION
Update publish workflow to use rust-lang/crates-io-auth-action to inject
the crates.io token via CARGO_REGISTRY_TOKEN instead of running
cargo login. This removes the need to expose the token in the step
commands and matches GitHub Actions best practices.

Move cargo license execution earlier so the job writes
dependencies-license.json before the Publish step. Also install
cargo-license as before and generate the JSON license report with
--all-features and --avoid-dev-deps to ensure accurate license data.