### PR TITLE
OAS correctness: numeric bounds, integer multi-type, paths, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,29 @@ or manually add the following lines:
 
 ```toml
 [dependencies]
-roas = "0.4"  
+roas = "0.6"
+```
+
+The default feature is `v3_0`. To parse v2.0 or v3.1 specs, enable the
+corresponding feature:
+
+```toml
+[dependencies]
+roas = { version = "0.6", default-features = false, features = ["v3_1"] }
 ```
 
 ## Examples
 
+The default feature is `v3_0`, so the example below works with `cargo add roas`
+out of the box:
+
 ```rust
-use roas::v3_1::spec::Spec;
+use roas::v3_0::spec::Spec;
 use roas::validation::{Options, Validate};
 
-...
-
-let spec = serde_json::from_str::<Spec>(raw_json).unwrap();
+let raw_json = r#"{ "openapi": "3.0.4", "info": { "title": "demo", "version": "1" }, "paths": {} }"#;
+let spec: Spec = serde_json::from_str(raw_json).unwrap();
 spec.validate(Options::IgnoreMissingTags | Options::IgnoreExternalReferences).unwrap();
-
-...
-
 ```
+
+For v3.1 (experimental), enable the `v3_1` feature and import from `roas::v3_1`.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ roas = { version = "0.6", default-features = false, features = ["v3_1"] }
 
 ## Examples
 
