### PR TITLE
chore(ci): remove redundant Build steps from checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -30,23 +30,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
       - uses: sv-tools/rust-metadata-action@8618602bef8488998677a4ed006f9a9a35cf6756 # v0.1.0
         id: rustmeta
-  BuildJob:
-    needs: RustMeta
-    strategy:
-      matrix:
-        args: ${{ fromJSON(needs.RustMeta.outputs.matrix) }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
-      - run: cargo build ${{ matrix.args }} --no-default-features --verbose
-  Build:
-    needs: BuildJob
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check status
-        if: ${{ needs.BuildJob.result != 'success' }}
-        run: exit 1
   Format:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Remove the duplicated BuildJob and Build entries generated from
 metadata. The CI already runs testing and other checks; keeping the
matrix build steps duplicated caused unnecessary CI complexity and extra
build runs. This simplifies the checks workflow, reduces CI runtime and
resource usage, and avoids running the same cargo build matrix twice.