### PR TITLE
fix(validation): correct doc for IgnoreUnusedServerVariables

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -54,7 +54,7 @@ pub enum Options {
     /// Applies for v2.0, v3.0, v3.1
     IgnoreUnusedResponses,
 
-    /// Ignore unused security definitions.
+    /// Ignore unused server variables.
     /// Applies for v3.0, v3.1
     IgnoreUnusedServerVariables,
 


### PR DESCRIPTION
Update comment for IgnoreUnusedServerVariables to accurately describe
that it ignores unused server variables instead of unused security
definitions. This fixes a misleading docstring introduced earlier and
prevents confusion when reading the validation options.