### PR TITLE
chore(deps): disable Dependabot grouping for Rust crates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,10 +12,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    groups:
-      rust-serde: # group updates of all serde crates togethers
-        patterns:
-          - "serde*"
-      rust: # group updates of all other crates togethers
-        patterns:
-          - "*"
+#    groups:
+#      rust-serde: # group updates of all serde crates togethers
+#        patterns:
+#          - "serde*"
+#      rust: # group updates of all other crates togethers
+#        patterns:
+#          - "*"


### PR DESCRIPTION
Disable the grouping section in .github/dependabot.yaml so daily
updates are processed as individual pull requests instead of being
grouped by serde or other Rust crates.

This simplifies update handling and avoids unexpected grouping logic
when reviewing or merging dependency updates.