-The default feature is `v3_0`, so the example below works with `cargo add roas`
-out of the box:
+The default feature is `v3_0`. The example below also uses `serde_json`
+directly, so add both crates:
+
+```shell
+cargo add roas serde_json
+```
 
 ```rust
 use roas::v3_0::spec::Spec;

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -333,18 +333,25 @@ pub struct IntegerSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<i64>>,
 
-    /// Declares the minimum value of the parameter.
+    /// Inclusive lower bound for the value.
+    /// Per JSON Schema draft-04 §5.1.3, this keyword is any number even when
+    /// the parent schema's `type` is `"integer"`. Stored as
+    /// [`serde_json::Number`] so integer-shaped values like `100` round-trip
+    /// without becoming `100.0`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<i64>,
+    pub minimum: Option<serde_json::Number>,
 
-    /// Declares that the value of the parameter is strictly greater than the value of `minimum`
+    /// If `true`, the value of the parameter is strictly greater than the
+    /// value of `minimum` (the draft-04 boolean modifier form, retained in
+    /// OpenAPI 3.0).
     #[serde(rename = "exclusiveMinimum")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclusive_minimum: Option<bool>,
 
-    /// Declares the minimum value of the parameter.
+    /// Inclusive upper bound for the value.
+    /// See [`Self::minimum`] for the rationale on the type.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<i64>,
+    pub maximum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly less than the value of `maximum`
     #[serde(rename = "exclusiveMaximum")]
@@ -1020,5 +1027,49 @@ mod tests {
                 ],
             }),
         );
+    }
+
+    #[test]
+    fn test_integer_bounds_round_trip() {
+        // OpenAPI 3.0 / JSON Schema draft-04: minimum and maximum on
+        // `IntegerSchema` are numbers, not integers. Integer-shaped JSON
+        // input must round-trip as integers (real-world specs like
+        // `tests/v3_0_data/petstore.json` write `"maximum": 100`),
+        // and fractional values must parse.
+        let json = serde_json::json!({
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).expect("must parse");
+        match &parsed {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Integer(int) => {
+                    assert_eq!(int.minimum.as_ref().unwrap().as_i64(), Some(0));
+                    assert_eq!(int.maximum.as_ref().unwrap().as_i64(), Some(100));
+                }
+                _ => panic!("expected Integer schema"),
+            },
+            _ => panic!("expected Single schema"),
+        }
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        let json = serde_json::json!({
+            "type": "integer",
+            "minimum": 0.5,
+            "maximum": 99.5,
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).expect("must parse");
+        match &parsed {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Integer(int) => {
+                    assert_eq!(int.minimum.as_ref().unwrap().as_f64(), Some(0.5));
+                    assert_eq!(int.maximum.as_ref().unwrap().as_f64(), Some(99.5));
+                }
+                _ => panic!("expected Integer schema"),
+            },
+            _ => panic!("expected Single schema"),
+        }
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
     }
 }

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -589,7 +589,7 @@ impl Validate for Spec {
         }
 
         if let Some(components) = &self.components {
-            components.validate_with_context(&mut ctx, "{}.components".to_owned());
+            components.validate_with_context(&mut ctx, "#.components".to_owned());
         }
 
         if let Some(docs) = &self.external_docs {

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -416,19 +416,21 @@ pub struct IntegerSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum: Option<i64>,
 
-    /// Declares that the value of the parameter is strictly greater than the value of `minimum`
+    /// Declares that the value of the parameter is strictly greater than this value.
+    /// In OpenAPI 3.1 / JSON Schema 2020-12 this is a numeric bound, not a boolean modifier.
     #[serde(rename = "exclusiveMinimum")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_minimum: Option<bool>,
+    pub exclusive_minimum: Option<i64>,
 
-    /// Declares the minimum value of the parameter.
+    /// Declares the maximum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<i64>,
 
-    /// Declares that the value of the parameter is strictly less than the value of `maximum`
+    /// Declares that the value of the parameter is strictly less than this value.
+    /// In OpenAPI 3.1 / JSON Schema 2020-12 this is a numeric bound, not a boolean modifier.
     #[serde(rename = "exclusiveMaximum")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_maximum: Option<bool>,
+    pub exclusive_maximum: Option<i64>,
 
     /// Declares that the value of the parameter can be restricted to a multiple of a given number
     #[serde(rename = "multipleOf")]
@@ -509,19 +511,21 @@ pub struct NumberSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum: Option<f64>,
 
-    /// Declares that the value of the parameter is strictly greater than the value of `minimum`
+    /// Declares that the value of the parameter is strictly greater than this value.
+    /// In OpenAPI 3.1 / JSON Schema 2020-12 this is a numeric bound, not a boolean modifier.
     #[serde(rename = "exclusiveMinimum")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_minimum: Option<bool>,
+    pub exclusive_minimum: Option<f64>,
 
-    /// Declares the minimum value of the parameter.
+    /// Declares the maximum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<f64>,
 
-    /// Declares that the value of the parameter is strictly less than the value of `maximum`
+    /// Declares that the value of the parameter is strictly less than this value.
+    /// In OpenAPI 3.1 / JSON Schema 2020-12 this is a numeric bound, not a boolean modifier.
     #[serde(rename = "exclusiveMaximum")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_maximum: Option<bool>,
+    pub exclusive_maximum: Option<f64>,
 
     /// Declares that the value of the parameter can be restricted to a multiple of a given number
     #[serde(rename = "multipleOf")]
@@ -1127,6 +1131,7 @@ impl ValidateWithContext<Spec> for MultiSchema {
         let allowed_types: HashSet<String> = HashSet::from_iter(vec![
             "string".into(),
             "number".into(),
+            "integer".into(),
             "object".into(),
             "array".into(),
             "boolean".into(),
@@ -1413,6 +1418,49 @@ mod tests {
     }
 
     #[test]
+    fn test_exclusive_bounds_are_numeric() {
+        // OpenAPI 3.1 / JSON Schema 2020-12: exclusiveMinimum/Maximum are numeric,
+        // not booleans (that was the OAS 3.0 / JSON Schema draft-04 form).
+        let json = serde_json::json!({
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "exclusiveMaximum": 100,
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).expect("must parse");
+        match &parsed {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Integer(int) => {
+                    assert_eq!(int.exclusive_minimum, Some(0));
+                    assert_eq!(int.exclusive_maximum, Some(100));
+                }
+                _ => panic!("expected Integer schema"),
+            },
+            _ => panic!("expected Single schema"),
+        }
+        // Round-trip back to JSON must produce the numeric form, not a boolean.
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        // Same for number
+        let json = serde_json::json!({
+            "type": "number",
+            "exclusiveMinimum": 0.5,
+            "exclusiveMaximum": 1.5,
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).expect("must parse");
+        match &parsed {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Number(n) => {
+                    assert_eq!(n.exclusive_minimum, Some(0.5));
+                    assert_eq!(n.exclusive_maximum, Some(1.5));
+                }
+                _ => panic!("expected Number schema"),
+            },
+            _ => panic!("expected Single schema"),
+        }
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+    }
+
+    #[test]
     fn test_number_serialize_deserialize() {
         let spec = Schema::Single(Box::new(SingleSchema::Number(NumberSchema {
             title: Some("foo".to_string()),
@@ -1557,6 +1605,29 @@ mod tests {
         });
         assert_eq!(serde_json::to_value(&spec).unwrap(), value);
         assert_eq!(serde_json::from_value::<Schema>(value).unwrap(), spec);
+
+        // Round-trip alone is not enough: validate that all primitive type
+        // names accepted by the deserializer are also accepted by the validator.
+        let spec_owner = Spec::default();
+        let mut ctx = Context::new(&spec_owner, crate::validation::Options::empty());
+        let multi = MultiSchema {
+            schema_types: vec![
+                "string".into(),
+                "integer".into(),
+                "number".into(),
+                "boolean".into(),
+                "object".into(),
+                "array".into(),
+                "null".into(),
+            ],
+            ..Default::default()
+        };
+        multi.validate_with_context(&mut ctx, "schema".into());
+        assert!(
+            ctx.errors.is_empty(),
+            "all primitive types should be valid: {:?}",
+            ctx.errors
+        );
     }
 
     #[test]

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -412,25 +412,33 @@ pub struct IntegerSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<i64>>,
 
-    /// Declares the minimum value of the parameter.
+    /// Inclusive lower bound for the value.
+    /// Per JSON Schema 2020-12 §6.2.4, this keyword is any number even when
+    /// the parent schema's `type` is `"integer"`, so a fractional bound such
+    /// as `0.5` is valid (and constrains the integer instance to `>= 1`).
+    /// Stored as [`serde_json::Number`] so integer-shaped values like `100`
+    /// round-trip without becoming `100.0`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<i64>,
+    pub minimum: Option<serde_json::Number>,
 
-    /// Declares that the value of the parameter is strictly greater than this value.
-    /// In OpenAPI 3.1 / JSON Schema 2020-12 this is a numeric bound, not a boolean modifier.
+    /// Strict (exclusive) lower bound for the value.
+    /// Per JSON Schema 2020-12 §6.2.5, the keyword value is any number — not
+    /// the boolean modifier from JSON Schema draft-04 / OAS 3.0.
     #[serde(rename = "exclusiveMinimum")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_minimum: Option<i64>,
+    pub exclusive_minimum: Option<serde_json::Number>,
 
-    /// Declares the maximum value of the parameter.
+    /// Inclusive upper bound for the value.
+    /// See [`Self::minimum`] for the rationale on the type.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<i64>,
+    pub maximum: Option<serde_json::Number>,
 
-    /// Declares that the value of the parameter is strictly less than this value.
-    /// In OpenAPI 3.1 / JSON Schema 2020-12 this is a numeric bound, not a boolean modifier.
+    /// Strict (exclusive) upper bound for the value.
+    /// Per JSON Schema 2020-12 §6.2.3, the keyword value is any number — not
+    /// the boolean modifier from JSON Schema draft-04 / OAS 3.0.
     #[serde(rename = "exclusiveMaximum")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_maximum: Option<i64>,
+    pub exclusive_maximum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter can be restricted to a multiple of a given number
     #[serde(rename = "multipleOf")]
@@ -1398,8 +1406,8 @@ mod tests {
             format: Some(IntegerFormat::Int32),
             default: Some(42),
             enum_values: Some(vec![1, 42, 105]),
-            minimum: Some(1),
-            maximum: Some(105),
+            minimum: Some(1.into()),
+            maximum: Some(105.into()),
             examples: Some(vec![serde_json::json!(1), serde_json::json!(42)]),
             ..Default::default()
         })));
@@ -1418,9 +1426,16 @@ mod tests {
     }
 
     #[test]
-    fn test_exclusive_bounds_are_numeric() {
-        // OpenAPI 3.1 / JSON Schema 2020-12: exclusiveMinimum/Maximum are numeric,
-        // not booleans (that was the OAS 3.0 / JSON Schema draft-04 form).
+    fn test_numeric_bounds_are_numbers() {
+        // OpenAPI 3.1 / JSON Schema 2020-12: minimum, maximum, exclusiveMinimum,
+        // and exclusiveMaximum are numbers — not booleans (the draft-04 form),
+        // and not constrained to integers when the parent type is "integer"
+        // (the keyword value is independent of the instance constraint).
+
+        // a) Integer-shaped JSON numbers (e.g. `0`, `100`) parse and
+        //    round-trip *without* becoming floats. This is required for
+        //    real-world OpenAPI documents (e.g. petstore.json) that write
+        //    `"maximum": 100` on an integer schema.
         let json = serde_json::json!({
             "type": "integer",
             "exclusiveMinimum": 0,
@@ -1430,17 +1445,41 @@ mod tests {
         match &parsed {
             Schema::Single(s) => match s.as_ref() {
                 SingleSchema::Integer(int) => {
-                    assert_eq!(int.exclusive_minimum, Some(0));
-                    assert_eq!(int.exclusive_maximum, Some(100));
+                    assert_eq!(int.exclusive_minimum.as_ref().unwrap().as_i64(), Some(0));
+                    assert_eq!(int.exclusive_maximum.as_ref().unwrap().as_i64(), Some(100));
                 }
                 _ => panic!("expected Integer schema"),
             },
             _ => panic!("expected Single schema"),
         }
-        // Round-trip back to JSON must produce the numeric form, not a boolean.
         assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
 
-        // Same for number
+        // b) Fractional bounds on `type: integer` MUST parse — JSON Schema
+        //    permits this; `minimum: 0.5` on an integer simply means
+        //    "instance is integer AND >= 0.5", i.e. >= 1.
+        let json = serde_json::json!({
+            "type": "integer",
+            "minimum": 0.5,
+            "maximum": 99.5,
+            "exclusiveMinimum": 0.5,
+            "exclusiveMaximum": 99.5,
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).expect("must parse");
+        match &parsed {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Integer(int) => {
+                    assert_eq!(int.minimum.as_ref().unwrap().as_f64(), Some(0.5));
+                    assert_eq!(int.maximum.as_ref().unwrap().as_f64(), Some(99.5));
+                    assert_eq!(int.exclusive_minimum.as_ref().unwrap().as_f64(), Some(0.5));
+                    assert_eq!(int.exclusive_maximum.as_ref().unwrap().as_f64(), Some(99.5));
+                }
+                _ => panic!("expected Integer schema"),
+            },
+            _ => panic!("expected Single schema"),
+        }
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        // c) Number schema accepts fractional bounds (sanity check).
         let json = serde_json::json!({
             "type": "number",
             "exclusiveMinimum": 0.5,

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -659,7 +659,7 @@ impl Validate for Spec {
         }
 
         if let Some(components) = &self.components {
-            components.validate_with_context(&mut ctx, "{}.components".to_owned());
+            components.validate_with_context(&mut ctx, "#.components".to_owned());
         }
 
         if self.components.is_none() && self.paths.is_none() && self.webhooks.is_none() {


### PR DESCRIPTION
Five correctness issues, all of which let invalid output through or rejected valid input.

## 1. (High) Numeric bounds had the wrong type

OpenAPI 3.0 inherits JSON Schema draft-04, where `exclusiveMinimum` / `exclusiveMaximum` are *boolean modifiers* on `minimum` / `maximum`. OpenAPI 3.1 inherits JSON Schema 2020-12, where all four (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`) are **numbers**. In both drafts, the bound *values* are numbers — even when the parent schema's `type` is `"integer"`. A `minimum: 0.5` on an integer schema is valid; it just constrains the integer to `>= 1`.

