### PR TITLE
fix(ci): correct outputs.publish mapping in checks workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,8 @@ on:
       CODECOV_TOKEN:
         required: true
     outputs:
-      publish: ${{ jobs.RustMeta.outputs.publish }}
+      publish:
+        value: ${{ jobs.RustMeta.outputs.publish }}
   schedule:
     - cron: "0 0 * * 0"
 


### PR DESCRIPTION
Adjust the GitHub Actions checks workflow to explicitly set the
outputs key as an object with a value field instead of a
bare string interpolation. This ensures the outputs schema matches
what composite or calling workflows expect and avoids failures when
referencing jobs.RustMeta.outputs.publish. The change preserves the
existing schedule and secrets while fixing the outputs structure.