### PR TITLE
feat(ci): use rust-metadata-action to drive feature matrix

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,16 +18,27 @@ env:
 permissions: read-all
 
 jobs:
+  RustMeta:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.rustmeta.outputs.matrix }}
+      publish: ${{ steps.rustmeta.outputs.publish }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+      - uses: sv-tools/rust-metadata-action@8618602bef8488998677a4ed006f9a9a35cf6756 # v0.1.0
+        id: rustmeta
   BuildJob:
+    needs: RustMeta
     strategy:
       matrix:
-        feature: [ "v2", "v3_0", "v3_1" ]
+        args: ${{ fromJSON(needs.RustMeta.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
-      - run: cargo build --features ${{ matrix.feature }} --no-default-features --verbose
+      - run: cargo build ${{ matrix.args }} --no-default-features --verbose
   Build:
     needs: BuildJob
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check status
@@ -51,9 +62,10 @@ jobs:
       - run: cargo clippy --all-features --quiet --message-format=json | cargo-action-fmt
         if: failure()
   TestsJob:
+    needs: RustMeta
     strategy:
       matrix:
-        feature: [ "v2", "v3_0", "v3_1" ]
+        args: ${{ fromJSON(needs.RustMeta.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
@@ -63,7 +75,7 @@ jobs:
           cache-all-crates: true
       - run: cargo tools
       - name: Run tests
-        run: cargo llvm-cov nextest --features ${{ matrix.feature }} --no-default-features --no-fail-fast --verbose
+        run: cargo llvm-cov nextest ${{ matrix.args }} --no-default-features --no-fail-fast --verbose
       - name: Prepare coverage report
         if: ${{ !cancelled() }}
         run: cargo llvm-cov report --lcov --output-path coverage.lcov
@@ -79,6 +91,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   Tests:
     needs: TestsJob
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check status
@@ -97,7 +110,11 @@ jobs:
         run: cargo machete
       - name: Deny
         run: cargo deny check all
-  Publish:
+  PublishJob:
+    needs: RustMeta
+    strategy:
+      matrix:
+        package: ${{ fromJSON(needs.RustMeta.outputs.publish) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
@@ -106,8 +123,20 @@ jobs:
           cache-targets: false
           cache-all-crates: true
       - run: cargo tools
+      - run: cargo license --all-features --avoid-dev-deps --json > dependencies-license.json
       - name: Dry run publish
-        run: |
-          cargo license --all-features --avoid-dev-deps --json > dependencies-license.json
-          cargo publish --all-features --allow-dirty --dry-run --verbose
-          cargo package --all-features --list --allow-dirty
+        run: cargo publish --package ${{ matrix.package }} --all-features --allow-dirty --dry-run --verbose
+      - name: Packaging
+        run: cargo package --package ${{ matrix.package }} --all-features --list --allow-dirty
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.package }}-crate
+          path: target/package/${{ matrix.package }}-*.crate
+  Publish:
+    needs: PublishJob
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status
+        if: ${{ needs.PublishJob.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,15 +10,30 @@ env:
 permissions: read-all
 
 jobs:
-  build:
+  Build:
     uses: ./.github/workflows/checks.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  publish:
-    needs: build
+  RustMeta:
+    needs: Build
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.rustmeta.outputs.publish }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+      - uses: sv-tools/rust-metadata-action@8618602bef8488998677a4ed006f9a9a35cf6756 # v0.1.0
+        id: rustmeta
+  Publish:
+    needs:
+      - Build
+      - RustMeta
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.RustMeta.outputs.publish) }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
       - run: cargo install cargo-license
@@ -28,4 +43,4 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --all-features --allow-dirty --verbose
+        run: cargo publish --package ${{ matrix.package }} --all-features --allow-dirty --verbose


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows for building, testing, and publishing Rust packages. The main improvement is the introduction of a new `RustMeta` job that dynamically determines build and publish matrices, enabling more flexible and automated handling of multiple packages and features. The workflows are also reorganized for better clarity and maintainability.

**Workflow automation and dynamic matrix generation:**

* Added a `RustMeta` job in both `.github/workflows/checks.yaml` and `.github/workflows/publish.yaml` that uses the `sv-tools/rust-metadata-action` to dynamically generate build and publish matrices, replacing hardcoded feature lists. Subsequent jobs (`BuildJob`, `TestsJob`, `PublishJob`, and `Publish`) now consume these outputs for their matrix strategies. [[1]](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5R21-R41) [[2]](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5R65-R68) [[3]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL13-R36)

**Build and test job improvements:**

* Updated `BuildJob` and `TestsJob` to use the dynamically generated `args` matrix instead of static feature lists, and adjusted their dependencies to require the `RustMeta` job. [[1]](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5R21-R41) [[2]](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5R65-R68) [[3]](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5L66-R78)
* Ensured that the `Build` and `Tests` jobs always run, regardless of previous job status, by adding `if: ${{ always() }}`.

**Publish job enhancements:**

* Refactored the publish process to use a matrix over packages, with each package being published individually using the output from `RustMeta`. Added steps for license generation, dry-run publishing, packaging, and artifact upload for each package. [[1]](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5L100-R117) [[2]](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5R126-R142) [[3]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL31-R46)
* In `publish.yaml`, restructured job dependencies and added a matrix strategy for publishing, ensuring each package is handled separately and errors are surfaced properly. [[1]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL13-R36) [[2]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL31-R46)

These changes make the CI/CD workflows more maintainable, scalable, and robust, especially as the number of Rust packages or features grows.