### PR TITLE
ci: route publish matrix from outputs

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,6 +9,8 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: true
+    outputs:
+      publish: ${{ jobs.RustMeta.outputs.publish }}
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,26 +15,16 @@ jobs:
     uses: ./.github/workflows/checks.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  RustMeta:
-    needs: Build
-    runs-on: ubuntu-latest
-    outputs:
-      publish: ${{ steps.rustmeta.outputs.publish }}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
-      - uses: sv-tools/rust-metadata-action@8618602bef8488998677a4ed006f9a9a35cf6756 # v0.1.0
-        id: rustmeta
   Publish:
     needs:
       - Build
-      - RustMeta
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     strategy:
       fail-fast: false
       matrix:
-        package: ${{ fromJSON(needs.RustMeta.outputs.publish) }}
+        package: ${{ fromJSON(needs.Build.outputs.publish) }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
       - run: cargo install cargo-license


### PR DESCRIPTION
Update workflow wiring so the Publish job gets its package matrix
from the Build's outputs instead of a removed RustMeta job.
Expose a publish output on the checks workflow and adjust the
publish workflow to consume needs.Build.outputs.publish.

This removes the redundant RustMeta job and simplifies the CI
graph while preserving the package publish matrix used by the
Publish job.