### PR TITLE
feat(deps): enable grouped updates in Dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,10 +12,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-#    groups:
-#      rust-serde: # group updates of all serde crates together
-#        patterns:
-#          - "serde*"
-#      rust: # group updates of all other crates together
-#        patterns:
-#          - "*"
+    groups:
+      rust-serde: # group updates of all serde crates together
+        patterns:
+          - "serde*"
+        update-types: [ "major", "minor", "patch" ]
+      rust: # group updates of all other crates together
+        patterns:
+          - "*"
+        update-types: [ "major", "minor", "patch" ]


### PR DESCRIPTION
Uncomment and enable grouping for Rust dependency updates in the
Dependabot configuration. Restore the rust-serde and rust groups so that
serde-related crates and all other Rust crates are grouped into separate
update PRs. Explicitly allow all update types (major, minor, patch)
for each group.

This reduces noise by aggregating related crate updates and ensures
Dependabot produces grouped PRs for any major, minor or patch updates.