### PR TITLE
ci(github): grant id-token write permission for publish job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,8 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
       - run: cargo install cargo-license


### PR DESCRIPTION
Add explicit permissions to the publish workflow so the job can request
an OIDC id-token. This enables secure authentication to external
registries or cloud providers without long-lived secrets during the
publish step.

Include only the minimal id-token: write permission required by the
publish job to support token exchange while keeping the workflow scope
narrow.