The library shipped the wrong types in two places:

- v3.1 `IntegerSchema.exclusive_{minimum,maximum}` and `NumberSchema.exclusive_{minimum,maximum}` were `Option<bool>` (the draft-04 form). Valid 3.1 input failed to deserialize, and round-trip emitted invalid 3.1 output.
- v3.0 and v3.1 `IntegerSchema.{minimum,maximum}` were `Option<i64>`. Valid input like `{ "type": "integer", "minimum": 0.5 }` failed to deserialize.

Fixed:

- v3.1 `IntegerSchema.{minimum, maximum, exclusiveMinimum, exclusiveMaximum}` → `Option<serde_json::Number>`.
- v3.0 `IntegerSchema.{minimum, maximum}` → `Option<serde_json::Number>`. (`exclusive_*` stay `Option<bool>` — that's correct in 3.0 / draft-04.)
- v3.1 `NumberSchema.{exclusiveMinimum, exclusiveMaximum}` → `Option<f64>` (matching the existing `minimum`/`maximum` types there).

`serde_json::Number` for `IntegerSchema` matters for round-trip fidelity: real-world specs (like `tests/v3_0_data/petstore.json` and `tests/v3_1_data/petstore.json`) write `"maximum": 100` as a JSON integer. `f64` would have round-tripped that as `100.0`, breaking the integration tests against the canonical documents. `Number` preserves the wire form.

Two regression tests (`test_numeric_bounds_are_numbers` in v3.1, `test_integer_bounds_round_trip` in v3.0) cover integer-shaped round-trip exactness, fractional parsing on `type: integer`, and `NumberSchema` accepting fractional bounds.

## 2. (Medium) `MultiSchema` validator rejected `"integer"`

`MultiSchema::validate_with_context` enforces that every entry of `type: [...]` is one of an allowlist. The list contained `string`, `number`, `object`, `array`, `boolean`, `null` — but not `integer`. A common nullable-integer schema (`["integer", "null"]`) would parse fine and then fail `validate()` with `type 'integer' is not supported`.

The existing `test_multi_serialize_deserialize` test used `["string", "integer"]` but only checked round-trip, not validation, which is why it didn't catch this. Fixed the allowlist and extended the test to call `validate_with_context` on every primitive type name accepted by the deserializer.

## 3. (Medium) README example didn't compile after `cargo add roas`

Three issues stacked:

- The example imported `roas::v3_1::spec::Spec`, which is behind the non-default `v3_1` feature, so the documented quickstart didn't compile after `cargo add roas`.
- The manual `Cargo.toml` snippet pinned `0.4` while the crate is at `0.6`.
- The example called `serde_json::from_str` without telling the user to add `serde_json` directly (transitive deps aren't usable).

Fixed: example uses `roas::v3_0` (the default feature) with a separate snippet for opting into `v3_1`; version bumped to `0.6`; install instructions are now `cargo add roas serde_json`.

## 4. (Low) Component validation paths used `{}.components`

`v3_0/spec.rs` and `v3_1/spec.rs` emitted error paths starting with `{}.components.…` instead of the `#.components.…` form used everywhere else. Validation still ran, but downstream tools formatting the path got `{}` literally. Both occurrences fixed.

## Test coverage

- 180 tests pass (was 176). Two new regression tests for finding 1; the existing test for finding 2 was upgraded to call the validator.
- `cargo clippy --all-features --all-targets` is clean.

Assisted-By: Claude <noreply@anthropic.com>