### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"


### PR DESCRIPTION
Update package version from 0.5.1 to 0.6.0 in Cargo.toml to mark a
new release. This increments the crate version to reflect recent
changes and prepare for publishing under the 0.6.0 tag.