### PR TITLE
chore(deps): bump enumset, regex, serde_json, and thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ v3_0 = []
 v3_1 = []
 
 [dependencies]
-enumset = "1.1.6"
+enumset = "1.1.10"
 monostate = "0.1.14"
-regex = "1.11.1"
+regex = "1.11.2"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
-thiserror = "2.0.12"
+serde_json = "1.0.143"
+thiserror = "2.0.16"


### PR DESCRIPTION
Update several dependency versions to pick up bug fixes and minor
improvements:

- enumset: 1.1.6 -> 1.1.10
- regex: 1.11.1 -> 1.11.2
- serde_json: 1.0.140 -> 1.0.143
- thiserror: 2.0.12 -> 2.0.16

Keep monostate and serde (with derive) unchanged. These dependency
updates improve compatibility and address downstream issues in the
parsing/serialization and error-handling libraries.