### PR TITLE
chore(ci): add manual dispatch to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,7 @@ name: Publish
 on:
   push:
     tags: [ "v*" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Allow the publish workflow to be triggered manually via the GitHub
Actions UI by adding workflow_dispatch to the on: triggers. This
provides a convenient way to run the release/publish flow on-demand
for testing or emergency publishes without needing a tag push. Also
preserve existing tag-based trigger for automated releases.