### PR TITLE
chore(re): bump version to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"


### PR DESCRIPTION
Update package version in Cargo.toml from 0.5.0 to 0.5.1.
This prepares a patch release for the crate without other code
changes.