### PR TITLE
style: fix formatting and align indentation in files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/sv-tools/roas"
 keywords = ["openapi", "swagger"]
 categories = ["web-programming", "parser-implementations"]
 include = [
-  "src",
-  "Cargo.toml",
-  "README.md",
-  "LICENSE-APACHE",
-  "LICENSE-MIT",
-  "dependencies-license.json",
+    "src",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "dependencies-license.json",
 ]
 
 [package.metadata]

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-  # The triple can be any string, but only the target triples built in to
-  # rustc (as of 1.40) can be checked against actual config expressions
-  #"x86_64-unknown-linux-musl",
-  # You can also specify which target_features you promise are enabled for a
-  # particular target. target_features are currently not validated against
-  # the actual valid features supported by the target architecture.
-  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #"x86_64-unknown-linux-musl",
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -70,10 +70,10 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  #"RUSTSEC-0000-0000",
-  #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-  #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-  #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+    #"RUSTSEC-0000-0000",
+    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -97,9 +97,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-  # Each entry is the crate and version constraint, and its specific allow
-  # list
-  #{ allow = ["Zlib"], crate = "adler32" },
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], crate = "adler32" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -130,7 +130,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-  #"https://sekretz.com/registry
+    #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -157,16 +157,16 @@ workspace-default-features = "allow"
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-  #"ansi_term@0.11.0",
-  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
 # List of crates to deny
 deny = [
-  #"ansi_term@0.11.0",
-  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-  # Wrapper crates can optionally be specified to allow the crate when it
-  # is a direct dependency of the otherwise banned crate
-  #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
 ]
 
 # List of features to allow/deny
@@ -194,16 +194,16 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-  #"ansi_term@0.11.0",
-  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-  #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-  #{ crate = "ansi_term@0.11.0", depth = 20 },
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -181,11 +181,11 @@ impl ValidateWithContext<Spec> for Operation {
                             }
                             if !found {
                                 ctx.error(
-                                        path.clone(),
-                                        format_args!(
-                                            "scope `{scope}` not found in spec by reference `{reference}`"
-                                        ),
-                                    );
+                                    path.clone(),
+                                    format_args!(
+                                        "scope `{scope}` not found in spec by reference `{reference}`"
+                                    ),
+                                );
                             }
                         }
                     }

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -393,11 +393,11 @@ impl Validate for Spec {
                             .insert(format!("#/paths/operations/{operation_id}"))
                     {
                         ctx.error(
-                                "#".to_owned(),
-                                format!(
-                                    ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
-                                ),
-                            );
+                            "#".to_owned(),
+                            format!(
+                                ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
+                            ),
+                        );
                     }
                 }
             }

--- a/src/v3_1/components.rs
+++ b/src/v3_1/components.rs
@@ -183,11 +183,11 @@ impl ValidateWithContext<Spec> for Components {
                                 .insert(format!("#/paths/operations/{operation_id}"))
                         {
                             ctx.error(
-                                    "#".to_owned(),
-                                    format_args!(
-                                        ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
-                                    ),
-                                );
+                                "#".to_owned(),
+                                format_args!(
+                                    ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
+                                ),
+                            );
                         }
                     }
                 }

--- a/src/v3_1/operation.rs
+++ b/src/v3_1/operation.rs
@@ -183,11 +183,11 @@ impl ValidateWithContext<Spec> for Operation {
                             }
                             if !found {
                                 ctx.error(
-                                        path.clone(),
-                                        format_args!(
-                                            "scope `{scope}` not found in spec by reference `{reference}`"
-                                        ),
-                                    );
+                                    path.clone(),
+                                    format_args!(
+                                        "scope `{scope}` not found in spec by reference `{reference}`"
+                                    ),
+                                );
                             }
                         }
                     }

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -427,11 +427,11 @@ impl Validate for Spec {
                                 .insert(format!("#/paths/operations/{operation_id}"))
                         {
                             ctx.error(
-                                    "#".to_owned(),
-                                    format_args!(
-                                        ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
-                                    ),
-                                );
+                                "#".to_owned(),
+                                format_args!(
+                                    ".paths[{name}].{method}.operationId: `{operation_id}` already in use"
+                                ),
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
Reformat several source and config files to normalize indentation and
align multiline arguments for readability. Adjusted the spec.rs error
call to align the parameters and closing paren with surrounding code,
preventing an awkward indentation mismatch. Updated deny.toml to use
four-space indentation for commented examples and list entries so the
file is consistently indented and easier to scan.

These changes are purely cosmetic and do not alter logic or behavior.
They improve code style and maintainability.