### PR TITLE
v2 OAS spec completeness: 17 fixes, ReDoc extensions, +96% coverage

### DIFF
--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1,6 +1,21 @@
 //! Implementation of v2.0 Specification
 //!
 //! Full specification can be found [here](https://spec.openapis.org/oas/v2.0).
+//!
+//! # Intentional permissive deviations from the spec
+//!
+//! The following are *additions* not present in the OAS 2.0 / JSON Schema
+//! draft-04 spec, kept on purpose:
+//!
+//! * `Schema` accepts a `null` type. Draft-04 has no `null` type (that
+//!   arrived in draft-06). This keeps the v2 model interoperable with
+//!   tools that emit JSON Schema 2020-12 idioms.
+//! * `PathItem` accepts arbitrary HTTP method names (e.g. `search`,
+//!   `trace`) in addition to the closed `get/put/post/delete/options/head/patch`
+//!   set defined in the spec.
+//!
+//! Both deviations are documented at the relevant types and are not
+//! flagged by `validate()`.
 
 pub mod external_documentation;
 pub mod header;
@@ -9,9 +24,11 @@ pub mod items;
 pub mod operation;
 pub mod parameter;
 pub mod path_item;
+pub mod reference;
 pub mod response;
 pub mod schema;
 pub mod security_scheme;
 pub mod spec;
 pub mod tag;
+pub(crate) mod validation;
 pub mod xml;

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -94,7 +94,7 @@ pub struct IntegerHeader {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<i64>,
+    pub minimum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly greater than the value of `minimum`
     #[serde(rename = "exclusiveMinimum")]
@@ -103,7 +103,7 @@ pub struct IntegerHeader {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<i64>,
+    pub maximum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly less than the value of `maximum`
     #[serde(rename = "exclusiveMaximum")]
@@ -213,6 +213,7 @@ pub struct ArrayHeader {
 
     /// Determines the format of the array if type array is used.
     #[serde(rename = "collectionFormat")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub collection_format: Option<CollectionFormat>,
 
     // Declares the maximum number of items that are allowed in the array.
@@ -333,9 +334,9 @@ mod tests {
                 format: Some(IntegerFormat::Int32),
                 default: Some(5.to_owned()),
                 enum_values: Some(vec![5.to_owned()]),
-                maximum: Some(10),
+                maximum: Some(10.into()),
                 exclusive_maximum: Some(true),
-                minimum: Some(1),
+                minimum: Some(1.into()),
                 exclusive_minimum: Some(true),
                 multiple_of: Some(1.0),
                 extensions: Some({
@@ -468,9 +469,9 @@ mod tests {
                 format: Some(IntegerFormat::Int32),
                 default: Some(5.to_owned()),
                 enum_values: Some(vec![5.to_owned()]),
-                maximum: Some(10),
+                maximum: Some(10.into()),
                 exclusive_maximum: Some(true),
-                minimum: Some(1),
+                minimum: Some(1.into()),
                 exclusive_minimum: Some(true),
                 multiple_of: Some(1.0),
                 extensions: Some({

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -51,6 +51,11 @@ pub struct Info {
     /// **Required** Provides the version of the application API (not to be confused with the specification version).
     pub version: String,
 
+    /// ReDoc extension that configures the API logo in generated documentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-logo")]
+    pub x_logo: Option<Logo>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -123,6 +128,32 @@ pub struct License {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+/// ReDoc `x-logo` extension object.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Logo {
+    /// **Required** URL pointing to the logo image.
+    pub url: String,
+
+    /// Optional background color, commonly a hex RGB value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_color: Option<String>,
+
+    /// Optional alt text for the logo image.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt_text: Option<String>,
+
+    /// Optional link target for the logo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub href: Option<String>,
+
+    /// Allows extensions on the logo extension object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
 impl ValidateWithContext<Spec> for Info {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if !ctx.is_option(Options::IgnoreEmptyInfoTitle) {
@@ -139,6 +170,10 @@ impl ValidateWithContext<Spec> for Info {
         if let Some(license) = &self.license {
             license.validate_with_context(ctx, format!("{path}.license"));
         }
+
+        if let Some(logo) = &self.x_logo {
+            logo.validate_with_context(ctx, format!("{path}.x-logo"));
+        }
     }
 }
 
@@ -153,6 +188,13 @@ impl ValidateWithContext<Spec> for License {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         validate_required_string(&self.name, ctx, format!("{path}.name"));
         validate_optional_url(&self.url, ctx, format!("{path}.url"));
+    }
+}
+
+impl ValidateWithContext<Spec> for Logo {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        crate::common::helpers::validate_required_url(&self.url, ctx, format!("{path}.url"));
+        validate_optional_url(&self.href, ctx, format!("{path}.href"));
     }
 }
 
@@ -244,6 +286,41 @@ mod tests {
             Info::default(),
             "deserialize",
         );
+    }
+
+    #[test]
+    fn test_info_x_logo_round_trip_and_validate() {
+        let value = json!({
+            "title": "Swagger Sample App",
+            "version": "1.0.1",
+            "x-logo": {
+                "url": "https://example.com/logo.png",
+                "backgroundColor": "#FFFFFF",
+                "altText": "Example logo",
+                "href": "https://example.com",
+                "x-extra": "kept"
+            }
+        });
+        let info = serde_json::from_value::<Info>(value.clone()).unwrap();
+        assert_eq!(
+            info.x_logo,
+            Some(Logo {
+                url: "https://example.com/logo.png".to_owned(),
+                background_color: Some("#FFFFFF".to_owned()),
+                alt_text: Some("Example logo".to_owned()),
+                href: Some("https://example.com".to_owned()),
+                extensions: Some(BTreeMap::from_iter([(
+                    "x-extra".to_owned(),
+                    serde_json::json!("kept")
+                )])),
+            })
+        );
+        assert_eq!(serde_json::to_value(&info).unwrap(), value);
+
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Default::default());
+        info.validate_with_context(&mut ctx, "info".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
     }
 
     #[test]

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -28,7 +28,6 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Info {
     /// **Required** The title of the application.
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub title: String,
 
     /// A short description of the application.
@@ -50,7 +49,6 @@ pub struct Info {
     pub license: Option<License>,
 
     /// **Required** Provides the version of the application API (not to be confused with the specification version).
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub version: String,
 
     /// Allows extensions to the Swagger Schema.
@@ -321,10 +319,13 @@ mod tests {
             }),
             "serialize",
         );
+        // Required fields are now serialized even when empty — the spec says
+        // they're required, and silently dropping them produced malformed v2
+        // output that round-tripped only by accident.
         assert_eq!(
             serde_json::to_value(Info::default()).unwrap(),
-            json!({}),
-            "serialize",
+            json!({"title": "", "version": ""}),
+            "serialize default emits required fields",
         );
     }
 

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -120,7 +120,7 @@ pub struct IntegerItem {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<i64>,
+    pub minimum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly greater than the value of `minimum`
     #[serde(rename = "exclusiveMinimum")]
@@ -129,7 +129,7 @@ pub struct IntegerItem {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<i64>,
+    pub maximum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly less than the value of `maximum`
     #[serde(rename = "exclusiveMaximum")]
@@ -379,9 +379,9 @@ mod tests {
                 format: Some(IntegerFormat::Int64),
                 default: Some(42),
                 enum_values: Some(vec![42, 105]),
-                minimum: Some(1),
+                minimum: Some(1.into()),
                 exclusive_minimum: Some(true),
-                maximum: Some(10),
+                maximum: Some(10.into()),
                 exclusive_maximum: Some(true),
                 multiple_of: Some(2.0),
                 extensions: Some({
@@ -401,9 +401,9 @@ mod tests {
                 format: Some(IntegerFormat::Int64),
                 default: Some(42),
                 enum_values: Some(vec![42, 105]),
-                minimum: Some(1),
+                minimum: Some(1.into()),
                 exclusive_minimum: Some(true),
-                maximum: Some(10),
+                maximum: Some(10.into()),
                 exclusive_maximum: Some(true),
                 multiple_of: Some(2.0),
                 extensions: Some({

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -87,9 +87,34 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub security: Option<Vec<BTreeMap<String, Vec<String>>>>,
 
+    /// ReDoc extension with code samples associated with this operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-codeSamples")]
+    pub x_code_samples: Option<Vec<CodeSample>>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// ReDoc `x-codeSamples` extension entry.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct CodeSample {
+    /// **Required** Code sample language.
+    pub lang: String,
+
+    /// Optional display label for the language tab.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+
+    /// **Required** Code sample source code.
+    pub source: String,
+
+    /// Allows extensions on the code sample extension object.
     #[serde(flatten)]
     #[serde(with = "crate::common::extensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,8 +163,21 @@ impl ValidateWithContext<Spec> for Operation {
             }
         }
 
+        if let Some(samples) = &self.x_code_samples {
+            for (i, sample) in samples.iter().enumerate() {
+                sample.validate_with_context(ctx, format!("{path}.x-codeSamples[{i}]"));
+            }
+        }
+
         self.responses
             .validate_with_context(ctx, format!("{path}.responses"));
+    }
+}
+
+impl ValidateWithContext<Spec> for CodeSample {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        validate_required_string(&self.lang, ctx, format!("{path}.lang"));
+        validate_required_string(&self.source, ctx, format!("{path}.source"));
     }
 }
 
@@ -263,6 +301,7 @@ mod tests {
                 }]),
                 deprecated: Some(true),
                 schemes: Some(vec![Scheme::HTTPS]),
+                x_code_samples: None,
                 extensions: Some({
                     let mut map = BTreeMap::new();
                     map.insert("x-extra".to_owned(), serde_json::json!("extra"));
@@ -333,6 +372,7 @@ mod tests {
                 }]),
                 deprecated: Some(true),
                 schemes: Some(vec![Scheme::HTTPS]),
+                x_code_samples: None,
                 extensions: Some({
                     let mut map = BTreeMap::new();
                     map.insert("x-extra".to_owned(), serde_json::json!("extra"));
@@ -395,5 +435,43 @@ mod tests {
             }),
             "serialization"
         );
+    }
+
+    #[test]
+    fn x_code_samples_round_trip_and_validate() {
+        let value = serde_json::json!({
+            "responses": {
+                "default": {
+                    "description": "ok"
+                }
+            },
+            "x-codeSamples": [
+                {
+                    "lang": "JavaScript",
+                    "label": "Node",
+                    "source": "console.log('ok');",
+                    "x-extra": "kept"
+                }
+            ]
+        });
+        let operation = serde_json::from_value::<Operation>(value.clone()).unwrap();
+        assert_eq!(
+            operation.x_code_samples,
+            Some(vec![CodeSample {
+                lang: "JavaScript".to_owned(),
+                label: Some("Node".to_owned()),
+                source: "console.log('ok');".to_owned(),
+                extensions: Some(BTreeMap::from_iter([(
+                    "x-extra".to_owned(),
+                    serde_json::json!("kept")
+                )])),
+            }])
+        );
+        assert_eq!(serde_json::to_value(&operation).unwrap(), value);
+
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Default::default());
+        operation.validate_with_context(&mut ctx, "operation".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
     }
 }

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -1,9 +1,9 @@
 //! Operation Object
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
-use crate::common::reference::RefOr;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::parameter::Parameter;
+use crate::v2::reference::RefOr;
 use crate::v2::response::Responses;
 use crate::v2::spec::{Scheme, Spec};
 use crate::v2::tag::Tag;
@@ -129,21 +129,12 @@ impl ValidateWithContext<Spec> for Operation {
             }
         }
 
+        // Per-parameter validation. Cross-cutting rules (body/formData
+        // exclusivity, (name, in) duplicates, path-template correspondence)
+        // run from `Spec::validate` via `crate::v2::validation`.
         if let Some(parameters) = &self.parameters {
-            let mut body_count = 0;
-            for (i, parameter) in parameters.clone().iter().enumerate() {
+            for (i, parameter) in parameters.iter().enumerate() {
                 parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
-                if let RefOr::Item(Parameter::Body(_)) = parameter {
-                    body_count += 1;
-                }
-            }
-            if body_count > 1 {
-                ctx.error(
-                    path.clone(),
-                    format_args!(
-                        ".parameters: only one body parameter allowed, found {body_count}",
-                    ),
-                );
             }
         }
 

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -49,6 +49,11 @@ pub struct InBody {
     /// ***Required*** The schema defining the type used for the body parameter.
     pub schema: RefOr<Schema>,
 
+    /// ReDoc extension containing named examples for the request body.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -189,6 +194,11 @@ pub struct StringParameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
 
+    /// ReDoc extension containing named examples for this parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -258,6 +268,11 @@ pub struct IntegerParameter {
     #[serde(rename = "multipleOf")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiple_of: Option<f64>,
+
+    /// ReDoc extension containing named examples for this parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
 
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
@@ -329,6 +344,11 @@ pub struct NumberParameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiple_of: Option<f64>,
 
+    /// ReDoc extension containing named examples for this parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -366,6 +386,11 @@ pub struct BooleanParameter {
     /// **Note**: "default" has no meaning for required parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<bool>,
+
+    /// ReDoc extension containing named examples for this parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
 
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
@@ -426,6 +451,11 @@ pub struct ArrayParameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unique_items: Option<bool>,
 
+    /// ReDoc extension containing named examples for this parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -456,6 +486,11 @@ pub struct FileParameter {
     /// **Note**: "default" has no meaning for required parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<serde_json::Value>,
+
+    /// ReDoc extension containing named examples for this parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
 
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
@@ -648,7 +683,7 @@ fn must_not_allow_empty_value(
 mod tests {
     use super::*;
     use crate::common::helpers::Context;
-    use crate::v2::items::{Items, StringItem};
+    use crate::v2::items::Items;
     use crate::v2::schema::{Schema, StringSchema};
     use crate::validation::Options;
     use serde_json::json;
@@ -692,6 +727,7 @@ mod tests {
             description: None,
             required: None,
             schema: RefOr::new_item(Schema::from(StringSchema::default())),
+            x_examples: None,
             extensions: None,
         }));
         let mut c = ctx();
@@ -797,7 +833,7 @@ mod tests {
             Parameter::Header(Box::new(InHeader::Array(ArrayParameter {
                 name: "h".into(),
                 allow_empty_value: Some(true),
-                items: Items::String(Box::new(StringItem::default())),
+                items: Items::String(Box::default()),
                 ..Default::default()
             }))),
         ] {
@@ -981,5 +1017,53 @@ mod tests {
                 c.errors
             );
         }
+    }
+
+    #[test]
+    fn x_examples_round_trip() {
+        let body = json!({
+            "in": "body",
+            "name": "payload",
+            "schema": { "type": "string" },
+            "x-examples": {
+                "application/json": { "value": "demo" }
+            }
+        });
+        let p: Parameter = serde_json::from_value(body.clone()).unwrap();
+        match &p {
+            Parameter::Body(body) => assert_eq!(
+                body.x_examples,
+                Some(BTreeMap::from_iter([(
+                    "application/json".to_owned(),
+                    serde_json::json!({ "value": "demo" })
+                )]))
+            ),
+            _ => panic!("expected body parameter"),
+        }
+        assert_eq!(serde_json::to_value(&p).unwrap(), body);
+
+        let query = json!({
+            "in": "query",
+            "type": "string",
+            "name": "q",
+            "x-examples": {
+                "default": "demo"
+            }
+        });
+        let p: Parameter = serde_json::from_value(query.clone()).unwrap();
+        match &p {
+            Parameter::Query(query) => match query.as_ref() {
+                InQuery::String(query) => assert_eq!(
+                    query.x_examples,
+                    Some(BTreeMap::from_iter([(
+                        "default".to_owned(),
+                        serde_json::json!("demo")
+                    )]))
+                ),
+                _ => panic!("expected string query parameter"),
+            },
+            _ => panic!("expected query parameter"),
+        }
+        assert_eq!(serde_json::to_value(&p).unwrap(), query);
     }
 }

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -4,8 +4,8 @@ use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, Stri
 use crate::common::helpers::{
     Context, ValidateWithContext, validate_pattern, validate_required_string,
 };
-use crate::common::reference::RefOr;
 use crate::v2::items::Items;
+use crate::v2::reference::RefOr;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
 use serde::{Deserialize, Serialize};
@@ -238,7 +238,7 @@ pub struct IntegerParameter {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<i64>,
+    pub minimum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly greater than the value of `minimum`
     #[serde(rename = "exclusiveMinimum")]
@@ -247,7 +247,7 @@ pub struct IntegerParameter {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<i64>,
+    pub maximum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly less than the value of `maximum`
     #[serde(rename = "exclusiveMaximum")]
@@ -641,5 +641,345 @@ fn must_not_allow_empty_value(
     if p.is_some_and(|x| x) {
         ctx.errors
             .push(format!("{path}.{name}: must not allow empty value"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::v2::items::{Items, StringItem};
+    use crate::v2::schema::{Schema, StringSchema};
+    use crate::validation::Options;
+    use serde_json::json;
+
+    fn ctx() -> Context<'static, Spec> {
+        // Returns a context with a default Spec held by the static box leaked.
+        // Using a leak keeps the borrow checker simple in tests; the spec lives
+        // for the test process which is fine.
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        Context::new(spec, Options::new())
+    }
+
+    #[test]
+    fn body_parameter_roundtrip_and_validate() {
+        let raw = json!({
+            "in": "body",
+            "name": "user",
+            "description": "the user",
+            "required": true,
+            "schema": {"type": "string"},
+            "x-foo": "bar",
+        });
+        let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+        match &p {
+            Parameter::Body(b) => {
+                assert_eq!(b.name, "user");
+                assert_eq!(b.required, Some(true));
+            }
+            _ => panic!("expected body"),
+        }
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v, raw);
+
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "x".into());
+        assert!(c.errors.is_empty(), "errors: {:?}", c.errors);
+
+        // Empty name produces an error.
+        let bad = Parameter::Body(Box::new(InBody {
+            name: String::new(),
+            description: None,
+            required: None,
+            schema: RefOr::new_item(Schema::from(StringSchema::default())),
+            extensions: None,
+        }));
+        let mut c = ctx();
+        bad.validate_with_context(&mut c, "p".into());
+        assert!(
+            c.errors.iter().any(|e| e.contains("must not be empty")),
+            "errors: {:?}",
+            c.errors
+        );
+    }
+
+    #[test]
+    fn header_parameter_all_variants_roundtrip_and_validate() {
+        // String
+        let raw = json!({"in": "header", "type": "string", "name": "h"});
+        let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(&p, Parameter::Header(h) if matches!(**h, InHeader::String(_))));
+        assert_eq!(serde_json::to_value(&p).unwrap(), raw);
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(c.errors.is_empty(), "errors: {:?}", c.errors);
+
+        // Integer
+        let raw = json!({"in": "header", "type": "integer", "name": "h"});
+        let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&p).unwrap(), raw);
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(c.errors.is_empty());
+
+        // Number
+        let raw = json!({"in": "header", "type": "number", "name": "h"});
+        let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&p).unwrap(), raw);
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(c.errors.is_empty());
+
+        // Boolean
+        let raw = json!({"in": "header", "type": "boolean", "name": "h"});
+        let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&p).unwrap(), raw);
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(c.errors.is_empty());
+
+        // Array
+        let raw =
+            json!({"in": "header", "type": "array", "name": "h", "items": {"type": "string"}});
+        let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&p).unwrap(), raw);
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(c.errors.is_empty());
+
+        // Header with allowEmptyValue=true should produce a "must not allow empty value" error
+        let p = Parameter::Header(Box::new(InHeader::String(StringParameter {
+            name: "h".into(),
+            allow_empty_value: Some(true),
+            ..Default::default()
+        })));
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e.contains("must not allow empty value")),
+            "errors: {:?}",
+            c.errors
+        );
+
+        // Header with bad pattern triggers pattern error.
+        let p = Parameter::Header(Box::new(InHeader::String(StringParameter {
+            name: "h".into(),
+            pattern: Some("[".into()),
+            ..Default::default()
+        })));
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(
+            c.errors.iter().any(|e| e.contains("pattern")),
+            "errors: {:?}",
+            c.errors
+        );
+
+        // Each non-string variant — exercise allow-empty-value on each.
+        for variant in [
+            Parameter::Header(Box::new(InHeader::Integer(IntegerParameter {
+                name: "h".into(),
+                allow_empty_value: Some(true),
+                ..Default::default()
+            }))),
+            Parameter::Header(Box::new(InHeader::Number(NumberParameter {
+                name: "h".into(),
+                allow_empty_value: Some(true),
+                ..Default::default()
+            }))),
+            Parameter::Header(Box::new(InHeader::Boolean(BooleanParameter {
+                name: "h".into(),
+                allow_empty_value: Some(true),
+                ..Default::default()
+            }))),
+            Parameter::Header(Box::new(InHeader::Array(ArrayParameter {
+                name: "h".into(),
+                allow_empty_value: Some(true),
+                items: Items::String(Box::new(StringItem::default())),
+                ..Default::default()
+            }))),
+        ] {
+            let mut c = ctx();
+            variant.validate_with_context(&mut c, "p".into());
+            assert!(
+                c.errors
+                    .iter()
+                    .any(|e| e.contains("must not allow empty value")),
+                "errors: {:?}",
+                c.errors
+            );
+        }
+    }
+
+    #[test]
+    fn query_parameter_all_variants_roundtrip_and_validate() {
+        for raw in [
+            json!({"in": "query", "type": "string", "name": "q"}),
+            json!({"in": "query", "type": "integer", "name": "q"}),
+            json!({"in": "query", "type": "number", "name": "q"}),
+            json!({"in": "query", "type": "boolean", "name": "q"}),
+            json!({"in": "query", "type": "array", "name": "q", "items": {"type": "string"}}),
+        ] {
+            let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+            assert_eq!(serde_json::to_value(&p).unwrap(), raw);
+            let mut c = ctx();
+            p.validate_with_context(&mut c, "p".into());
+            assert!(c.errors.is_empty(), "errors: {:?}", c.errors);
+        }
+
+        // Validate empty name reports an error for each kind.
+        for inner in [
+            InQuery::String(StringParameter::default()),
+            InQuery::Integer(IntegerParameter::default()),
+            InQuery::Number(NumberParameter::default()),
+            InQuery::Boolean(BooleanParameter::default()),
+            InQuery::Array(ArrayParameter {
+                items: Items::String(Box::default()),
+                ..Default::default()
+            }),
+        ] {
+            let p = Parameter::Query(Box::new(inner));
+            let mut c = ctx();
+            p.validate_with_context(&mut c, "p".into());
+            assert!(
+                c.errors.iter().any(|e| e.contains("must not be empty")),
+                "errors: {:?}",
+                c.errors
+            );
+        }
+    }
+
+    #[test]
+    fn path_parameter_all_variants_validate() {
+        // Each path parameter variant must have required=true; otherwise an error is reported.
+        let cases = [
+            Parameter::Path(Box::new(InPath::String(StringParameter {
+                name: "id".into(),
+                required: Some(true),
+                ..Default::default()
+            }))),
+            Parameter::Path(Box::new(InPath::Integer(IntegerParameter {
+                name: "id".into(),
+                required: Some(true),
+                ..Default::default()
+            }))),
+            Parameter::Path(Box::new(InPath::Number(NumberParameter {
+                name: "id".into(),
+                required: Some(true),
+                ..Default::default()
+            }))),
+            Parameter::Path(Box::new(InPath::Boolean(BooleanParameter {
+                name: "id".into(),
+                required: Some(true),
+                ..Default::default()
+            }))),
+            Parameter::Path(Box::new(InPath::Array(ArrayParameter {
+                name: "id".into(),
+                required: Some(true),
+                items: Items::String(Box::default()),
+                ..Default::default()
+            }))),
+        ];
+        for p in &cases {
+            let raw = serde_json::to_value(p).unwrap();
+            let p2: Parameter = serde_json::from_value(raw.clone()).unwrap();
+            assert_eq!(p, &p2);
+            let mut c = ctx();
+            p.validate_with_context(&mut c, "p".into());
+            assert!(c.errors.is_empty(), "errors: {:?}", c.errors);
+        }
+
+        // Path without required produces an error
+        let p = Parameter::Path(Box::new(InPath::String(StringParameter {
+            name: "id".into(),
+            required: None,
+            ..Default::default()
+        })));
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(
+            c.errors.iter().any(|e| e.contains("must be required")),
+            "errors: {:?}",
+            c.errors
+        );
+
+        // Path with allow_empty_value triggers extra error.
+        let p = Parameter::Path(Box::new(InPath::String(StringParameter {
+            name: "id".into(),
+            required: Some(true),
+            allow_empty_value: Some(true),
+            ..Default::default()
+        })));
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e.contains("must not allow empty value")),
+            "errors: {:?}",
+            c.errors
+        );
+
+        // Hit each Path variant's must_be_required + allow-empty-value branches.
+        for inner in [
+            InPath::Integer(IntegerParameter::default()),
+            InPath::Number(NumberParameter::default()),
+            InPath::Boolean(BooleanParameter::default()),
+            InPath::Array(ArrayParameter {
+                items: Items::String(Box::default()),
+                ..Default::default()
+            }),
+        ] {
+            let p = Parameter::Path(Box::new(inner));
+            let mut c = ctx();
+            p.validate_with_context(&mut c, "p".into());
+            assert!(
+                c.errors.iter().any(|e| e.contains("must be required")),
+                "errors: {:?}",
+                c.errors
+            );
+        }
+    }
+
+    #[test]
+    fn formdata_parameter_all_variants_roundtrip_and_validate() {
+        for raw in [
+            json!({"in": "formData", "type": "string", "name": "f"}),
+            json!({"in": "formData", "type": "integer", "name": "f"}),
+            json!({"in": "formData", "type": "number", "name": "f"}),
+            json!({"in": "formData", "type": "boolean", "name": "f"}),
+            json!({"in": "formData", "type": "array", "name": "f", "items": {"type": "string"}}),
+            json!({"in": "formData", "type": "file", "name": "f"}),
+        ] {
+            let p: Parameter = serde_json::from_value(raw.clone()).unwrap();
+            assert_eq!(serde_json::to_value(&p).unwrap(), raw);
+            let mut c = ctx();
+            p.validate_with_context(&mut c, "p".into());
+            assert!(c.errors.is_empty(), "errors: {:?}", c.errors);
+        }
+
+        // Empty-name validation for each variant.
+        for inner in [
+            InFormData::String(StringParameter::default()),
+            InFormData::Integer(IntegerParameter::default()),
+            InFormData::Number(NumberParameter::default()),
+            InFormData::Boolean(BooleanParameter::default()),
+            InFormData::Array(ArrayParameter {
+                items: Items::String(Box::default()),
+                ..Default::default()
+            }),
+            InFormData::File(FileParameter::default()),
+        ] {
+            let p = Parameter::FormData(Box::new(inner));
+            let mut c = ctx();
+            p.validate_with_context(&mut c, "p".into());
+            assert!(
+                c.errors.iter().any(|e| e.contains("must not be empty")),
+                "errors: {:?}",
+                c.errors
+            );
+        }
     }
 }

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -1,9 +1,9 @@
 //! Path Items
 
 use crate::common::helpers::{Context, ValidateWithContext};
-use crate::common::reference::RefOr;
 use crate::v2::operation::Operation;
 use crate::v2::parameter::Parameter;
+use crate::v2::reference::RefOr;
 use crate::v2::spec::Spec;
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
@@ -67,11 +67,20 @@ use std::fmt;
 /// ```
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct PathItem {
+    /// Allows for an external definition of this path item.
+    /// The referenced structure MUST be in the format of a Path Item Object.
+    /// If there are conflicts between the referenced definition and this Path Item's
+    /// definition, the behavior is undefined.
+    pub reference: Option<String>,
+
     /// A definition of the operations on this path.
     ///
     /// Any map items that can be converted to an `Operation` object will be stored here.
     /// This includes `get`, `put`, `post`, `delete`, `options`, `head`, `patch`, `trace`,
     /// and any other custom operations, like SEARCH and etc...
+    ///
+    /// Note: v2 spec defines a closed set (`get/put/post/delete/options/head/patch`); this
+    /// implementation accepts arbitrary HTTP methods as an intentional permissive extension.
     pub operations: Option<BTreeMap<String, Operation>>,
 
     /// A list of parameters that are applicable for all the operations described under this path.
@@ -95,6 +104,10 @@ impl Serialize for PathItem {
         S: Serializer,
     {
         let mut map = serializer.serialize_map(None)?;
+
+        if let Some(reference) = &self.reference {
+            map.serialize_entry("$ref", reference)?;
+        }
 
         if let Some(o) = &self.operations {
             for (k, v) in o {
@@ -124,6 +137,7 @@ impl<'de> Deserialize<'de> for PathItem {
         D: Deserializer<'de>,
     {
         const FIELDS: &[&str] = &[
+            "$ref",
             "parameters",
             "get",
             "head",
@@ -154,7 +168,12 @@ impl<'de> Deserialize<'de> for PathItem {
                 let mut operations: BTreeMap<String, Operation> = BTreeMap::new();
                 let mut extensions: BTreeMap<String, serde_json::Value> = BTreeMap::new();
                 while let Some(key) = map.next_key::<String>()? {
-                    if key == "parameters" {
+                    if key == "$ref" {
+                        if res.reference.is_some() {
+                            return Err(Error::duplicate_field("$ref"));
+                        }
+                        res.reference = Some(map.next_value()?);
+                    } else if key == "parameters" {
                         if res.parameters.is_some() {
                             return Err(Error::duplicate_field("parameters"));
                         }
@@ -199,6 +218,109 @@ impl ValidateWithContext<Spec> for PathItem {
                 parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
             }
         }
+    }
+}
+
+/// The Paths Object: holds the relative paths to the individual endpoints.
+///
+/// In addition to the path-keyed entries, this object supports
+/// Specification Extensions (`^x-` keys) per the v2 spec.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Paths {
+    /// Map from a path (which MUST begin with `/`) to its `PathItem`.
+    pub paths: BTreeMap<String, PathItem>,
+
+    /// `^x-` Specification Extensions on the Paths Object itself.
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Paths {
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, PathItem> {
+        self.paths.iter()
+    }
+}
+
+impl<S, K> From<S> for Paths
+where
+    S: IntoIterator<Item = (K, PathItem)>,
+    K: Into<String>,
+{
+    fn from(iter: S) -> Self {
+        Paths {
+            paths: iter.into_iter().map(|(k, v)| (k.into(), v)).collect(),
+            extensions: None,
+        }
+    }
+}
+
+impl Serialize for Paths {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let total = self.paths.len() + self.extensions.as_ref().map(|e| e.len()).unwrap_or(0);
+        let mut map = serializer.serialize_map(Some(total))?;
+        for (k, v) in &self.paths {
+            map.serialize_entry(k, v)?;
+        }
+        if let Some(ext) = &self.extensions {
+            for (k, v) in ext {
+                if k.starts_with("x-") {
+                    map.serialize_entry(k, v)?;
+                }
+            }
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Paths {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PathsVisitor;
+        impl<'de> Visitor<'de> for PathsVisitor {
+            type Value = Paths;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a Paths object")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Paths, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut paths: BTreeMap<String, PathItem> = BTreeMap::new();
+                let mut ext: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if key.starts_with("x-") {
+                        if ext.contains_key(&key) {
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
+                        }
+                        ext.insert(key, map.next_value()?);
+                    } else {
+                        if paths.contains_key(&key) {
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
+                        }
+                        paths.insert(key, map.next_value()?);
+                    }
+                }
+                Ok(Paths {
+                    paths,
+                    extensions: if ext.is_empty() { None } else { Some(ext) },
+                })
+            }
+        }
+        deserializer.deserialize_map(PathsVisitor)
     }
 }
 
@@ -397,6 +519,7 @@ mod tests {
             }))
             .unwrap(),
             PathItem {
+                reference: None,
                 operations: Some({
                     let mut operations = BTreeMap::new();
                     operations.insert(
@@ -641,5 +764,144 @@ mod tests {
             },
             "deserialize",
         );
+    }
+
+    #[test]
+    fn path_item_with_ref_roundtrip() {
+        let raw = serde_json::json!({
+            "$ref": "#/paths/~1foo",
+            "x-extra": "y",
+        });
+        let item: PathItem = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(item.reference, Some("#/paths/~1foo".to_owned()));
+        assert!(item.operations.is_none());
+        let v = serde_json::to_value(&item).unwrap();
+        assert_eq!(v, raw);
+    }
+
+    #[test]
+    fn path_item_serialize_with_parameters() {
+        let item = PathItem {
+            reference: Some("#/x".to_owned()),
+            operations: None,
+            parameters: Some(vec![RefOr::new_ref("#/parameters/Foo".to_owned())]),
+            extensions: Some({
+                let mut m = BTreeMap::new();
+                m.insert("x-bar".to_owned(), serde_json::json!("baz"));
+                m
+            }),
+        };
+        let v = serde_json::to_value(&item).unwrap();
+        assert_eq!(v["$ref"], serde_json::json!("#/x"));
+        assert_eq!(
+            v["parameters"][0]["$ref"],
+            serde_json::json!("#/parameters/Foo")
+        );
+        assert_eq!(v["x-bar"], serde_json::json!("baz"));
+    }
+
+    #[test]
+    fn path_item_validate_runs_operations_and_parameters() {
+        use crate::common::helpers::Context;
+        use crate::v2::operation::Operation;
+        use crate::v2::response::Responses;
+        use crate::v2::spec::Spec;
+        use crate::validation::Options;
+        let spec = Spec::default();
+
+        // operation with empty Responses (no default + no responses) triggers error
+        let mut ops = BTreeMap::new();
+        ops.insert(
+            "get".to_owned(),
+            Operation {
+                responses: Responses::default(),
+                ..Default::default()
+            },
+        );
+        let item = PathItem {
+            operations: Some(ops),
+            parameters: Some(vec![RefOr::new_item(Parameter::Path(Box::new(
+                InPath::String(crate::v2::parameter::StringParameter {
+                    name: "id".into(),
+                    required: None,
+                    ..Default::default()
+                }),
+            )))]),
+            ..Default::default()
+        };
+
+        let mut ctx = Context::new(&spec, Options::new());
+        item.validate_with_context(&mut ctx, "p".into());
+        // Responses-empty error + must-be-required error.
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must declare at least one response")),
+            "errors: {:?}",
+            ctx.errors
+        );
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must be required")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn paths_serde_roundtrip_with_extensions() {
+        let raw = serde_json::json!({
+            "/users": {
+                "get": {
+                    "responses": {
+                        "default": {"description": "ok"}
+                    }
+                }
+            },
+            "x-spec-ext": "yes",
+        });
+        let paths: Paths = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(paths.len(), 1);
+        assert!(paths.extensions.is_some());
+        assert!(!paths.is_empty());
+        let v = serde_json::to_value(&paths).unwrap();
+        assert_eq!(v, raw);
+    }
+
+    #[test]
+    fn paths_duplicate_path_and_extension_error() {
+        let err = serde_json::from_str::<Paths>("{\"/a\": {}, \"/a\": {}}").unwrap_err();
+        assert!(err.to_string().contains("duplicate field"), "err: {err}");
+
+        let err = serde_json::from_str::<Paths>("{\"x-a\": \"1\", \"x-a\": \"2\"}").unwrap_err();
+        assert!(err.to_string().contains("duplicate field"), "err: {err}");
+    }
+
+    #[test]
+    fn paths_from_iter() {
+        let p = Paths::from(vec![("/a".to_owned(), PathItem::default())]);
+        assert_eq!(p.len(), 1);
+        let mut iter = p.iter();
+        assert!(iter.next().is_some());
+    }
+
+    #[test]
+    fn path_item_duplicate_field_errors() {
+        let err =
+            serde_json::from_str::<PathItem>("{\"$ref\": \"#/x\", \"$ref\": \"#/y\"}").unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "err: {err}");
+
+        let err = serde_json::from_str::<PathItem>("{\"parameters\": [], \"parameters\": []}")
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "err: {err}");
+
+        let err = serde_json::from_str::<PathItem>("{\"x-a\": \"1\", \"x-a\": \"2\"}").unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "err: {err}");
+
+        let err = serde_json::from_str::<PathItem>(
+            "{\"GET\": {\"responses\":{\"default\":{\"description\":\"ok\"}}}, \"get\": {\"responses\":{\"default\":{\"description\":\"ok\"}}}}",
+        )
+        .unwrap_err();
+        // Duplicate detection lower-cases method names.
+        assert!(err.to_string().contains("duplicate"), "err: {err}");
     }
 }

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -207,6 +207,16 @@ impl<'de> Deserialize<'de> for PathItem {
 
 impl ValidateWithContext<Spec> for PathItem {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // `$ref` (when present) MUST be a non-empty URI per the spec; the same
+        // shape `v2::reference::Ref::validate_with_context` enforces.
+        if let Some(reference) = &self.reference {
+            crate::common::helpers::validate_required_string(
+                reference,
+                ctx,
+                format!("{path}.$ref"),
+            );
+        }
+
         if let Some(other) = &self.operations {
             for (method, operation) in other.iter() {
                 operation.validate_with_context(ctx, format!("{path}.{method}"));
@@ -266,7 +276,15 @@ impl Serialize for Paths {
     where
         S: Serializer,
     {
-        let total = self.paths.len() + self.extensions.as_ref().map(|e| e.len()).unwrap_or(0);
+        // Only `x-` keys are emitted from `extensions`, so the size hint must
+        // count only those — a programmatically constructed map could carry
+        // non-`x-` entries that would otherwise overstate the count.
+        let ext_x_count = self
+            .extensions
+            .as_ref()
+            .map(|e| e.keys().filter(|k| k.starts_with("x-")).count())
+            .unwrap_or(0);
+        let total = self.paths.len() + ext_x_count;
         let mut map = serializer.serialize_map(Some(total))?;
         for (k, v) in &self.paths {
             map.serialize_entry(k, v)?;
@@ -777,6 +795,23 @@ mod tests {
         assert!(item.operations.is_none());
         let v = serde_json::to_value(&item).unwrap();
         assert_eq!(v, raw);
+    }
+
+    #[test]
+    fn path_item_empty_ref_is_flagged() {
+        // Empty `$ref` is invalid — it must be a non-empty URI.
+        let item = PathItem {
+            reference: Some(String::new()),
+            ..Default::default()
+        };
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        item.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
     }
 
     #[test]

--- a/src/v2/reference.rs
+++ b/src/v2/reference.rs
@@ -1,0 +1,319 @@
+//! v2 Reference Object — `$ref`-only.
+//!
+//! OpenAPI 2.0's Reference Object has exactly one field, `$ref`. The shared
+//! `crate::common::reference::Ref` carries `summary` and `description` for
+//! v3.1 compatibility; using it in v2 would let those v3.1-only fields leak
+//! into v2 deserialize/serialize. This module pins v2 to the spec form.
+
+use serde::{Deserialize, Serialize};
+
+use crate::common::helpers::{Context, PushError, ValidateWithContext};
+use crate::common::reference::{ResolveError, ResolveReference};
+use crate::validation::Options;
+
+/// v2 Reference Object — exactly `{ "$ref": "..." }`.
+///
+/// `#[serde(deny_unknown_fields)]` rejects extra v3.1-style `summary` /
+/// `description` keys that are not part of the v2 spec.
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Ref {
+    /// **Required** The reference identifier. MUST be a URI.
+    #[serde(rename = "$ref")]
+    pub reference: String,
+}
+
+impl Ref {
+    pub fn new(reference: impl Into<String>) -> Self {
+        Ref {
+            reference: reference.into(),
+        }
+    }
+
+    pub fn validate_with_context<T, D>(&self, ctx: &mut Context<T>, path: String)
+    where
+        T: ResolveReference<D>,
+        D: ValidateWithContext<T>,
+    {
+        if self.reference.is_empty() {
+            ctx.error(path, ".$ref: must not be empty");
+        }
+    }
+}
+
+/// v2 RefOr<T> — either a `$ref` (v2 form) or an inline value of `T`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RefOr<T> {
+    Ref(Ref),
+    Item(T),
+}
+
+impl<D> RefOr<D> {
+    pub fn new_ref(reference: impl Into<String>) -> Self {
+        RefOr::Ref(Ref::new(reference))
+    }
+
+    pub fn new_item(item: D) -> Self {
+        RefOr::Item(item)
+    }
+
+    pub fn get_item<'a, T>(&'a self, spec: &'a T) -> Result<&'a D, ResolveError>
+    where
+        T: ResolveReference<D>,
+    {
+        match self {
+            RefOr::Item(d) => Ok(d),
+            RefOr::Ref(r) => {
+                if r.reference.starts_with("#/") {
+                    match spec.resolve_reference(&r.reference) {
+                        Some(d) => Ok(d),
+                        None => Err(ResolveError::NotFound(r.reference.clone())),
+                    }
+                } else {
+                    Err(ResolveError::ExternalUnsupported(r.reference.clone()))
+                }
+            }
+        }
+    }
+
+    pub fn validate_with_context<T>(&self, ctx: &mut Context<T>, path: String)
+    where
+        T: ResolveReference<D>,
+        D: ValidateWithContext<T>,
+    {
+        match self {
+            RefOr::Ref(r) => {
+                r.validate_with_context(ctx, path.clone());
+                if ctx.visit(r.reference.clone()) {
+                    match self.get_item(ctx.spec) {
+                        Ok(d) => {
+                            d.validate_with_context(ctx, r.reference.clone());
+                        }
+                        Err(ResolveError::NotFound(reference)) => {
+                            ctx.error(path, format_args!(".$ref: `{reference}` not found"));
+                        }
+                        Err(e @ ResolveError::ExternalUnsupported(_)) => {
+                            if !ctx.is_option(Options::IgnoreExternalReferences) {
+                                ctx.error(path, format_args!(".$ref: {e}"));
+                            }
+                        }
+                    }
+                }
+            }
+            RefOr::Item(d) => d.validate_with_context(ctx, path),
+        }
+    }
+}
+
+/// Resolve a `$ref` against a `BTreeMap<String, RefOr<D>>` field on the spec.
+pub fn resolve_in_map<'a, T, D>(
+    spec: &'a T,
+    reference: &str,
+    prefix: &str,
+    map: &'a Option<std::collections::BTreeMap<String, RefOr<D>>>,
+) -> Option<&'a D>
+where
+    T: ResolveReference<D>,
+{
+    map.as_ref()
+        .and_then(|x| x.get(reference.trim_start_matches(prefix)))
+        .and_then(move |x| x.get_item(spec).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+    struct Foo {
+        pub foo: String,
+    }
+
+    #[test]
+    fn ref_only_serializes_dollar_ref() {
+        let r = RefOr::<Foo>::new_ref("#/definitions/Foo");
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            json!({"$ref": "#/definitions/Foo"}),
+        );
+    }
+
+    #[test]
+    fn item_serializes_inline() {
+        let r = RefOr::new_item(Foo { foo: "bar".into() });
+        assert_eq!(serde_json::to_value(&r).unwrap(), json!({"foo": "bar"}),);
+    }
+
+    #[test]
+    fn deserialize_ref() {
+        let r: RefOr<Foo> = serde_json::from_value(json!({"$ref": "#/definitions/Foo"})).unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/definitions/Foo"));
+    }
+
+    #[test]
+    fn deserialize_rejects_v3_1_fields() {
+        // v3.1's `summary` / `description` on a Ref are not allowed in v2.
+        let r = serde_json::from_value::<RefOr<Foo>>(json!({
+            "$ref": "#/definitions/Foo",
+            "summary": "should be rejected",
+        }));
+        // We expect the ref form to be rejected (deny_unknown_fields), and the
+        // input to fall through to the Item form, which then also fails because
+        // it lacks the required `foo` field.
+        assert!(
+            r.is_err(),
+            "should not silently accept v3.1 summary on v2 Ref"
+        );
+    }
+
+    use crate::common::helpers::Context;
+    use crate::v2::schema::{Schema, StringSchema};
+    use crate::v2::spec::Spec;
+    use crate::validation::Options;
+
+    #[test]
+    fn get_item_returns_inline() {
+        let mut spec = Spec::default();
+        let _ = spec
+            .define_schema("Foo", Schema::from(StringSchema::default()))
+            .unwrap();
+        let r = RefOr::<Schema>::new_item(Schema::from(StringSchema::default()));
+        let v = r.get_item(&spec).unwrap();
+        assert!(matches!(v, Schema::String(_)));
+    }
+
+    #[test]
+    fn get_item_resolves_internal_ref() {
+        let mut spec = Spec::default();
+        let _ = spec
+            .define_schema("Foo", Schema::from(StringSchema::default()))
+            .unwrap();
+        let r = RefOr::<Schema>::new_ref("#/definitions/Foo");
+        assert!(r.get_item(&spec).is_ok());
+    }
+
+    #[test]
+    fn get_item_returns_not_found() {
+        let spec = Spec::default();
+        let r = RefOr::<Schema>::new_ref("#/definitions/Missing");
+        let err = r.get_item(&spec).unwrap_err();
+        assert!(matches!(err, ResolveError::NotFound(_)));
+    }
+
+    #[test]
+    fn get_item_external_unsupported() {
+        let spec = Spec::default();
+        let r = RefOr::<Schema>::new_ref("https://example.com/foo.json");
+        let err = r.get_item(&spec).unwrap_err();
+        assert!(matches!(err, ResolveError::ExternalUnsupported(_)));
+    }
+
+    #[test]
+    fn validate_with_context_inline_propagates() {
+        let spec = Spec::default();
+        let r = RefOr::<Schema>::new_item(Schema::from(StringSchema {
+            pattern: Some("[".into()),
+            ..Default::default()
+        }));
+        let mut ctx = Context::new(&spec, Options::new());
+        r.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("pattern")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_with_context_ref_hit() {
+        let mut spec = Spec::default();
+        let _ = spec
+            .define_schema(
+                "Foo",
+                Schema::from(StringSchema {
+                    pattern: Some("[".into()),
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+        let r = RefOr::<Schema>::new_ref("#/definitions/Foo");
+        let mut ctx = Context::new(&spec, Options::new());
+        r.validate_with_context(&mut ctx, "p".into());
+        // The inner schema's pattern should be invalidated.
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("pattern")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_with_context_ref_miss() {
+        let spec = Spec::default();
+        let r = RefOr::<Schema>::new_ref("#/definitions/Missing");
+        let mut ctx = Context::new(&spec, Options::new());
+        r.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("not found")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_with_context_external_unsupported() {
+        let spec = Spec::default();
+        let r = RefOr::<Schema>::new_ref("https://example.com/foo.json");
+        let mut ctx = Context::new(&spec, Options::new());
+        r.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("not supported") || e.contains("external")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // With option set, no error.
+        let mut ctx = Context::new(&spec, Options::only(&Options::IgnoreExternalReferences));
+        r.validate_with_context(&mut ctx, "p".into());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn validate_empty_ref_string() {
+        let r = Ref::new("");
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        // Use Schema as the resolved type so ValidateWithContext bound is satisfied.
+        r.validate_with_context::<Spec, Schema>(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn resolve_in_map_helper() {
+        let mut spec = Spec::default();
+        let _ = spec
+            .define_schema("Foo", Schema::from(StringSchema::default()))
+            .unwrap();
+        // Using a built map of RefOr<Schema>, not the spec's `definitions` field.
+        let mut map: std::collections::BTreeMap<String, RefOr<Schema>> = Default::default();
+        map.insert(
+            "X".into(),
+            RefOr::new_item(Schema::from(StringSchema::default())),
+        );
+        let opt = Some(map);
+        let v = resolve_in_map::<Spec, Schema>(&spec, "#/definitions/X", "#/definitions/", &opt);
+        assert!(v.is_some());
+
+        let v =
+            resolve_in_map::<Spec, Schema>(&spec, "#/definitions/Missing", "#/definitions/", &opt);
+        assert!(v.is_none());
+    }
+}

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -55,6 +55,11 @@ pub struct Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub examples: Option<BTreeMap<String, serde_json::Value>>,
 
+    /// ReDoc extension with a short response summary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-summary")]
+    pub x_summary: Option<String>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -269,6 +274,7 @@ mod tests {
                     map.insert("baz".to_owned(), serde_json::json!(42));
                     map
                 }),
+                x_summary: None,
                 extensions: Some({
                     let mut map = BTreeMap::new();
                     map.insert("x-extra".to_owned(), serde_json::json!("extension"));
@@ -314,6 +320,7 @@ mod tests {
                     map.insert("baz".to_owned(), serde_json::json!(42));
                     map
                 }),
+                x_summary: None,
                 extensions: Some({
                     let mut map = BTreeMap::new();
                     map.insert("x-extra".to_owned(), serde_json::json!("extension"));
@@ -426,6 +433,7 @@ mod tests {
                         map.insert("baz".to_owned(), serde_json::json!(42));
                         map
                     }),
+                    x_summary: None,
                     extensions: Some({
                         let mut map = BTreeMap::new();
                         map.insert("x-extra".to_owned(), serde_json::json!("extension"));
@@ -472,6 +480,7 @@ mod tests {
                                 map.insert("baz".to_owned(), serde_json::json!(42));
                                 map
                             }),
+                            x_summary: None,
                             extensions: Some({
                                 let mut map = BTreeMap::new();
                                 map.insert("x-extra".to_owned(), serde_json::json!("extension"));
@@ -575,6 +584,7 @@ mod tests {
                         map.insert("baz".to_owned(), serde_json::json!(42));
                         map
                     }),
+                    x_summary: None,
                     extensions: Some({
                         let mut map = BTreeMap::new();
                         map.insert("x-extra".to_owned(), serde_json::json!("extension"));
@@ -621,6 +631,7 @@ mod tests {
                                 map.insert("baz".to_owned(), serde_json::json!(42));
                                 map
                             }),
+                            x_summary: None,
                             extensions: Some({
                                 let mut map = BTreeMap::new();
                                 map.insert("x-extra".to_owned(), serde_json::json!("extension"));
@@ -726,6 +737,7 @@ mod tests {
                 map.insert("baz".to_owned(), serde_json::json!(42));
                 map
             }),
+            x_summary: None,
             extensions: Some({
                 let mut map = BTreeMap::new();
                 map.insert("x-extra".to_owned(), serde_json::json!("extension"));
@@ -758,5 +770,16 @@ mod tests {
         );
         Response::default().validate_with_context(&mut ctx, "response".to_owned());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn x_summary_round_trip() {
+        let value = serde_json::json!({
+            "description": "A simple response",
+            "x-summary": "Created"
+        });
+        let response = serde_json::from_value::<Response>(value.clone()).unwrap();
+        assert_eq!(response.x_summary, Some("Created".to_owned()));
+        assert_eq!(serde_json::to_value(response).unwrap(), value);
     }
 }

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -1,8 +1,8 @@
 //! Response Object
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
-use crate::common::reference::RefOr;
 use crate::v2::header::Header;
+use crate::v2::reference::RefOr;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
 use crate::validation::Options;
@@ -173,6 +173,16 @@ impl ValidateWithContext<Spec> for Response {
 
 impl ValidateWithContext<Spec> for Responses {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // Per OAS v2: a Responses Object MUST contain at least one response code
+        // (`default` counts as a catch-all and is sufficient on its own).
+        let has_status = self.responses.as_ref().is_some_and(|r| !r.is_empty());
+        if self.default.is_none() && !has_status {
+            ctx.error(
+                path.clone(),
+                "must declare at least one response (a status code or `default`)",
+            );
+        }
+
         if let Some(response) = &self.default {
             response.validate_with_context(ctx, format!("{path}.default"));
         }
@@ -199,8 +209,8 @@ impl ValidateWithContext<Spec> for Responses {
 mod tests {
     use super::*;
     use crate::common::helpers::Context;
-    use crate::common::reference::RefOr;
     use crate::v2::header::{IntegerHeader, StringHeader};
+    use crate::v2::reference::RefOr;
     use crate::validation::Options;
     use std::collections::BTreeMap;
 

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -2,9 +2,9 @@
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
-use crate::common::reference::RefOr;
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
 use crate::v2::external_documentation::ExternalDocumentation;
+use crate::v2::reference::RefOr;
 use crate::v2::spec::Spec;
 use crate::v2::xml::XML;
 use monostate::MustBe;
@@ -30,11 +30,21 @@ pub enum Schema {
     #[serde(rename = "array")]
     Array(Box<ArraySchema>),
 
+    /// `null` type — extra (not in OAS 2.0 / draft-04). Intentionally retained
+    /// as a permissive deviation from the v2 spec.
     #[serde(rename = "null")]
     Null(Box<NullSchema>),
 
     #[serde(rename = "object")]
-    Object(Box<ObjectSchema>), // must be last
+    Object(Box<ObjectSchema>),
+
+    /// A schema composed of `allOf` other schemas (no parent `type` field).
+    /// Per JSON Schema draft-04, `allOf` may appear on any schema; this variant
+    /// is the top-level form (parallel to v3.0/v3.1's design). The inner
+    /// `ObjectSchema` also keeps its own `all_of` for backward compatibility,
+    /// so an `{"allOf": [...], "type": "object"}` input still deserializes as
+    /// `Object`. // must be last — typed variants take precedence.
+    AllOf(Box<AllOfSchema>),
 }
 
 impl Default for Schema {
@@ -85,6 +95,53 @@ impl From<ObjectSchema> for Schema {
     }
 }
 
+impl From<AllOfSchema> for Schema {
+    fn from(s: AllOfSchema) -> Self {
+        Schema::AllOf(Box::new(s))
+    }
+}
+
+/// A schema composed of `allOf` other schemas.
+/// Per JSON Schema draft-04, `allOf` may appear on any schema; this is the
+/// top-level form.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct AllOfSchema {
+    /// **Required** The list of schemas that this schema is composed of.
+    #[serde(rename = "allOf")]
+    pub all_of: Vec<RefOr<Schema>>,
+
+    /// A title to explain the purpose of the schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    /// A short description of the attribute.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Additional external documentation for this schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "externalDocs")]
+    pub external_docs: Option<ExternalDocumentation>,
+
+    /// Adds support for polymorphism. The discriminator is the schema property
+    /// name that is used to differentiate between other schemas which may
+    /// satisfy the payload description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<String>,
+
+    /// A free-form property to include an example of an instance for this schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<serde_json::Value>,
+
+    /// Allows extensions to the Swagger Schema.
+    /// The field name MUST begin with `x-`, for example, `x-internal-id`.
+    /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
 impl Display for Schema {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -95,6 +152,7 @@ impl Display for Schema {
             Schema::Array(_) => write!(f, "array"),
             Schema::Object(_) => write!(f, "object"),
             Schema::Null(_) => write!(f, "null"),
+            Schema::AllOf(_) => write!(f, "allOf"),
         }
     }
 }
@@ -206,7 +264,7 @@ pub struct IntegerSchema {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<i64>,
+    pub minimum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly greater than the value of `minimum`
     #[serde(rename = "exclusiveMinimum")]
@@ -215,7 +273,7 @@ pub struct IntegerSchema {
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<i64>,
+    pub maximum: Option<serde_json::Number>,
 
     /// Declares that the value of the parameter is strictly less than the value of `maximum`
     #[serde(rename = "exclusiveMaximum")]
@@ -490,9 +548,10 @@ pub struct ObjectSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<BTreeMap<String, RefOr<Schema>>>,
 
-    /// Declares the values of the header that the server will use if none is provided.
+    /// Declares the default value of the schema. For an object schema, this is
+    /// typically a JSON object that conforms to the property definitions.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<Vec<serde_json::Value>>,
+    pub default: Option<serde_json::Value>,
 
     /// Declares the maximum number of items that are allowed in the array.
     #[serde(rename = "maxProperties")]
@@ -623,6 +682,21 @@ impl ValidateWithContext<Spec> for Schema {
             Schema::Array(s) => s.validate_with_context(ctx, path),
             Schema::Object(s) => s.validate_with_context(ctx, path),
             Schema::Null(s) => s.validate_with_context(ctx, path),
+            Schema::AllOf(s) => s.validate_with_context(ctx, path),
+        }
+    }
+}
+
+impl ValidateWithContext<Spec> for AllOfSchema {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        if self.all_of.is_empty() {
+            ctx.error(path.clone(), ".allOf: must not be empty");
+        }
+        for (i, schema) in self.all_of.iter().enumerate() {
+            schema.validate_with_context(ctx, format!("{path}.allOf[{i}]"));
+        }
+        if let Some(docs) = &self.external_docs {
+            docs.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
     }
 }
@@ -837,6 +911,228 @@ mod tests {
                 },
             }),
         );
+    }
+
+    #[test]
+    fn integer_number_boolean_array_null_serde_roundtrip() {
+        // Integer
+        let raw = serde_json::json!({"type": "integer", "format": "int32"});
+        let s: Schema = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(s, Schema::Integer(_)));
+        assert_eq!(serde_json::to_value(&s).unwrap(), raw);
+
+        // Number
+        let raw = serde_json::json!({"type": "number", "format": "double"});
+        let s: Schema = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(s, Schema::Number(_)));
+        assert_eq!(serde_json::to_value(&s).unwrap(), raw);
+
+        // Boolean
+        let raw = serde_json::json!({"type": "boolean"});
+        let s: Schema = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(s, Schema::Boolean(_)));
+        assert_eq!(serde_json::to_value(&s).unwrap(), raw);
+
+        // Array
+        let raw = serde_json::json!({
+            "type": "array",
+            "items": {"type": "string"}
+        });
+        let s: Schema = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(s, Schema::Array(_)));
+        assert_eq!(serde_json::to_value(&s).unwrap(), raw);
+
+        // Null
+        let raw = serde_json::json!({"type": "null"});
+        let s: Schema = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(s, Schema::Null(_)));
+        assert_eq!(serde_json::to_value(&s).unwrap(), raw);
+    }
+
+    #[test]
+    fn schema_validate_each_variant() {
+        let spec = Spec::default();
+
+        // String w/ bad pattern
+        let s = Schema::String(Box::new(StringSchema {
+            pattern: Some("[".into()),
+            ..Default::default()
+        }));
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("pattern")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // External docs validation paths
+        let ed = crate::v2::external_documentation::ExternalDocumentation {
+            url: "not-a-url".into(),
+            ..Default::default()
+        };
+        let s = Schema::Integer(Box::new(IntegerSchema {
+            external_docs: Some(ed.clone()),
+            ..Default::default()
+        }));
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Number, Boolean, Array, Null with externalDocs.
+        for s in [
+            Schema::Number(Box::new(NumberSchema {
+                external_docs: Some(ed.clone()),
+                ..Default::default()
+            })),
+            Schema::Boolean(Box::new(BooleanSchema {
+                external_docs: Some(ed.clone()),
+                ..Default::default()
+            })),
+            Schema::Array(Box::new(ArraySchema {
+                external_docs: Some(ed.clone()),
+                items: Some(RefOr::new_item(Schema::from(StringSchema::default()))),
+                ..Default::default()
+            })),
+            Schema::Null(Box::new(NullSchema {
+                external_docs: Some(ed.clone()),
+                ..Default::default()
+            })),
+        ] {
+            let mut ctx = Context::new(&spec, crate::validation::Options::new());
+            s.validate_with_context(&mut ctx, "p".into());
+            assert!(
+                ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+                "errors: {:?}",
+                ctx.errors
+            );
+        }
+
+        // Object with properties + additionalProperties + allOf
+        let s = Schema::Object(Box::new(ObjectSchema {
+            properties: Some({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "k".into(),
+                    RefOr::new_item(Schema::from(StringSchema {
+                        pattern: Some("[".into()),
+                        ..Default::default()
+                    })),
+                );
+                m
+            }),
+            additional_properties: Some(crate::common::bool_or::BoolOr::Item(RefOr::new_item(
+                Schema::from(StringSchema {
+                    pattern: Some("[".into()),
+                    ..Default::default()
+                }),
+            ))),
+            all_of: Some(vec![RefOr::new_item(ObjectSchema {
+                external_docs: Some(ed.clone()),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }));
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        // Should accumulate errors from each branch
+        assert!(ctx.errors.len() >= 2, "errors: {:?}", ctx.errors);
+
+        // additionalProperties = bool, no schema validation needed
+        let s = Schema::Object(Box::new(ObjectSchema {
+            additional_properties: Some(crate::common::bool_or::BoolOr::Bool(true)),
+            ..Default::default()
+        }));
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn allof_schema_from_and_validate() {
+        let s = Schema::from(AllOfSchema {
+            all_of: vec![RefOr::new_item(Schema::from(StringSchema::default()))],
+            title: Some("t".into()),
+            ..Default::default()
+        });
+        assert!(matches!(s, Schema::AllOf(_)));
+        // Display
+        assert_eq!(format!("{s}"), "allOf");
+
+        // Empty allOf produces an error
+        let s = Schema::AllOf(Box::new(AllOfSchema::default()));
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".allOf: must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Non-empty allOf with externalDocs validation propagates
+        let ed = crate::v2::external_documentation::ExternalDocumentation {
+            url: "not-a-url".into(),
+            ..Default::default()
+        };
+        let s = Schema::AllOf(Box::new(AllOfSchema {
+            all_of: vec![RefOr::new_item(Schema::from(StringSchema::default()))],
+            external_docs: Some(ed),
+            ..Default::default()
+        }));
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn allof_schema_serde_roundtrip() {
+        let raw = serde_json::json!({
+            "allOf": [{"type": "string"}],
+            "title": "T",
+        });
+        let s: AllOfSchema = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(s.title, Some("T".into()));
+        assert_eq!(s.all_of.len(), 1);
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(v, raw);
+    }
+
+    #[test]
+    fn schema_display_formats() {
+        assert_eq!(format!("{}", Schema::String(Box::default())), "string");
+        assert_eq!(format!("{}", Schema::Integer(Box::default())), "integer");
+        assert_eq!(format!("{}", Schema::Number(Box::default())), "number");
+        assert_eq!(format!("{}", Schema::Boolean(Box::default())), "boolean");
+        assert_eq!(
+            format!("{}", Schema::Array(Box::new(ArraySchema::default()))),
+            "array"
+        );
+        assert_eq!(format!("{}", Schema::Object(Box::default())), "object");
+        assert_eq!(format!("{}", Schema::Null(Box::default())), "null");
+    }
+
+    #[test]
+    fn schema_from_helpers() {
+        // Exercise each From impl.
+        let _: Schema = StringSchema::default().into();
+        let _: Schema = IntegerSchema::default().into();
+        let _: Schema = NumberSchema::default().into();
+        let _: Schema = BooleanSchema::default().into();
+        let _: Schema = ArraySchema::default().into();
+        let _: Schema = NullSchema::default().into();
+        let _: Schema = ObjectSchema::default().into();
+        let _: Schema = AllOfSchema::default().into();
     }
 
     #[test]

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -1149,10 +1149,7 @@ mod tests {
         assert_eq!(format!("{}", Schema::Integer(Box::default())), "integer");
         assert_eq!(format!("{}", Schema::Number(Box::default())), "number");
         assert_eq!(format!("{}", Schema::Boolean(Box::default())), "boolean");
-        assert_eq!(
-            format!("{}", Schema::Array(Box::default())),
-            "array"
-        );
+        assert_eq!(format!("{}", Schema::Array(Box::default())), "array");
         assert_eq!(format!("{}", Schema::Object(Box::default())), "object");
         assert_eq!(format!("{}", Schema::Null(Box::default())), "null");
     }

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -133,6 +133,11 @@ pub struct AllOfSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::Value>,
 
+    /// ReDoc extension that marks this schema as nullable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-nullable")]
+    pub x_nullable: Option<bool>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -225,6 +230,11 @@ pub struct StringSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::Value>,
 
+    /// ReDoc extension that marks this schema as nullable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-nullable")]
+    pub x_nullable: Option<bool>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -310,6 +320,11 @@ pub struct IntegerSchema {
     /// A free-form property to include an example of an instance for this schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::Value>,
+
+    /// ReDoc extension that marks this schema as nullable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-nullable")]
+    pub x_nullable: Option<bool>,
 
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
@@ -397,6 +412,11 @@ pub struct NumberSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::Value>,
 
+    /// ReDoc extension that marks this schema as nullable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-nullable")]
+    pub x_nullable: Option<bool>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -450,6 +470,11 @@ pub struct BooleanSchema {
     /// A free-form property to include an example of an instance for this schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::Value>,
+
+    /// ReDoc extension that marks this schema as nullable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-nullable")]
+    pub x_nullable: Option<bool>,
 
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
@@ -521,6 +546,11 @@ pub struct ArraySchema {
     /// A free-form property to include an example of an instance for this schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::Value>,
+
+    /// ReDoc extension that marks this schema as nullable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-nullable")]
+    pub x_nullable: Option<bool>,
 
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
@@ -608,6 +638,11 @@ pub struct ObjectSchema {
     /// A free-form property to include an example of an instance for this schema.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub example: Option<serde_json::Value>,
+
+    /// ReDoc extension that marks this schema as nullable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-nullable")]
+    pub x_nullable: Option<bool>,
 
     /// Takes an array of object definitions that are validated independently
     /// but together compose a single object
@@ -1064,7 +1099,7 @@ mod tests {
         assert_eq!(format!("{s}"), "allOf");
 
         // Empty allOf produces an error
-        let s = Schema::AllOf(Box::new(AllOfSchema::default()));
+        let s = Schema::AllOf(Box::default());
         let spec = Spec::default();
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         s.validate_with_context(&mut ctx, "p".into());
@@ -1115,7 +1150,7 @@ mod tests {
         assert_eq!(format!("{}", Schema::Number(Box::default())), "number");
         assert_eq!(format!("{}", Schema::Boolean(Box::default())), "boolean");
         assert_eq!(
-            format!("{}", Schema::Array(Box::new(ArraySchema::default()))),
+            format!("{}", Schema::Array(Box::default())),
             "array"
         );
         assert_eq!(format!("{}", Schema::Object(Box::default())), "object");
@@ -1162,5 +1197,30 @@ mod tests {
                 ],
             }),
         );
+    }
+
+    #[test]
+    fn x_nullable_round_trip() {
+        let value = serde_json::json!({
+            "type": "string",
+            "x-nullable": true
+        });
+        let schema = serde_json::from_value::<Schema>(value.clone()).unwrap();
+        match &schema {
+            Schema::String(schema) => assert_eq!(schema.x_nullable, Some(true)),
+            _ => panic!("expected string schema"),
+        }
+        assert_eq!(serde_json::to_value(schema).unwrap(), value);
+
+        let value = serde_json::json!({
+            "type": "object",
+            "x-nullable": true
+        });
+        let schema = serde_json::from_value::<Schema>(value.clone()).unwrap();
+        match &schema {
+            Schema::Object(schema) => assert_eq!(schema.x_nullable, Some(true)),
+            _ => panic!("expected object schema"),
+        }
+        assert_eq!(serde_json::to_value(schema).unwrap(), value);
     }
 }

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -194,7 +194,15 @@ impl Serialize for Scopes {
     where
         S: Serializer,
     {
-        let total = self.scopes.len() + self.extensions.as_ref().map(|e| e.len()).unwrap_or(0);
+        // Only `x-` keys are emitted from `extensions`, so the size hint must
+        // count only those — a programmatically constructed map could carry
+        // non-`x-` entries that would otherwise overstate the count.
+        let ext_x_count = self
+            .extensions
+            .as_ref()
+            .map(|e| e.keys().filter(|k| k.starts_with("x-")).count())
+            .unwrap_or(0);
+        let total = self.scopes.len() + ext_x_count;
         let mut map = serializer.serialize_map(Some(total))?;
         for (k, v) in &self.scopes {
             map.serialize_entry(k, v)?;

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -1,11 +1,14 @@
 //! Security Scheme Object
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_optional_url, validate_required_string,
+    Context, PushError, ValidateWithContext, validate_required_string, validate_required_url,
 };
 use crate::v2::spec::Spec;
-use serde::{Deserialize, Serialize};
+use serde::de::{Error as DeError, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fmt::{Display, Formatter};
 
 /// Allows the definition of a security scheme that can be used by the operations.
@@ -66,11 +69,19 @@ pub struct BasicSecurityScheme {
     /// A short description for security scheme.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Allows extensions to the Swagger Schema.
+    /// The field name MUST begin with `x-`, for example, `x-internal-id`.
+    /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ApiKeySecurityScheme {
-    /// **Required** A short description for security scheme.
+    /// **Required** The name of the header or query parameter to be used.
     pub name: String,
 
     /// **Required** The location of the API key.
@@ -80,6 +91,14 @@ pub struct ApiKeySecurityScheme {
     /// A short description for security scheme.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Allows extensions to the Swagger Schema.
+    /// The field name MUST begin with `x-`, for example, `x-internal-id`.
+    /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 /// The location of the API key.
@@ -104,28 +123,133 @@ impl Display for SecuritySchemeApiKeyLocation {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct OAuth2SecurityScheme {
     /// **Required** The flow used by the OAuth2 security scheme.
-    flow: SecuritySchemeOAuth2Flow,
+    pub flow: SecuritySchemeOAuth2Flow,
 
     /// The authorization URL to be used for this flow.
     /// Required for `implicit` and `accessCode` flows.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "authorizationUrl")]
-    authorization_url: Option<String>,
+    pub authorization_url: Option<String>,
 
     /// The token URL to be used for this flow.
     /// Required for `password`, `application` and `accessCode` flows.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "tokenUrl")]
-    token_url: Option<String>,
+    pub token_url: Option<String>,
 
     /// **Required** The available scopes for the OAuth2 security scheme.
-    ///
-    /// The extensions support is dropped for simplicity.
-    scopes: BTreeMap<String, String>,
+    pub scopes: Scopes,
 
     /// A short description for security scheme.
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    pub description: Option<String>,
+
+    /// Allows extensions to the Swagger Schema.
+    /// The field name MUST begin with `x-`, for example, `x-internal-id`.
+    /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// Lists the available scopes for an OAuth2 security scheme.
+/// Extra keys starting with `x-` are stored as Specification Extensions, the
+/// rest map a scope name to a short description.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Scopes {
+    pub scopes: BTreeMap<String, String>,
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Scopes {
+    pub fn is_empty(&self) -> bool {
+        self.scopes.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.scopes.len()
+    }
+}
+
+impl<S, K, V> From<S> for Scopes
+where
+    S: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    fn from(iter: S) -> Self {
+        Scopes {
+            scopes: iter
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+            extensions: None,
+        }
+    }
+}
+
+impl Serialize for Scopes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let total = self.scopes.len() + self.extensions.as_ref().map(|e| e.len()).unwrap_or(0);
+        let mut map = serializer.serialize_map(Some(total))?;
+        for (k, v) in &self.scopes {
+            map.serialize_entry(k, v)?;
+        }
+        if let Some(ext) = &self.extensions {
+            for (k, v) in ext {
+                if k.starts_with("x-") {
+                    map.serialize_entry(k, v)?;
+                }
+            }
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Scopes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ScopesVisitor;
+        impl<'de> Visitor<'de> for ScopesVisitor {
+            type Value = Scopes;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a Scopes object")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Scopes, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut scopes: BTreeMap<String, String> = BTreeMap::new();
+                let mut ext: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if key.starts_with("x-") {
+                        if ext.contains_key(&key) {
+                            return Err(DeError::custom(format_args!("duplicate field `{key}`")));
+                        }
+                        ext.insert(key, map.next_value()?);
+                    } else {
+                        if scopes.contains_key(&key) {
+                            return Err(DeError::custom(format_args!("duplicate field `{key}`")));
+                        }
+                        scopes.insert(key, map.next_value()?);
+                    }
+                }
+                Ok(Scopes {
+                    scopes,
+                    extensions: if ext.is_empty() { None } else { Some(ext) },
+                })
+            }
+        }
+        deserializer.deserialize_map(ScopesVisitor)
+    }
 }
 
 /// The flow used by the OAuth2 security scheme.
@@ -178,23 +302,42 @@ impl ValidateWithContext<Spec> for OAuth2SecurityScheme {
         if self.scopes.is_empty() {
             ctx.error(path.clone(), ".scopes: must not be empty");
         }
-        if self.authorization_url.is_none()
-            && (self.flow == SecuritySchemeOAuth2Flow::Implicit
-                || self.flow == SecuritySchemeOAuth2Flow::AccessCode)
-        {
-            ctx.error(
-                path,
+
+        // authorizationUrl required for `implicit` and `accessCode` flows.
+        let auth_required = matches!(
+            self.flow,
+            SecuritySchemeOAuth2Flow::Implicit | SecuritySchemeOAuth2Flow::AccessCode
+        );
+        match (&self.authorization_url, auth_required) {
+            (None, true) => ctx.error(
+                path.clone(),
                 format_args!(
                     ".authorizationUrl: must be present for flow `{}`",
                     self.flow,
                 ),
-            );
-        } else {
-            validate_optional_url(
-                &self.authorization_url,
-                ctx,
-                format!("{path}.authorizationUrl"),
-            );
+            ),
+            (Some(url), _) => {
+                validate_required_url(url, ctx, format!("{path}.authorizationUrl"));
+            }
+            (None, false) => {}
+        }
+
+        // tokenUrl required for `password`, `application` and `accessCode` flows.
+        let token_required = matches!(
+            self.flow,
+            SecuritySchemeOAuth2Flow::Password
+                | SecuritySchemeOAuth2Flow::Application
+                | SecuritySchemeOAuth2Flow::AccessCode
+        );
+        match (&self.token_url, token_required) {
+            (None, true) => ctx.error(
+                path,
+                format_args!(".tokenUrl: must be present for flow `{}`", self.flow),
+            ),
+            (Some(url), _) => {
+                validate_required_url(url, ctx, format!("{path}.tokenUrl"));
+            }
+            (None, false) => {}
         }
     }
 }
@@ -214,6 +357,7 @@ mod tests {
             .unwrap(),
             SecurityScheme::Basic(BasicSecurityScheme {
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }),
             "deserialize",
         );
@@ -224,6 +368,7 @@ mod tests {
         assert_eq!(
             serde_json::to_value(SecurityScheme::Basic(BasicSecurityScheme {
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }))
             .unwrap(),
             json!({
@@ -248,6 +393,7 @@ mod tests {
                 name: String::from("api_key"),
                 location: SecuritySchemeApiKeyLocation::Header,
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }),
             "deserialize in = header",
         );
@@ -263,6 +409,7 @@ mod tests {
                 name: String::from("api_key"),
                 location: SecuritySchemeApiKeyLocation::Query,
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }),
             "deserialize in = query",
         );
@@ -275,6 +422,7 @@ mod tests {
                 name: String::from("api_key"),
                 location: SecuritySchemeApiKeyLocation::Header,
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }))
             .unwrap(),
             json!({
@@ -290,6 +438,7 @@ mod tests {
                 name: String::from("api_key"),
                 location: SecuritySchemeApiKeyLocation::Query,
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }))
             .unwrap(),
             json!({
@@ -320,7 +469,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::Implicit,
                 authorization_url: Some(String::from("https://example.com/api/oauth/dialog")),
                 token_url: None,
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -328,6 +477,7 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }),
             "deserialize flow = implicit",
         );
@@ -347,7 +497,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::AccessCode,
                 authorization_url: Some(String::from("https://example.com/api/oauth/dialog")),
                 token_url: None,
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -355,6 +505,7 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }),
             "deserialize flow = accessCode",
         );
@@ -374,7 +525,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::Password,
                 authorization_url: None,
                 token_url: Some(String::from("https://example.com/api/oauth/dialog")),
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -382,6 +533,7 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }),
             "deserialize flow = password",
         );
@@ -401,7 +553,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::Application,
                 authorization_url: None,
                 token_url: Some(String::from("https://example.com/api/oauth/dialog")),
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -409,9 +561,235 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }),
             "deserialize flow = application",
         );
+    }
+
+    #[test]
+    fn oauth2_validate_empty_scopes_and_url_branches() {
+        use crate::common::helpers::Context;
+        use crate::validation::Options;
+        let spec = Spec::default();
+
+        // Empty scopes + missing tokenUrl on `password` flow.
+        let s = OAuth2SecurityScheme {
+            flow: SecuritySchemeOAuth2Flow::Password,
+            authorization_url: None,
+            token_url: None,
+            scopes: Scopes::default(),
+            description: None,
+            extensions: None,
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".scopes: must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".tokenUrl: must be present for flow `password`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Missing authorizationUrl on `implicit` flow.
+        let s = OAuth2SecurityScheme {
+            flow: SecuritySchemeOAuth2Flow::Implicit,
+            authorization_url: None,
+            token_url: None,
+            scopes: Scopes::from([("a".to_owned(), "b".to_owned())]),
+            description: None,
+            extensions: None,
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".authorizationUrl: must be present for flow `implicit`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // accessCode flow needs both URLs.
+        let s = OAuth2SecurityScheme {
+            flow: SecuritySchemeOAuth2Flow::AccessCode,
+            authorization_url: None,
+            token_url: None,
+            scopes: Scopes::from([("a".to_owned(), "b".to_owned())]),
+            description: None,
+            extensions: None,
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must be present for flow `accessCode`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Invalid URL format on tokenUrl/authorizationUrl.
+        let s = OAuth2SecurityScheme {
+            flow: SecuritySchemeOAuth2Flow::AccessCode,
+            authorization_url: Some("ftp://x".into()),
+            token_url: Some("ftp://y".into()),
+            scopes: Scopes::from([("a".to_owned(), "b".to_owned())]),
+            description: None,
+            extensions: None,
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // application flow only needs tokenUrl
+        let s = OAuth2SecurityScheme {
+            flow: SecuritySchemeOAuth2Flow::Application,
+            authorization_url: None,
+            token_url: None,
+            scopes: Scopes::from([("a".to_owned(), "b".to_owned())]),
+            description: None,
+            extensions: None,
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must be present for flow `application`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Successful path: implicit with valid URL and one scope.
+        let s = OAuth2SecurityScheme {
+            flow: SecuritySchemeOAuth2Flow::Implicit,
+            authorization_url: Some("https://example.com/auth".into()),
+            token_url: None,
+            scopes: Scopes::from([("a".to_owned(), "b".to_owned())]),
+            description: None,
+            extensions: None,
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn scopes_serde_roundtrip_with_extensions() {
+        let raw = json!({
+            "read": "Read",
+            "write": "Write",
+            "x-extra": "ext-value",
+        });
+        let s: Scopes = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(s.scopes.len(), 2);
+        assert!(s.extensions.is_some());
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(v, raw);
+    }
+
+    #[test]
+    fn scopes_only_extensions() {
+        let raw = json!({"x-foo": "bar"});
+        let s: Scopes = serde_json::from_value(raw.clone()).unwrap();
+        assert!(s.scopes.is_empty());
+        assert!(s.extensions.is_some());
+        assert_eq!(serde_json::to_value(&s).unwrap(), raw);
+    }
+
+    #[test]
+    fn scopes_duplicate_key_error() {
+        // duplicate scope key
+        let err = serde_json::from_str::<Scopes>(r#"{"a": "x", "a": "y"}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate field `a`"),
+            "err: {err}"
+        );
+
+        // duplicate extension key
+        let err = serde_json::from_str::<Scopes>(r#"{"x-a": "x", "x-a": "y"}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate field `x-a`"),
+            "err: {err}"
+        );
+    }
+
+    #[test]
+    fn scopes_helpers() {
+        let s = Scopes::default();
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+
+        let s = Scopes::from([("a".to_owned(), "b".to_owned())]);
+        assert!(!s.is_empty());
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn security_scheme_display() {
+        assert_eq!(
+            format!("{}", SecurityScheme::Basic(BasicSecurityScheme::default())),
+            "basic"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                SecurityScheme::ApiKey(ApiKeySecurityScheme {
+                    name: "x".into(),
+                    location: SecuritySchemeApiKeyLocation::Header,
+                    ..Default::default()
+                })
+            ),
+            "apiKey"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                SecurityScheme::OAuth2(OAuth2SecurityScheme::default())
+            ),
+            "oauth2"
+        );
+        assert_eq!(
+            format!("{}", SecuritySchemeApiKeyLocation::Header),
+            "header"
+        );
+        assert_eq!(format!("{}", SecuritySchemeApiKeyLocation::Query), "query");
+        for (f, expected) in [
+            (SecuritySchemeOAuth2Flow::Implicit, "implicit"),
+            (SecuritySchemeOAuth2Flow::Password, "password"),
+            (SecuritySchemeOAuth2Flow::Application, "application"),
+            (SecuritySchemeOAuth2Flow::AccessCode, "accessCode"),
+        ] {
+            assert_eq!(format!("{f}"), expected);
+        }
+    }
+
+    #[test]
+    fn apikey_validate_required_name() {
+        use crate::common::helpers::Context;
+        use crate::validation::Options;
+        let spec = Spec::default();
+        let s = ApiKeySecurityScheme {
+            name: "".into(),
+            location: SecuritySchemeApiKeyLocation::Header,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        s.validate_with_context(&mut ctx, "p".into());
+        assert!(ctx.errors.iter().any(|e| e.contains("must not be empty")));
     }
 
     #[test]
@@ -421,7 +799,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::Implicit,
                 authorization_url: Some(String::from("https://example.com/api/oauth/dialog")),
                 token_url: None,
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -429,6 +807,7 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }))
             .unwrap(),
             json!({
@@ -448,7 +827,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::AccessCode,
                 authorization_url: Some(String::from("https://example.com/api/oauth/dialog")),
                 token_url: None,
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -456,6 +835,7 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }))
             .unwrap(),
             json!({
@@ -475,7 +855,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::Password,
                 authorization_url: None,
                 token_url: Some(String::from("https://example.com/api/oauth/dialog")),
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -483,6 +863,7 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }))
             .unwrap(),
             json!({
@@ -502,7 +883,7 @@ mod tests {
                 flow: SecuritySchemeOAuth2Flow::Application,
                 authorization_url: None,
                 token_url: Some(String::from("https://example.com/api/oauth/dialog")),
-                scopes: BTreeMap::from_iter(vec![
+                scopes: Scopes::from([
                     (
                         String::from("write:pets"),
                         String::from("modify pets in your account"),
@@ -510,6 +891,7 @@ mod tests {
                     (String::from("read:pets"), String::from("read your pets"),),
                 ]),
                 description: Some(String::from("A short description for security scheme.")),
+                extensions: None,
             }))
             .unwrap(),
             json!({

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -4,11 +4,12 @@ use crate::common::helpers::{
     Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
     validate_not_visited, validate_optional_string_matches,
 };
-use crate::common::reference::{RefOr, ResolveReference};
+use crate::common::reference::ResolveReference;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::info::Info;
 use crate::v2::parameter::Parameter;
-use crate::v2::path_item::PathItem;
+use crate::v2::path_item::Paths;
+use crate::v2::reference::RefOr;
 use crate::v2::response::Response;
 use crate::v2::schema::{ObjectSchema, Schema};
 use crate::v2::security_scheme::SecurityScheme;
@@ -124,8 +125,8 @@ pub struct Spec {
     /// The path is appended to the basePath in order to construct the full URL.
     /// [Path templating](https://swagger.io/specification/v2/#path-templating) is allowed.
     ///
-    /// The extensions support is dropped for simplicity.
-    pub paths: BTreeMap<String, PathItem>,
+    /// Supports `^x-` Specification Extensions on the Paths Object itself.
+    pub paths: Paths,
 
     /// An object to hold data types produced and consumed by operations.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -361,14 +362,25 @@ impl Validate for Spec {
             );
         }
 
-        // validate paths operations
+        // Validate paths operations and the new path-template / parameter rules.
         for (name, item) in self.paths.iter() {
             let path = format!("#.paths[{name}]");
             if !name.starts_with('/') {
                 ctx.error(path.clone(), "must start with `/`");
             }
-            item.validate_with_context(&mut ctx, path);
+            item.validate_with_context(&mut ctx, path.clone());
+            crate::v2::validation::validate_path_item(&mut ctx, name, &path, item);
         }
+
+        // Validate Spec-level security requirements against security_definitions.
+        if let Some(security) = &self.security {
+            crate::v2::validation::validate_security_requirements(&mut ctx, "#.security", security);
+        }
+
+        // Walk security_definitions: each scheme runs its own validator so
+        // missing required URLs etc. are reported even when no requirement
+        // references the scheme.
+        crate::v2::validation::validate_security_definitions(&mut ctx);
 
         if let Some(docs) = &self.external_docs {
             docs.validate_with_context(&mut ctx, "#.externalDocs".to_owned())
@@ -623,6 +635,546 @@ mod tests {
             .to_string(),
             r#"unknown variant `foo`, expected one of `http`, `https`, `ws`, `wss`"#,
             "foo string as scheme",
+        );
+    }
+
+    use crate::v2::operation::Operation;
+    use crate::v2::parameter::{InQuery, Parameter, StringParameter};
+    use crate::v2::path_item::PathItem;
+    use crate::v2::response::{Response, Responses};
+    use crate::v2::schema::{ObjectSchema, Schema, StringSchema};
+    use crate::v2::security_scheme::{
+        BasicSecurityScheme, OAuth2SecurityScheme, Scopes, SecurityScheme, SecuritySchemeOAuth2Flow,
+    };
+
+    fn happy_op() -> Operation {
+        Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn version_and_scheme_display() {
+        assert_eq!(format!("{}", Version::V2_0), "2.0");
+        for (s, expected) in [
+            (Scheme::HTTP, "http"),
+            (Scheme::HTTPS, "https"),
+            (Scheme::WS, "ws"),
+            (Scheme::WSS, "wss"),
+        ] {
+            assert_eq!(format!("{s}"), expected);
+        }
+    }
+
+    #[test]
+    fn happy_path_validate_no_errors() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".into(), happy_op());
+        let mut paths = BTreeMap::new();
+        paths.insert(
+            "/users".to_owned(),
+            PathItem {
+                operations: Some(ops),
+                ..Default::default()
+            },
+        );
+        spec.paths = crate::v2::path_item::Paths {
+            paths,
+            extensions: None,
+        };
+        let res = spec.validate(Options::new());
+        assert!(res.is_ok(), "errors: {:?}", res);
+    }
+
+    #[test]
+    fn validate_path_must_start_with_slash() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut paths = BTreeMap::new();
+        paths.insert(
+            "no-slash".to_owned(),
+            PathItem {
+                operations: Some({
+                    let mut m = BTreeMap::new();
+                    m.insert("get".to_owned(), happy_op());
+                    m
+                }),
+                ..Default::default()
+            },
+        );
+        spec.paths = crate::v2::path_item::Paths {
+            paths,
+            extensions: None,
+        };
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors.iter().any(|e| e.contains("must start with `/`")),
+            "errors: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn validate_base_path_must_start_with_slash() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        spec.base_path = Some("api".into());
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("basePath") && e.contains("must start with `/`")),
+            "errors: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn validate_security_with_definitions() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "basicAuth".to_owned(),
+            SecurityScheme::Basic(BasicSecurityScheme::default()),
+        );
+        spec.security_definitions = Some(defs);
+        let mut req = BTreeMap::new();
+        req.insert("basicAuth".to_owned(), vec![]);
+        spec.security = Some(vec![req]);
+        let res = spec.validate(Options::new());
+        assert!(res.is_ok(), "errors: {:?}", res);
+    }
+
+    #[test]
+    fn validate_undefined_security_scheme() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut req = BTreeMap::new();
+        req.insert("foo".to_owned(), vec![]);
+        spec.security = Some(vec![req]);
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("no securityDefinitions on the spec")),
+            "errors: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn validate_body_and_formdata_together_via_spec() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut op = happy_op();
+        op.parameters = Some(vec![
+            RefOr::new_item(Parameter::Body(Box::new(crate::v2::parameter::InBody {
+                name: "b".into(),
+                description: None,
+                required: None,
+                schema: RefOr::new_item(Schema::from(StringSchema::default())),
+                extensions: None,
+            }))),
+            RefOr::new_item(Parameter::FormData(Box::new(
+                crate::v2::parameter::InFormData::String(StringParameter {
+                    name: "f".into(),
+                    ..Default::default()
+                }),
+            ))),
+        ]);
+        let mut ops = BTreeMap::new();
+        ops.insert("post".into(), op);
+        let mut paths = BTreeMap::new();
+        paths.insert(
+            "/p".to_owned(),
+            PathItem {
+                operations: Some(ops),
+                ..Default::default()
+            },
+        );
+        spec.paths = crate::v2::path_item::Paths {
+            paths,
+            extensions: None,
+        };
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("`body` and `formData`")),
+            "errors: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn validate_duplicate_param_via_spec() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut op = happy_op();
+        op.parameters = Some(vec![
+            RefOr::new_item(Parameter::Query(Box::new(InQuery::String(
+                StringParameter {
+                    name: "q".into(),
+                    ..Default::default()
+                },
+            )))),
+            RefOr::new_item(Parameter::Query(Box::new(InQuery::String(
+                StringParameter {
+                    name: "q".into(),
+                    ..Default::default()
+                },
+            )))),
+        ]);
+        let mut ops = BTreeMap::new();
+        ops.insert("get".into(), op);
+        let mut paths = BTreeMap::new();
+        paths.insert(
+            "/p".to_owned(),
+            PathItem {
+                operations: Some(ops),
+                ..Default::default()
+            },
+        );
+        spec.paths = crate::v2::path_item::Paths {
+            paths,
+            extensions: None,
+        };
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors.iter().any(|e| e.contains("duplicate parameter")),
+            "errors: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn validate_missing_path_template_param_via_spec() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".into(), happy_op());
+        let mut paths = BTreeMap::new();
+        paths.insert(
+            "/users/{id}".to_owned(),
+            PathItem {
+                operations: Some(ops),
+                ..Default::default()
+            },
+        );
+        spec.paths = crate::v2::path_item::Paths {
+            paths,
+            extensions: None,
+        };
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("path template variable `{id}`")),
+            "errors: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn validate_empty_responses_via_spec() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert(
+            "get".into(),
+            Operation {
+                responses: Responses::default(),
+                ..Default::default()
+            },
+        );
+        let mut paths = BTreeMap::new();
+        paths.insert(
+            "/p".to_owned(),
+            PathItem {
+                operations: Some(ops),
+                ..Default::default()
+            },
+        );
+        spec.paths = crate::v2::path_item::Paths {
+            paths,
+            extensions: None,
+        };
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("must declare at least one response")),
+            "errors: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn define_schema_parameter_response_helpers() {
+        let mut spec = Spec::default();
+
+        let r = spec
+            .define_schema("Foo", Schema::from(StringSchema::default()))
+            .unwrap();
+        match r {
+            RefOr::Ref(rr) => assert_eq!(rr.reference, "#/definitions/Foo"),
+            _ => panic!(),
+        }
+        let p = Parameter::Query(Box::new(InQuery::String(StringParameter {
+            name: "p".into(),
+            ..Default::default()
+        })));
+        let r = spec.define_parameter("Bar", p).unwrap();
+        match r {
+            RefOr::Ref(rr) => assert_eq!(rr.reference, "#/parameters/Bar"),
+            _ => panic!(),
+        }
+        let r = spec
+            .define_response(
+                "Baz",
+                Response {
+                    description: "x".into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        match r {
+            RefOr::Ref(rr) => assert_eq!(rr.reference, "#/responses/Baz"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn define_helpers_invalid_component_name() {
+        let mut spec = Spec::default();
+        let err = spec
+            .define_schema("bad name", Schema::from(StringSchema::default()))
+            .unwrap_err();
+        assert_eq!(err.name, "bad name");
+        let err = spec
+            .define_parameter(
+                "bad name",
+                Parameter::Query(Box::new(InQuery::String(StringParameter::default()))),
+            )
+            .unwrap_err();
+        assert_eq!(err.name, "bad name");
+        let err = spec
+            .define_response(
+                "bad name",
+                Response {
+                    description: "x".into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert_eq!(err.name, "bad name");
+    }
+
+    #[test]
+    fn paths_with_x_extensions_serde() {
+        let raw = serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "t", "version": "1"},
+            "paths": {
+                "/p": {},
+                "x-extra": "v",
+            },
+        });
+        let spec: Spec = serde_json::from_value(raw.clone()).unwrap();
+        assert!(spec.paths.extensions.is_some());
+        let v = serde_json::to_value(&spec).unwrap();
+        // The shape may differ in field ordering, but we round-trip through a
+        // re-parse to confirm equivalence.
+        let spec2: Spec = serde_json::from_value(v).unwrap();
+        assert_eq!(spec, spec2);
+    }
+
+    #[test]
+    fn resolve_reference_schema_objectschema_parameter() {
+        let mut spec = Spec::default();
+        let _ = spec
+            .define_schema(
+                "Object",
+                Schema::from(ObjectSchema {
+                    title: Some("t".into()),
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+        let _ = spec
+            .define_schema("StringSchema", Schema::from(StringSchema::default()))
+            .unwrap();
+        let _ = spec
+            .define_parameter(
+                "P",
+                Parameter::Query(Box::new(InQuery::String(StringParameter {
+                    name: "n".into(),
+                    ..Default::default()
+                }))),
+            )
+            .unwrap();
+
+        // ResolveReference<Schema>
+        let s: Option<&Schema> =
+            <Spec as ResolveReference<Schema>>::resolve_reference(&spec, "#/definitions/Object");
+        assert!(s.is_some());
+        let s: Option<&Schema> =
+            <Spec as ResolveReference<Schema>>::resolve_reference(&spec, "#/definitions/Missing");
+        assert!(s.is_none());
+
+        // ResolveReference<ObjectSchema>
+        let s: Option<&ObjectSchema> = <Spec as ResolveReference<ObjectSchema>>::resolve_reference(
+            &spec,
+            "#/definitions/Object",
+        );
+        assert!(s.is_some());
+        // Hits a non-object definition: returns None.
+        let s: Option<&ObjectSchema> = <Spec as ResolveReference<ObjectSchema>>::resolve_reference(
+            &spec,
+            "#/definitions/StringSchema",
+        );
+        assert!(s.is_none());
+        let s: Option<&ObjectSchema> = <Spec as ResolveReference<ObjectSchema>>::resolve_reference(
+            &spec,
+            "#/definitions/Missing",
+        );
+        assert!(s.is_none());
+
+        // ResolveReference<Parameter>
+        let p: Option<&Parameter> =
+            <Spec as ResolveReference<Parameter>>::resolve_reference(&spec, "#/parameters/P");
+        assert!(p.is_some());
+        let p: Option<&Parameter> =
+            <Spec as ResolveReference<Parameter>>::resolve_reference(&spec, "#/parameters/Missing");
+        assert!(p.is_none());
+
+        // ResolveReference<Response>
+        let _ = spec
+            .define_response(
+                "R",
+                Response {
+                    description: "x".into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let r: Option<&Response> =
+            <Spec as ResolveReference<Response>>::resolve_reference(&spec, "#/responses/R");
+        assert!(r.is_some());
+        let r: Option<&Response> =
+            <Spec as ResolveReference<Response>>::resolve_reference(&spec, "#/responses/Missing");
+        assert!(r.is_none());
+
+        // ResolveReference<SecurityScheme>
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "S".to_owned(),
+            SecurityScheme::Basic(BasicSecurityScheme::default()),
+        );
+        spec.security_definitions = Some(defs);
+        let s: Option<&SecurityScheme> =
+            <Spec as ResolveReference<SecurityScheme>>::resolve_reference(
+                &spec,
+                "#/securityDefinitions/S",
+            );
+        assert!(s.is_some());
+        let s: Option<&SecurityScheme> =
+            <Spec as ResolveReference<SecurityScheme>>::resolve_reference(
+                &spec,
+                "#/securityDefinitions/Missing",
+            );
+        assert!(s.is_none());
+
+        // ResolveReference<Tag>
+        spec.tags = Some(vec![crate::v2::tag::Tag {
+            name: "t1".into(),
+            ..Default::default()
+        }]);
+        let t =
+            <Spec as ResolveReference<crate::v2::tag::Tag>>::resolve_reference(&spec, "#/tags/t1");
+        assert!(t.is_some());
+        let t = <Spec as ResolveReference<crate::v2::tag::Tag>>::resolve_reference(
+            &spec,
+            "#/tags/missing",
+        );
+        assert!(t.is_none());
+    }
+
+    #[test]
+    fn validate_oauth2_definitions_walked() {
+        let mut spec = Spec::default();
+        spec.info = crate::v2::info::Info {
+            title: "T".into(),
+            version: "1".into(),
+            ..Default::default()
+        };
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "o".to_owned(),
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                flow: SecuritySchemeOAuth2Flow::Implicit,
+                authorization_url: None,
+                token_url: None,
+                scopes: Scopes::default(),
+                description: None,
+                extensions: None,
+            }),
+        );
+        spec.security_definitions = Some(defs);
+        let err = spec.validate(Options::new()).unwrap_err();
+        // Per-scheme validate fires on missing URLs / empty scopes.
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("must not be empty") || e.contains("must be present")),
+            "errors: {:?}",
+            err.errors
         );
     }
 }

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -174,6 +174,16 @@ pub struct Spec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
 
+    /// ReDoc extension that backports OpenAPI 3 servers to Swagger 2.0.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-servers")]
+    pub x_servers: Option<Vec<Server>>,
+
+    /// ReDoc extension that groups tags in the side menu.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-tagGroups")]
+    pub x_tag_groups: Option<Vec<TagGroup>>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -217,6 +227,39 @@ pub enum Scheme {
     /// `wss` protocol (WebSocket Secure)
     #[serde(rename = "wss")]
     WSS,
+}
+
+/// ReDoc `x-servers` extension entry.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Server {
+    /// **Required** The server URL.
+    pub url: String,
+
+    /// A short description of the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Allows extensions on the server extension object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// ReDoc `x-tagGroups` extension entry.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct TagGroup {
+    /// **Required** The display name for the tag group.
+    pub name: String,
+
+    /// **Required** The tags included in the group.
+    pub tags: Vec<String>,
+
+    /// Allows extensions on the tag group extension object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 impl Display for Scheme {
@@ -386,6 +429,18 @@ impl Validate for Spec {
             docs.validate_with_context(&mut ctx, "#.externalDocs".to_owned())
         }
 
+        if let Some(servers) = &self.x_servers {
+            for (i, server) in servers.iter().enumerate() {
+                server.validate_with_context(&mut ctx, format!("#.x-servers[{i}]"));
+            }
+        }
+
+        if let Some(tag_groups) = &self.x_tag_groups {
+            for (i, tag_group) in tag_groups.iter().enumerate() {
+                tag_group.validate_with_context(&mut ctx, format!("#.x-tagGroups[{i}]"));
+            }
+        }
+
         if let Some(tags) = &self.tags {
             for tag in tags.iter() {
                 let path = format!("#/tags/{}", tag.name);
@@ -415,6 +470,21 @@ impl Validate for Spec {
         }
 
         ctx.into()
+    }
+}
+
+impl ValidateWithContext<Spec> for Server {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        crate::common::helpers::validate_required_string(&self.url, ctx, format!("{path}.url"));
+    }
+}
+
+impl ValidateWithContext<Spec> for TagGroup {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        crate::common::helpers::validate_required_string(&self.name, ctx, format!("{path}.name"));
+        for (i, tag) in self.tags.iter().enumerate() {
+            crate::common::helpers::validate_required_string(tag, ctx, format!("{path}.tags[{i}]"));
+        }
     }
 }
 
@@ -472,6 +542,57 @@ mod tests {
             "unknown variant `foo`, expected `2.0`",
             "foo as swagger version",
         );
+    }
+
+    #[test]
+    fn test_common_doc_extensions_round_trip_and_validate() {
+        let value = serde_json::json!({
+            "swagger": "2.0",
+            "info": {
+                "title": "foo",
+                "version": "1",
+            },
+            "paths": {},
+            "x-servers": [
+                {
+                    "url": "https://api.example.com",
+                    "description": "Production",
+                    "x-extra": true,
+                }
+            ],
+            "x-tagGroups": [
+                {
+                    "name": "Core",
+                    "tags": ["pets"],
+                    "x-extra": "group",
+                }
+            ],
+        });
+        let spec = serde_json::from_value::<Spec>(value.clone()).unwrap();
+        assert_eq!(
+            spec.x_servers,
+            Some(vec![Server {
+                url: "https://api.example.com".to_owned(),
+                description: Some("Production".to_owned()),
+                extensions: Some(BTreeMap::from_iter([(
+                    "x-extra".to_owned(),
+                    serde_json::json!(true)
+                )])),
+            }])
+        );
+        assert_eq!(
+            spec.x_tag_groups,
+            Some(vec![TagGroup {
+                name: "Core".to_owned(),
+                tags: vec!["pets".to_owned()],
+                extensions: Some(BTreeMap::from_iter([(
+                    "x-extra".to_owned(),
+                    serde_json::json!("group")
+                )])),
+            }])
+        );
+        assert_eq!(serde_json::to_value(&spec).unwrap(), value);
+        assert!(spec.validate(Default::default()).is_ok());
     }
 
     #[test]
@@ -660,6 +781,17 @@ mod tests {
         }
     }
 
+    fn spec_with_info() -> Spec {
+        Spec {
+            info: crate::v2::info::Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn version_and_scheme_display() {
         assert_eq!(format!("{}", Version::V2_0), "2.0");
@@ -675,12 +807,7 @@ mod tests {
 
     #[test]
     fn happy_path_validate_no_errors() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
+        let mut spec = spec_with_info();
         let mut ops = BTreeMap::new();
         ops.insert("get".into(), happy_op());
         let mut paths = BTreeMap::new();
@@ -701,12 +828,7 @@ mod tests {
 
     #[test]
     fn validate_path_must_start_with_slash() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
+        let mut spec = spec_with_info();
         let mut paths = BTreeMap::new();
         paths.insert(
             "no-slash".to_owned(),
@@ -733,12 +855,7 @@ mod tests {
 
     #[test]
     fn validate_base_path_must_start_with_slash() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
+        let mut spec = spec_with_info();
         spec.base_path = Some("api".into());
         let err = spec.validate(Options::new()).unwrap_err();
         assert!(
@@ -752,36 +869,30 @@ mod tests {
 
     #[test]
     fn validate_security_with_definitions() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
         let mut defs = BTreeMap::new();
         defs.insert(
             "basicAuth".to_owned(),
             SecurityScheme::Basic(BasicSecurityScheme::default()),
         );
-        spec.security_definitions = Some(defs);
         let mut req = BTreeMap::new();
         req.insert("basicAuth".to_owned(), vec![]);
-        spec.security = Some(vec![req]);
+        let spec = Spec {
+            security_definitions: Some(defs),
+            security: Some(vec![req]),
+            ..spec_with_info()
+        };
         let res = spec.validate(Options::new());
         assert!(res.is_ok(), "errors: {:?}", res);
     }
 
     #[test]
     fn validate_undefined_security_scheme() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
         let mut req = BTreeMap::new();
         req.insert("foo".to_owned(), vec![]);
-        spec.security = Some(vec![req]);
+        let spec = Spec {
+            security: Some(vec![req]),
+            ..spec_with_info()
+        };
         let err = spec.validate(Options::new()).unwrap_err();
         assert!(
             err.errors
@@ -794,12 +905,7 @@ mod tests {
 
     #[test]
     fn validate_body_and_formdata_together_via_spec() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
+        let mut spec = spec_with_info();
         let mut op = happy_op();
         op.parameters = Some(vec![
             RefOr::new_item(Parameter::Body(Box::new(crate::v2::parameter::InBody {
@@ -807,6 +913,7 @@ mod tests {
                 description: None,
                 required: None,
                 schema: RefOr::new_item(Schema::from(StringSchema::default())),
+                x_examples: None,
                 extensions: None,
             }))),
             RefOr::new_item(Parameter::FormData(Box::new(
@@ -842,12 +949,7 @@ mod tests {
 
     #[test]
     fn validate_duplicate_param_via_spec() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
+        let mut spec = spec_with_info();
         let mut op = happy_op();
         op.parameters = Some(vec![
             RefOr::new_item(Parameter::Query(Box::new(InQuery::String(
@@ -887,12 +989,7 @@ mod tests {
 
     #[test]
     fn validate_missing_path_template_param_via_spec() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
+        let mut spec = spec_with_info();
         let mut ops = BTreeMap::new();
         ops.insert("get".into(), happy_op());
         let mut paths = BTreeMap::new();
@@ -919,12 +1016,7 @@ mod tests {
 
     #[test]
     fn validate_empty_responses_via_spec() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
+        let mut spec = spec_with_info();
         let mut ops = BTreeMap::new();
         ops.insert(
             "get".into(),
@@ -1148,12 +1240,6 @@ mod tests {
 
     #[test]
     fn validate_oauth2_definitions_walked() {
-        let mut spec = Spec::default();
-        spec.info = crate::v2::info::Info {
-            title: "T".into(),
-            version: "1".into(),
-            ..Default::default()
-        };
         let mut defs = BTreeMap::new();
         defs.insert(
             "o".to_owned(),
@@ -1166,7 +1252,10 @@ mod tests {
                 extensions: None,
             }),
         );
-        spec.security_definitions = Some(defs);
+        let spec = Spec {
+            security_definitions: Some(defs),
+            ..spec_with_info()
+        };
         let err = spec.validate(Options::new()).unwrap_err();
         // Per-scheme validate fires on missing URLs / empty scopes.
         assert!(

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -31,6 +31,11 @@ pub struct Tag {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
 
+    /// ReDoc extension that overrides tag display text in documentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-displayName")]
+    pub x_display_name: Option<String>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -85,6 +90,18 @@ mod tests {
             }),
             "serialize",
         );
+    }
+
+    #[test]
+    fn x_display_name_round_trip() {
+        let value = serde_json::json!({
+            "name": "pet",
+            "description": "Pets operations",
+            "x-displayName": "Pets",
+        });
+        let tag = serde_json::from_value::<Tag>(value.clone()).unwrap();
+        assert_eq!(tag.x_display_name, Some("Pets".to_owned()));
+        assert_eq!(serde_json::to_value(tag).unwrap(), value);
     }
 
     #[test]

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -381,6 +381,7 @@ mod tests {
             description: None,
             required: None,
             schema: RefOr::new_item(Schema::from(StringSchema::default())),
+            x_examples: None,
             extensions: None,
         })))
     }
@@ -418,6 +419,13 @@ mod tests {
             allow_empty_value: Some(true),
             ..Default::default()
         }))))
+    }
+
+    fn spec_with_security_definitions(defs: BTreeMap<String, SecurityScheme>) -> Spec {
+        Spec {
+            security_definitions: Some(defs),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -570,13 +578,12 @@ mod tests {
 
     #[test]
     fn security_requires_existing_scheme() {
-        let mut spec = Spec::default();
         let mut defs = BTreeMap::new();
         defs.insert(
             "basic".to_owned(),
             SecurityScheme::Basic(BasicSecurityScheme::default()),
         );
-        spec.security_definitions = Some(defs);
+        let spec = spec_with_security_definitions(defs);
         let spec: &'static Spec = Box::leak(Box::new(spec));
 
         let mut ctx = Context::new(spec, Options::new());
@@ -594,13 +601,12 @@ mod tests {
 
     #[test]
     fn security_basic_with_scopes_is_invalid() {
-        let mut spec = Spec::default();
         let mut defs = BTreeMap::new();
         defs.insert(
             "b".to_owned(),
             SecurityScheme::Basic(BasicSecurityScheme::default()),
         );
-        spec.security_definitions = Some(defs);
+        let spec = spec_with_security_definitions(defs);
         let spec: &'static Spec = Box::leak(Box::new(spec));
 
         let mut ctx = Context::new(spec, Options::new());
@@ -618,7 +624,6 @@ mod tests {
 
     #[test]
     fn security_apikey_with_scopes_is_invalid() {
-        let mut spec = Spec::default();
         let mut defs = BTreeMap::new();
         defs.insert(
             "ak".to_owned(),
@@ -628,7 +633,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        spec.security_definitions = Some(defs);
+        let spec = spec_with_security_definitions(defs);
         let spec: &'static Spec = Box::leak(Box::new(spec));
 
         let mut ctx = Context::new(spec, Options::new());
@@ -646,7 +651,6 @@ mod tests {
 
     #[test]
     fn security_oauth2_undefined_scope() {
-        let mut spec = Spec::default();
         let mut defs = BTreeMap::new();
         defs.insert(
             "o".to_owned(),
@@ -659,7 +663,7 @@ mod tests {
                 extensions: None,
             }),
         );
-        spec.security_definitions = Some(defs);
+        let spec = spec_with_security_definitions(defs);
         let spec: &'static Spec = Box::leak(Box::new(spec));
 
         let mut ctx = Context::new(spec, Options::new());
@@ -678,7 +682,6 @@ mod tests {
     #[test]
     fn security_oauth2_missing_token_or_auth() {
         // Implicit without authorizationUrl
-        let mut spec = Spec::default();
         let mut defs = BTreeMap::new();
         defs.insert(
             "o".to_owned(),
@@ -691,7 +694,7 @@ mod tests {
                 extensions: None,
             }),
         );
-        spec.security_definitions = Some(defs);
+        let spec = spec_with_security_definitions(defs);
         let spec: &'static Spec = Box::leak(Box::new(spec));
         let mut ctx = Context::new(spec, Options::new());
         let mut req = BTreeMap::new();
@@ -706,7 +709,6 @@ mod tests {
         );
 
         // Password without tokenUrl
-        let mut spec = Spec::default();
         let mut defs = BTreeMap::new();
         defs.insert(
             "o".to_owned(),
@@ -719,7 +721,7 @@ mod tests {
                 extensions: None,
             }),
         );
-        spec.security_definitions = Some(defs);
+        let spec = spec_with_security_definitions(defs);
         let spec: &'static Spec = Box::leak(Box::new(spec));
         let mut ctx = Context::new(spec, Options::new());
         let mut req = BTreeMap::new();
@@ -736,7 +738,6 @@ mod tests {
 
     #[test]
     fn validate_security_definitions_walks_each() {
-        let mut spec = Spec::default();
         let mut defs = BTreeMap::new();
         defs.insert(
             "o".to_owned(),
@@ -749,7 +750,7 @@ mod tests {
                 extensions: None,
             }),
         );
-        spec.security_definitions = Some(defs);
+        let spec = spec_with_security_definitions(defs);
         let spec: &'static Spec = Box::leak(Box::new(spec));
         let mut ctx = Context::new(spec, Options::new());
         validate_security_definitions(&mut ctx);
@@ -773,12 +774,14 @@ mod tests {
     fn validate_path_item_invokes_op_validators() {
         // Build a spec, path with templated path /users/{id}, an operation
         // missing the corresponding `in: path` parameter — should produce an error.
-        let mut op = crate::v2::operation::Operation::default();
-        op.responses = Responses {
-            default: Some(RefOr::new_item(Response {
-                description: "ok".into(),
+        let op = crate::v2::operation::Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
                 ..Default::default()
-            })),
+            },
             ..Default::default()
         };
         let mut ops = BTreeMap::new();

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -21,6 +21,7 @@ use crate::v2::path_item::PathItem;
 use crate::v2::reference::RefOr;
 use crate::v2::security_scheme::{SecurityScheme, SecuritySchemeOAuth2Flow};
 use crate::v2::spec::Spec;
+use crate::validation::Options;
 
 /// Resolve a `RefOr<Parameter>` against the spec's `#/parameters/...` pool.
 fn resolve_parameter<'a>(spec: &'a Spec, p: &'a RefOr<Parameter>) -> Option<&'a Parameter> {
@@ -321,14 +322,18 @@ pub fn validate_security_requirements(
     }
 }
 
-/// Walk `security_definitions` and run each scheme's per-scheme validator
-/// (URL-required-by-flow rules, etc.). Unused-scheme detection is wired up
-/// from `Spec::validate` via `validate_not_visited`.
+/// Walk `security_definitions`: run each scheme's per-scheme validator
+/// (URL-required-by-flow rules, etc.) and report unused schemes — those
+/// not referenced by any `security` requirement at the top level or any
+/// operation level — unless `Options::IgnoreUnusedSecuritySchemes` is set.
+///
+/// Must run AFTER `validate_security_requirements` has marked used
+/// schemes via `ctx.visit("#/securityDefinitions/{name}")`.
 ///
 /// We pre-collect the names so the `&mut Context` borrow used by each
 /// `validate_with_context` call doesn't overlap with the immutable borrow
-/// of `ctx.spec.security_definitions`. The schemes themselves are *not*
-/// cloned — they're looked up by reference per iteration.
+/// of `ctx.spec.security_definitions`. Each scheme is cloned once per
+/// iteration (a small enum), which is cheaper than cloning the whole map.
 pub fn validate_security_definitions(ctx: &mut Context<Spec>) {
     let names: Vec<String> = ctx
         .spec
@@ -338,9 +343,6 @@ pub fn validate_security_definitions(ctx: &mut Context<Spec>) {
         .unwrap_or_default();
     for name in names {
         let p = format!("#/securityDefinitions/{name}");
-        // Snapshot the scheme into an owned value: cloning a single
-        // `SecurityScheme` (a small enum) is cheaper than refactoring
-        // `ValidateWithContext` to split the &mut Context borrow.
         let Some(scheme) = ctx
             .spec
             .security_definitions
@@ -350,7 +352,10 @@ pub fn validate_security_definitions(ctx: &mut Context<Spec>) {
         else {
             continue;
         };
-        crate::common::helpers::ValidateWithContext::validate_with_context(&scheme, ctx, p);
+        crate::common::helpers::ValidateWithContext::validate_with_context(&scheme, ctx, p.clone());
+        if !ctx.is_visited(&p) && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes) {
+            ctx.error(p, "unused");
+        }
     }
 }
 
@@ -827,6 +832,67 @@ mod tests {
         let mut ctx = Context::new(spec, Options::new());
         validate_security_definitions(&mut ctx);
         assert!(ctx.errors.is_empty());
+    }
+
+    #[test]
+    fn unused_scheme_is_reported() {
+        // A scheme that is not referenced from any security requirement
+        // should be flagged as unused (matching v3 Components behavior).
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "orphan".to_owned(),
+            SecurityScheme::Basic(BasicSecurityScheme::default()),
+        );
+        let spec = spec_with_security_definitions(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_security_definitions(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("#/securityDefinitions/orphan") && e.contains("unused")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn unused_scheme_silenced_by_option() {
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "orphan".to_owned(),
+            SecurityScheme::Basic(BasicSecurityScheme::default()),
+        );
+        let spec = spec_with_security_definitions(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+        let mut ctx = Context::new(spec, Options::IgnoreUnusedSecuritySchemes.only());
+        validate_security_definitions(&mut ctx);
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("unused")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn used_scheme_is_not_flagged_as_unused() {
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "used".to_owned(),
+            SecurityScheme::Basic(BasicSecurityScheme::default()),
+        );
+        let spec = spec_with_security_definitions(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+        let mut ctx = Context::new(spec, Options::new());
+        // Mark as used, simulating what `validate_security_requirements`
+        // would do when processing `Spec.security` or operation-level security.
+        ctx.visit("#/securityDefinitions/used".to_owned());
+        validate_security_definitions(&mut ctx);
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("unused")),
+            "errors: {:?}",
+            ctx.errors
+        );
     }
 
     #[test]

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -1,0 +1,841 @@
+//! Cross-cutting v2 validation rules that span multiple objects.
+//!
+//! Each helper is invoked from `Spec::validate` to enforce rules from the
+//! OpenAPI 2.0 spec that don't naturally fit on a single struct's
+//! `ValidateWithContext` impl:
+//!
+//! * security_definitions / security cross-referencing
+//! * Operation parameters: body/formData exclusivity, (name, in) uniqueness,
+//!   path-parameter-name vs path-template correspondence
+//! * Responses: at least one entry required
+//! * allowEmptyValue: only meaningful on `query` / `formData` parameters
+
+use lazy_regex::regex;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::common::helpers::{Context, PushError};
+use crate::common::reference::ResolveReference;
+use crate::v2::operation::Operation;
+use crate::v2::parameter::{InFormData, InHeader, InPath, InQuery, Parameter};
+use crate::v2::path_item::PathItem;
+use crate::v2::reference::RefOr;
+use crate::v2::security_scheme::{SecurityScheme, SecuritySchemeOAuth2Flow};
+use crate::v2::spec::Spec;
+use crate::validation::Options;
+
+/// Resolve a `RefOr<Parameter>` against the spec's `#/parameters/...` pool.
+fn resolve_parameter<'a>(spec: &'a Spec, p: &'a RefOr<Parameter>) -> Option<&'a Parameter> {
+    match p {
+        RefOr::Item(p) => Some(p),
+        RefOr::Ref(r) => {
+            <Spec as ResolveReference<Parameter>>::resolve_reference(spec, &r.reference)
+        }
+    }
+}
+
+/// (name, location-string) identity tuple for a Parameter, used for
+/// duplicate detection per the v2 spec uniqueness rule.
+fn parameter_identity(p: &Parameter) -> (&str, &'static str) {
+    match p {
+        Parameter::Body(b) => (b.name.as_str(), "body"),
+        Parameter::Header(h) => (in_header_name(h), "header"),
+        Parameter::Query(q) => (in_query_name(q), "query"),
+        Parameter::Path(p) => (in_path_name(p), "path"),
+        Parameter::FormData(f) => (in_formdata_name(f), "formData"),
+    }
+}
+
+fn in_header_name(h: &InHeader) -> &str {
+    match h {
+        InHeader::String(p) => &p.name,
+        InHeader::Integer(p) => &p.name,
+        InHeader::Number(p) => &p.name,
+        InHeader::Boolean(p) => &p.name,
+        InHeader::Array(p) => &p.name,
+    }
+}
+fn in_query_name(q: &InQuery) -> &str {
+    match q {
+        InQuery::String(p) => &p.name,
+        InQuery::Integer(p) => &p.name,
+        InQuery::Number(p) => &p.name,
+        InQuery::Boolean(p) => &p.name,
+        InQuery::Array(p) => &p.name,
+    }
+}
+fn in_path_name(p: &InPath) -> &str {
+    match p {
+        InPath::String(p) => &p.name,
+        InPath::Integer(p) => &p.name,
+        InPath::Number(p) => &p.name,
+        InPath::Boolean(p) => &p.name,
+        InPath::Array(p) => &p.name,
+    }
+}
+fn in_formdata_name(f: &InFormData) -> &str {
+    match f {
+        InFormData::String(p) => &p.name,
+        InFormData::Integer(p) => &p.name,
+        InFormData::Number(p) => &p.name,
+        InFormData::Boolean(p) => &p.name,
+        InFormData::Array(p) => &p.name,
+        InFormData::File(p) => &p.name,
+    }
+}
+
+/// Returns true if the parameter sets `allowEmptyValue: true`.
+fn parameter_allows_empty_value(p: &Parameter) -> bool {
+    fn header_aev(h: &InHeader) -> bool {
+        match h {
+            InHeader::String(p) => p.allow_empty_value == Some(true),
+            InHeader::Integer(p) => p.allow_empty_value == Some(true),
+            InHeader::Number(p) => p.allow_empty_value == Some(true),
+            InHeader::Boolean(p) => p.allow_empty_value == Some(true),
+            InHeader::Array(p) => p.allow_empty_value == Some(true),
+        }
+    }
+    fn path_aev(p: &InPath) -> bool {
+        match p {
+            InPath::String(p) => p.allow_empty_value == Some(true),
+            InPath::Integer(p) => p.allow_empty_value == Some(true),
+            InPath::Number(p) => p.allow_empty_value == Some(true),
+            InPath::Boolean(p) => p.allow_empty_value == Some(true),
+            InPath::Array(p) => p.allow_empty_value == Some(true),
+        }
+    }
+    match p {
+        Parameter::Header(h) => header_aev(h),
+        Parameter::Path(p) => path_aev(p),
+        _ => false,
+    }
+}
+
+/// Extract `{name}` placeholders from a path template.
+fn path_template_variables(template: &str) -> BTreeSet<String> {
+    let re = regex!(r"\{([^}]+)\}");
+    re.captures_iter(template)
+        .map(|c| c.get(1).unwrap().as_str().to_owned())
+        .collect()
+}
+
+/// Validate operation-level parameter rules:
+/// * body / formData exclusivity (at most one body; body and formData cannot coexist),
+/// * (name, in) uniqueness (resolving references),
+/// * path parameter names match `{name}` in the path template,
+/// * `allowEmptyValue: true` only valid on header / path locations is rejected
+///   (per spec it is only meaningful for `query` / `formData`).
+///
+/// `path_item_params` is the path-item-level parameters list; merging happens
+/// per the spec ("path item parameters can be overridden at the operation level
+/// but not removed"). For uniqueness we check the union by (name, in).
+pub fn validate_operation_parameters(
+    ctx: &mut Context<Spec>,
+    op_path: &str,
+    template: &str,
+    path_item_params: Option<&[RefOr<Parameter>]>,
+    op_params: Option<&[RefOr<Parameter>]>,
+) {
+    let template_vars = path_template_variables(template);
+
+    let mut body_count = 0usize;
+    let mut form_count = 0usize;
+    let mut seen: BTreeMap<(String, &'static str), usize> = BTreeMap::new();
+    let mut declared_path_params: BTreeSet<String> = BTreeSet::new();
+
+    let mut iter = |params: &[RefOr<Parameter>], origin: &str| {
+        for (i, raw) in params.iter().enumerate() {
+            let resolved = resolve_parameter(ctx.spec, raw);
+            let Some(p) = resolved else { continue };
+            let (name, loc) = parameter_identity(p);
+            let key = (name.to_owned(), loc);
+            *seen.entry(key.clone()).or_insert(0) += 1;
+            if seen[&key] == 2 {
+                ctx.error(
+                    op_path.to_owned(),
+                    format_args!(
+                        ".parameters: duplicate parameter `{name}` in `{loc}` ({origin}[{i}])"
+                    ),
+                );
+            }
+            match p {
+                Parameter::Body(_) => body_count += 1,
+                Parameter::FormData(_) => form_count += 1,
+                Parameter::Path(_) => {
+                    declared_path_params.insert(name.to_owned());
+                }
+                _ => {}
+            }
+            // allowEmptyValue is only valid on `query` / `formData`.
+            if parameter_allows_empty_value(p)
+                && !matches!(p, Parameter::Query(_) | Parameter::FormData(_))
+            {
+                ctx.error(
+                    op_path.to_owned(),
+                    format_args!(
+                        ".parameters[{i}]: allowEmptyValue is only valid for `query` or `formData`"
+                    ),
+                );
+            }
+        }
+    };
+    if let Some(p) = path_item_params {
+        iter(p, "path-item");
+    }
+    if let Some(p) = op_params {
+        iter(p, "operation");
+    }
+
+    if body_count > 1 {
+        ctx.error(
+            op_path.to_owned(),
+            format_args!(".parameters: only one body parameter allowed, found {body_count}"),
+        );
+    }
+    if body_count > 0 && form_count > 0 {
+        ctx.error(
+            op_path.to_owned(),
+            "`body` and `formData` parameters cannot coexist on the same operation",
+        );
+    }
+
+    // Each `{name}` in the template must have a matching `in: path` parameter.
+    for var in &template_vars {
+        if !declared_path_params.contains(var) {
+            ctx.error(
+                op_path.to_owned(),
+                format_args!(
+                    ".parameters: path template variable `{{{var}}}` has no matching `in: path` parameter"
+                ),
+            );
+        }
+    }
+    // And each path parameter must appear in the template.
+    for declared in &declared_path_params {
+        if !template_vars.contains(declared) {
+            ctx.error(
+                op_path.to_owned(),
+                format_args!(
+                    ".parameters: path parameter `{declared}` does not match any `{{name}}` in the path template"
+                ),
+            );
+        }
+    }
+}
+
+/// Validate Spec-level security rules:
+/// * Each security_definitions entry is itself walked (already done elsewhere).
+/// * Top-level `security` requirements: the scheme name must exist; non-OAuth2
+///   schemes must have an empty scope list; OAuth2 scopes must be defined.
+/// * Operation-level `security`: same checks.
+pub fn validate_security_requirements(
+    ctx: &mut Context<Spec>,
+    path: &str,
+    requirements: &[BTreeMap<String, Vec<String>>],
+) {
+    let defs = ctx.spec.security_definitions.as_ref();
+    for (i, req) in requirements.iter().enumerate() {
+        for (name, scopes) in req {
+            let Some(defs) = defs else {
+                ctx.error(
+                    path.to_owned(),
+                    format_args!(
+                        "[{i}].`{name}`: no securityDefinitions on the spec to resolve against"
+                    ),
+                );
+                continue;
+            };
+            let Some(scheme) = defs.get(name) else {
+                ctx.error(
+                    path.to_owned(),
+                    format_args!("[{i}].`{name}`: not declared in `securityDefinitions`"),
+                );
+                continue;
+            };
+            // record the scheme as visited so that "unused security scheme" detection works.
+            ctx.visit(format!("#/securityDefinitions/{name}"));
+
+            match scheme {
+                SecurityScheme::OAuth2(o) => {
+                    for scope in scopes {
+                        if !o.scopes.scopes.contains_key(scope) {
+                            ctx.error(
+                                path.to_owned(),
+                                format_args!(
+                                    "[{i}].`{name}`: scope `{scope}` not declared in scheme's scopes"
+                                ),
+                            );
+                        }
+                    }
+                    // Also flag schemes whose token/auth URL prerequisites were
+                    // never even set (defense in depth — schemes' own
+                    // validators should catch this, but we double-check here
+                    // because security_definitions wasn't always walked).
+                    let needs_auth = matches!(
+                        o.flow,
+                        SecuritySchemeOAuth2Flow::Implicit | SecuritySchemeOAuth2Flow::AccessCode
+                    );
+                    let needs_token = matches!(
+                        o.flow,
+                        SecuritySchemeOAuth2Flow::Password
+                            | SecuritySchemeOAuth2Flow::Application
+                            | SecuritySchemeOAuth2Flow::AccessCode
+                    );
+                    if needs_auth && o.authorization_url.is_none() {
+                        ctx.error(
+                            path.to_owned(),
+                            format_args!(
+                                "[{i}].`{name}`: scheme requires `authorizationUrl` for flow `{}`",
+                                o.flow,
+                            ),
+                        );
+                    }
+                    if needs_token && o.token_url.is_none() {
+                        ctx.error(
+                            path.to_owned(),
+                            format_args!(
+                                "[{i}].`{name}`: scheme requires `tokenUrl` for flow `{}`",
+                                o.flow,
+                            ),
+                        );
+                    }
+                }
+                SecurityScheme::Basic(_) | SecurityScheme::ApiKey(_) => {
+                    if !scopes.is_empty() {
+                        ctx.error(
+                            path.to_owned(),
+                            format_args!(
+                                "[{i}].`{name}`: non-OAuth2 scheme requirement must list no scopes"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Walk `security_definitions` and ensure each one is visited (so "unused
+/// scheme" detection can fire) plus its own per-scheme validation runs.
+pub fn validate_security_definitions(ctx: &mut Context<Spec>) {
+    let Some(defs) = ctx.spec.security_definitions.clone() else {
+        return;
+    };
+    for (name, scheme) in &defs {
+        let p = format!("#/securityDefinitions/{name}");
+        // Per-scheme validation (URL-required-by-flow rules, etc.).
+        crate::common::helpers::ValidateWithContext::validate_with_context(scheme, ctx, p.clone());
+        // Treat as referenced so unused-scheme detection only flags truly
+        // orphan schemes; per-requirement validators above already mark used
+        // schemes via ctx.visit().
+        if !ctx.is_visited(&p) && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes) {
+            // Don't error here — leave to caller / validate_not_visited
+            // hookup. We just record absence.
+        }
+    }
+}
+
+/// Validate operation-level + path-item parameters together with knowledge of
+/// the path template. Called from `Spec::validate` for each path entry.
+pub fn validate_path_item(ctx: &mut Context<Spec>, template: &str, path: &str, item: &PathItem) {
+    let pi_params = item.parameters.as_deref();
+    if let Some(ops) = &item.operations {
+        for (method, op) in ops {
+            let op_path = format!("{path}.{method}");
+            validate_operation_parameters(
+                ctx,
+                &op_path,
+                template,
+                pi_params,
+                op.parameters.as_deref(),
+            );
+            validate_operation_security(ctx, &op_path, op);
+        }
+    }
+}
+
+fn validate_operation_security(ctx: &mut Context<Spec>, op_path: &str, op: &Operation) {
+    if let Some(sec) = &op.security {
+        validate_security_requirements(ctx, &format!("{op_path}.security"), sec);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::v2::parameter::{InBody, InFormData, InPath, InQuery, Parameter, StringParameter};
+    use crate::v2::path_item::PathItem;
+    use crate::v2::reference::RefOr;
+    use crate::v2::response::{Response, Responses};
+    use crate::v2::schema::{Schema, StringSchema};
+    use crate::v2::security_scheme::{
+        ApiKeySecurityScheme, BasicSecurityScheme, OAuth2SecurityScheme, Scopes, SecurityScheme,
+        SecuritySchemeApiKeyLocation, SecuritySchemeOAuth2Flow,
+    };
+    use crate::v2::spec::Spec;
+    use crate::validation::Options;
+
+    fn body_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Body(Box::new(InBody {
+            name: name.into(),
+            description: None,
+            required: None,
+            schema: RefOr::new_item(Schema::from(StringSchema::default())),
+            extensions: None,
+        })))
+    }
+
+    fn formdata_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::FormData(Box::new(InFormData::String(
+            StringParameter {
+                name: name.into(),
+                ..Default::default()
+            },
+        ))))
+    }
+
+    fn query_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Query(Box::new(InQuery::String(
+            StringParameter {
+                name: name.into(),
+                ..Default::default()
+            },
+        ))))
+    }
+
+    fn path_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Path(Box::new(InPath::String(StringParameter {
+            name: name.into(),
+            required: Some(true),
+            ..Default::default()
+        }))))
+    }
+
+    fn path_param_aev(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Path(Box::new(InPath::String(StringParameter {
+            name: name.into(),
+            required: Some(true),
+            allow_empty_value: Some(true),
+            ..Default::default()
+        }))))
+    }
+
+    #[test]
+    fn body_formdata_exclusivity() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![body_param("b"), formdata_param("f")];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&params));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("`body` and `formData` parameters cannot coexist")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn multiple_body_params_error() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![body_param("a"), body_param("b")];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&params));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("only one body parameter allowed")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn duplicate_name_in_location() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![query_param("q"), query_param("q")];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&params));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("duplicate parameter `q`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn path_template_variable_missing_param() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, None);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("path template variable `{id}`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn path_param_without_template_variable() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![path_param("id")];
+        validate_operation_parameters(&mut ctx, "op", "/no-vars", None, Some(&params));
+        assert!(
+            ctx.errors.iter().any(|e| e
+                .contains("path parameter `id` does not match any `{name}` in the path template")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn path_template_correspondence_ok() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![path_param("id")];
+        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn allow_empty_value_only_for_query_or_formdata() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![path_param_aev("id")];
+        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("allowEmptyValue is only valid for `query` or `formData`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn parameters_resolve_via_ref() {
+        let mut spec = Spec::default();
+        let p = Parameter::Query(Box::new(InQuery::String(StringParameter {
+            name: "shared".into(),
+            ..Default::default()
+        })));
+        spec.define_parameter("shared", p).unwrap();
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![
+            RefOr::<Parameter>::new_ref("#/parameters/shared"),
+            RefOr::<Parameter>::new_ref("#/parameters/shared"),
+        ];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&params));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("duplicate parameter `shared`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn parameters_unresolvable_ref_skipped() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![RefOr::<Parameter>::new_ref("#/parameters/missing")];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&params));
+        // No path-template vars, no params resolve, so no errors.
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn security_undeclared_scheme_when_no_definitions() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("foo".to_owned(), vec![]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("no securityDefinitions on the spec")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_requires_existing_scheme() {
+        let mut spec = Spec::default();
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "basic".to_owned(),
+            SecurityScheme::Basic(BasicSecurityScheme::default()),
+        );
+        spec.security_definitions = Some(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("missing".to_owned(), vec![]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("not declared in `securityDefinitions`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_basic_with_scopes_is_invalid() {
+        let mut spec = Spec::default();
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "b".to_owned(),
+            SecurityScheme::Basic(BasicSecurityScheme::default()),
+        );
+        spec.security_definitions = Some(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("b".to_owned(), vec!["read".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("non-OAuth2 scheme requirement must list no scopes")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_apikey_with_scopes_is_invalid() {
+        let mut spec = Spec::default();
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "ak".to_owned(),
+            SecurityScheme::ApiKey(ApiKeySecurityScheme {
+                name: "X".into(),
+                location: SecuritySchemeApiKeyLocation::Header,
+                ..Default::default()
+            }),
+        );
+        spec.security_definitions = Some(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("ak".to_owned(), vec!["read".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("non-OAuth2 scheme requirement must list no scopes")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_oauth2_undefined_scope() {
+        let mut spec = Spec::default();
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "o".to_owned(),
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                flow: SecuritySchemeOAuth2Flow::Implicit,
+                authorization_url: Some("https://x.example.com/a".into()),
+                token_url: None,
+                scopes: Scopes::from([("read".to_owned(), "Read".to_owned())]),
+                description: None,
+                extensions: None,
+            }),
+        );
+        spec.security_definitions = Some(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("o".to_owned(), vec!["write".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("scope `write` not declared in scheme's scopes")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_oauth2_missing_token_or_auth() {
+        // Implicit without authorizationUrl
+        let mut spec = Spec::default();
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "o".to_owned(),
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                flow: SecuritySchemeOAuth2Flow::Implicit,
+                authorization_url: None,
+                token_url: None,
+                scopes: Scopes::from([("read".to_owned(), "Read".to_owned())]),
+                description: None,
+                extensions: None,
+            }),
+        );
+        spec.security_definitions = Some(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("o".to_owned(), vec!["read".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("scheme requires `authorizationUrl`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Password without tokenUrl
+        let mut spec = Spec::default();
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "o".to_owned(),
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                flow: SecuritySchemeOAuth2Flow::Password,
+                authorization_url: None,
+                token_url: None,
+                scopes: Scopes::from([("read".to_owned(), "Read".to_owned())]),
+                description: None,
+                extensions: None,
+            }),
+        );
+        spec.security_definitions = Some(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("o".to_owned(), vec!["read".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("scheme requires `tokenUrl`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_security_definitions_walks_each() {
+        let mut spec = Spec::default();
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "o".to_owned(),
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                flow: SecuritySchemeOAuth2Flow::Implicit,
+                authorization_url: None,
+                token_url: None,
+                scopes: Scopes::default(),
+                description: None,
+                extensions: None,
+            }),
+        );
+        spec.security_definitions = Some(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_security_definitions(&mut ctx);
+        // Empty scopes + missing authorizationUrl produce errors from per-scheme validate.
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_security_definitions_none() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_security_definitions(&mut ctx);
+        assert!(ctx.errors.is_empty());
+    }
+
+    #[test]
+    fn validate_path_item_invokes_op_validators() {
+        // Build a spec, path with templated path /users/{id}, an operation
+        // missing the corresponding `in: path` parameter — should produce an error.
+        let mut op = crate::v2::operation::Operation::default();
+        op.responses = Responses {
+            default: Some(RefOr::new_item(Response {
+                description: "ok".into(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".to_owned(), op);
+        let item = PathItem {
+            reference: None,
+            operations: Some(ops),
+            parameters: None,
+            extensions: None,
+        };
+
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_path_item(&mut ctx, "/users/{id}", "#.paths[/users/{id}]", &item);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("path template variable `{id}`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_path_item_with_op_security() {
+        // Operation has security referencing a scheme not defined.
+        let mut sec_req = BTreeMap::new();
+        sec_req.insert("missing".to_owned(), vec![]);
+        let op = crate::v2::operation::Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            security: Some(vec![sec_req]),
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".to_owned(), op);
+        let item = PathItem {
+            reference: None,
+            operations: Some(ops),
+            parameters: None,
+            extensions: None,
+        };
+
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_path_item(&mut ctx, "/p", "#.paths[/p]", &item);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("no securityDefinitions on the spec")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -21,7 +21,6 @@ use crate::v2::path_item::PathItem;
 use crate::v2::reference::RefOr;
 use crate::v2::security_scheme::{SecurityScheme, SecuritySchemeOAuth2Flow};
 use crate::v2::spec::Spec;
-use crate::validation::Options;
 
 /// Resolve a `RefOr<Parameter>` against the spec's `#/parameters/...` pool.
 fn resolve_parameter<'a>(spec: &'a Spec, p: &'a RefOr<Parameter>) -> Option<&'a Parameter> {
@@ -83,33 +82,6 @@ fn in_formdata_name(f: &InFormData) -> &str {
     }
 }
 
-/// Returns true if the parameter sets `allowEmptyValue: true`.
-fn parameter_allows_empty_value(p: &Parameter) -> bool {
-    fn header_aev(h: &InHeader) -> bool {
-        match h {
-            InHeader::String(p) => p.allow_empty_value == Some(true),
-            InHeader::Integer(p) => p.allow_empty_value == Some(true),
-            InHeader::Number(p) => p.allow_empty_value == Some(true),
-            InHeader::Boolean(p) => p.allow_empty_value == Some(true),
-            InHeader::Array(p) => p.allow_empty_value == Some(true),
-        }
-    }
-    fn path_aev(p: &InPath) -> bool {
-        match p {
-            InPath::String(p) => p.allow_empty_value == Some(true),
-            InPath::Integer(p) => p.allow_empty_value == Some(true),
-            InPath::Number(p) => p.allow_empty_value == Some(true),
-            InPath::Boolean(p) => p.allow_empty_value == Some(true),
-            InPath::Array(p) => p.allow_empty_value == Some(true),
-        }
-    }
-    match p {
-        Parameter::Header(h) => header_aev(h),
-        Parameter::Path(p) => path_aev(p),
-        _ => false,
-    }
-}
-
 /// Extract `{name}` placeholders from a path template.
 fn path_template_variables(template: &str) -> BTreeSet<String> {
     let re = regex!(r"\{([^}]+)\}");
@@ -120,14 +92,18 @@ fn path_template_variables(template: &str) -> BTreeSet<String> {
 
 /// Validate operation-level parameter rules:
 /// * body / formData exclusivity (at most one body; body and formData cannot coexist),
-/// * (name, in) uniqueness (resolving references),
-/// * path parameter names match `{name}` in the path template,
-/// * `allowEmptyValue: true` only valid on header / path locations is rejected
-///   (per spec it is only meaningful for `query` / `formData`).
+/// * (name, in) uniqueness — duplicates *within the same level* are flagged.
+/// * path parameter names match `{name}` in the path template.
 ///
-/// `path_item_params` is the path-item-level parameters list; merging happens
-/// per the spec ("path item parameters can be overridden at the operation level
-/// but not removed"). For uniqueness we check the union by (name, in).
+/// Per OAS v2: "If a parameter is already defined at the Path Item, the new
+/// definition will override it, but can never remove it." So we first detect
+/// within-level duplicates (a real spec violation), then **merge** the lists by
+/// (name, in) with operation-level entries replacing path-item-level entries
+/// — and only then run body/formData/path-template checks on the merged set.
+///
+/// Per-parameter `allowEmptyValue` location rules are enforced inside each
+/// parameter's own `validate_with_context` (`must_not_allow_empty_value` for
+/// `header` / `path`), not here, to avoid duplicate errors.
 pub fn validate_operation_parameters(
     ctx: &mut Context<Spec>,
     op_path: &str,
@@ -137,15 +113,13 @@ pub fn validate_operation_parameters(
 ) {
     let template_vars = path_template_variables(template);
 
-    let mut body_count = 0usize;
-    let mut form_count = 0usize;
-    let mut seen: BTreeMap<(String, &'static str), usize> = BTreeMap::new();
-    let mut declared_path_params: BTreeSet<String> = BTreeSet::new();
-
-    let mut iter = |params: &[RefOr<Parameter>], origin: &str| {
+    // Within-level duplicate detection: report once per (name, in) per layer.
+    let mut emit_within_level_dups = |params: &[RefOr<Parameter>], origin: &str| {
+        let mut seen: BTreeMap<(String, &'static str), usize> = BTreeMap::new();
         for (i, raw) in params.iter().enumerate() {
-            let resolved = resolve_parameter(ctx.spec, raw);
-            let Some(p) = resolved else { continue };
+            let Some(p) = resolve_parameter(ctx.spec, raw) else {
+                continue;
+            };
             let (name, loc) = parameter_identity(p);
             let key = (name.to_owned(), loc);
             *seen.entry(key.clone()).or_insert(0) += 1;
@@ -157,32 +131,65 @@ pub fn validate_operation_parameters(
                     ),
                 );
             }
-            match p {
-                Parameter::Body(_) => body_count += 1,
-                Parameter::FormData(_) => form_count += 1,
-                Parameter::Path(_) => {
-                    declared_path_params.insert(name.to_owned());
-                }
-                _ => {}
-            }
-            // allowEmptyValue is only valid on `query` / `formData`.
-            if parameter_allows_empty_value(p)
-                && !matches!(p, Parameter::Query(_) | Parameter::FormData(_))
-            {
-                ctx.error(
-                    op_path.to_owned(),
-                    format_args!(
-                        ".parameters[{i}]: allowEmptyValue is only valid for `query` or `formData`"
-                    ),
-                );
-            }
         }
     };
     if let Some(p) = path_item_params {
-        iter(p, "path-item");
+        emit_within_level_dups(p, "path-item");
     }
     if let Some(p) = op_params {
-        iter(p, "operation");
+        emit_within_level_dups(p, "operation");
+    }
+
+    // Merge: keyed by (name, in). Operation-level overrides path-item-level
+    // (same key replaces). We only need the kind of the *winning* parameter
+    // for body/formData/path counting, so we store it as an enum tag — this
+    // sidesteps lifetime issues that would arise from holding `&Parameter`
+    // references across the closure / collection boundary.
+    #[derive(Clone, Copy)]
+    enum Kind {
+        Body,
+        FormData,
+        Path,
+        Other,
+    }
+    fn kind_of(p: &Parameter) -> Kind {
+        match p {
+            Parameter::Body(_) => Kind::Body,
+            Parameter::FormData(_) => Kind::FormData,
+            Parameter::Path(_) => Kind::Path,
+            _ => Kind::Other,
+        }
+    }
+    let mut merged: BTreeMap<(String, &'static str), Kind> = BTreeMap::new();
+    if let Some(params) = path_item_params {
+        for raw in params {
+            if let Some(p) = resolve_parameter(ctx.spec, raw) {
+                let (name, loc) = parameter_identity(p);
+                merged.insert((name.to_owned(), loc), kind_of(p));
+            }
+        }
+    }
+    if let Some(params) = op_params {
+        for raw in params {
+            if let Some(p) = resolve_parameter(ctx.spec, raw) {
+                let (name, loc) = parameter_identity(p);
+                merged.insert((name.to_owned(), loc), kind_of(p));
+            }
+        }
+    }
+
+    let mut body_count = 0usize;
+    let mut form_count = 0usize;
+    let mut declared_path_params: BTreeSet<String> = BTreeSet::new();
+    for ((name, _loc), kind) in &merged {
+        match kind {
+            Kind::Body => body_count += 1,
+            Kind::FormData => form_count += 1,
+            Kind::Path => {
+                declared_path_params.insert(name.clone());
+            }
+            Kind::Other => {}
+        }
     }
 
     if body_count > 1 {
@@ -314,23 +321,36 @@ pub fn validate_security_requirements(
     }
 }
 
-/// Walk `security_definitions` and ensure each one is visited (so "unused
-/// scheme" detection can fire) plus its own per-scheme validation runs.
+/// Walk `security_definitions` and run each scheme's per-scheme validator
+/// (URL-required-by-flow rules, etc.). Unused-scheme detection is wired up
+/// from `Spec::validate` via `validate_not_visited`.
+///
+/// We pre-collect the names so the `&mut Context` borrow used by each
+/// `validate_with_context` call doesn't overlap with the immutable borrow
+/// of `ctx.spec.security_definitions`. The schemes themselves are *not*
+/// cloned — they're looked up by reference per iteration.
 pub fn validate_security_definitions(ctx: &mut Context<Spec>) {
-    let Some(defs) = ctx.spec.security_definitions.clone() else {
-        return;
-    };
-    for (name, scheme) in &defs {
+    let names: Vec<String> = ctx
+        .spec
+        .security_definitions
+        .as_ref()
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default();
+    for name in names {
         let p = format!("#/securityDefinitions/{name}");
-        // Per-scheme validation (URL-required-by-flow rules, etc.).
-        crate::common::helpers::ValidateWithContext::validate_with_context(scheme, ctx, p.clone());
-        // Treat as referenced so unused-scheme detection only flags truly
-        // orphan schemes; per-requirement validators above already mark used
-        // schemes via ctx.visit().
-        if !ctx.is_visited(&p) && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes) {
-            // Don't error here — leave to caller / validate_not_visited
-            // hookup. We just record absence.
-        }
+        // Snapshot the scheme into an owned value: cloning a single
+        // `SecurityScheme` (a small enum) is cheaper than refactoring
+        // `ValidateWithContext` to split the &mut Context borrow.
+        let Some(scheme) = ctx
+            .spec
+            .security_definitions
+            .as_ref()
+            .and_then(|m| m.get(&name))
+            .cloned()
+        else {
+            continue;
+        };
+        crate::common::helpers::ValidateWithContext::validate_with_context(&scheme, ctx, p);
     }
 }
 
@@ -459,6 +479,40 @@ mod tests {
     }
 
     #[test]
+    fn op_level_param_overrides_path_item_does_not_double_count() {
+        // Per spec, an operation-level parameter with the same (name, in)
+        // as a path-item-level parameter *overrides* it — not a duplicate
+        // and not double-counted toward body / formData totals.
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let path_item = vec![body_param("payload")];
+        let op = vec![body_param("payload")];
+        validate_operation_parameters(&mut ctx, "op", "/p", Some(&path_item), Some(&op));
+        assert!(
+            ctx.errors.is_empty(),
+            "override should not duplicate or inflate counts: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn within_level_duplicate_still_flagged_after_merge() {
+        // True within-level duplicates (two body params at the operation
+        // level) remain a spec violation even with the merge step.
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let op = vec![body_param("x"), body_param("x")];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&op));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("duplicate parameter `x` in `body`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
     fn duplicate_name_in_location() {
         let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
         let mut ctx = Context::new(spec, Options::new());
@@ -512,14 +566,19 @@ mod tests {
 
     #[test]
     fn allow_empty_value_only_for_query_or_formdata() {
+        // The rule lives on each parameter's own validator (via
+        // `must_not_allow_empty_value` in `parameter.rs`), so we exercise it
+        // by running per-parameter validation rather than the cross-cutting
+        // helper. This avoids the duplicate-error pattern flagged in PR #100
+        // review.
         let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
         let mut ctx = Context::new(spec, Options::new());
-        let params = vec![path_param_aev("id")];
-        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
+        let p = path_param_aev("id");
+        p.validate_with_context(&mut ctx, "op.parameters[0]".into());
         assert!(
             ctx.errors
                 .iter()
-                .any(|e| e.contains("allowEmptyValue is only valid for `query` or `formData`")),
+                .any(|e| e.contains("must not allow empty value")),
             "errors: {:?}",
             ctx.errors
         );


### PR DESCRIPTION
Closes the gap between the v2 module and the OpenAPI 2.0 / JSON Schema draft-04 spec, adds first-class support for the most common ReDoc-flavored vendor extensions, and lifts v2 unit-test coverage to **96.78% line / 94.93% region** (was ~73% / ~81%).

Two independent audits flagged 17 issues across data shape, validation, and spec completeness; this PR addresses all of them. Per-file coverage targets are all met: `parameter.rs` 99.07%, `schema.rs` 95.69%, `spec.rs` 97.42%, `reference.rs` 99.49%, `security_scheme.rs` 98.73%, `path_item.rs` 98.03%, `validation.rs` 96.24%. **262 lib tests pass** (was 176; +86 new).

## Spec compliance — data shape

| ID | Fix | Location |
|---|---|---|
| H3 | New `v2::reference::{Ref, RefOr}` with `deny_unknown_fields` so v3.1's `summary` / `description` cannot leak into v2 deserialize/serialize. Every v2 module repointed. | `src/v2/reference.rs` (new) |
| H4 | `OAuth2SecurityScheme` fields all `pub`. | `src/v2/security_scheme.rs` |
| H5 | `extensions` field on `BasicSecurityScheme`, `ApiKeySecurityScheme`, `OAuth2SecurityScheme`. New `Scopes` struct with custom serde splits `^x-` keys from scope-name keys. | same |
| H6 | `PathItem.reference` (`$ref`) added; serialized first, deserialized before other keys; non-empty validation. | `src/v2/path_item.rs` |
| H7 | `Integer{Schema,Parameter,Item,Header}.minimum` / `.maximum` switched from `Option<i64>` to `Option<serde_json::Number>` (matches v3.x fix; preserves wire form on round-trip). | `schema.rs`, `parameter.rs`, `items.rs`, `header.rs` |
| M1 | `ObjectSchema.default` was `Option<Vec<Value>>`; now `Option<serde_json::Value>`. | `src/v2/schema.rs` |
| M2 | `AllOfSchema` top-level variant added (parallel to v3.x). | same |
| M8 | `Paths` struct (custom serde) replaces the bare `BTreeMap` on `Spec.paths` and supports `^x-` extensions per spec. | `src/v2/path_item.rs` |
| L1 | `ArrayHeader.collection_format` gains `skip_serializing_if`. | `src/v2/header.rs` |
| L2 | `Info.title` / `Info.version` no longer skip-if-empty; required fields are now structurally serialized. | `src/v2/info.rs` |
| — | `Responses` gained `^x-` extension support too. | `src/v2/response.rs` |

## Spec compliance — validation overhaul (`src/v2/validation.rs`, new)

| ID | Rule |
|---|---|
| H1 | Walk `security_definitions` (per-scheme rules surface even for unused schemes). Validate every top-level + operation-level `security` requirement against the definitions: unknown scheme name, undefined OAuth2 scope, non-OAuth2 with scopes, missing `tokenUrl` / `authorizationUrl` for the relevant flows. **Unused-scheme detection** — `#/securityDefinitions/{name}: unused` — gated by `Options::IgnoreUnusedSecuritySchemes`. |
| H2 | Body / formData mutual exclusion and at-most-one-body per operation. **Operation parameters override path-item parameters by `(name, in)`** per spec — only after the merge are body/formData/path-template counts run. |
| M3 | Duplicate `(name, in)` parameters detected within each level (path-item alone, op alone), with reference resolution. |
| M4 | `{name}` placeholders in the path template must match the set of `in: path` parameters on the operation, in both directions. |
| M5 | Empty `Responses {}` is now an error. |
| M9 | `allowEmptyValue: true` only valid on `query` / `formData`; flagged by each parameter's own validator. |

OAuth2 scheme validation also tightened: both `authorizationUrl` and `tokenUrl` are required by their respective flow sets, and the URL *format* is checked, not just presence.

## Documented permissive deviations (M6, M7)

`v2.rs` module-level docs explicitly call out two intentional deviations kept on purpose:
- `Schema::Null` (draft-04 has no `null` type — kept for interop).
- `PathItem` accepting arbitrary HTTP methods (closed set in spec; kept permissive).

Neither is flagged by `validate()`.

## ReDoc extension fields

Adds typed support for the most common ReDoc-flavored vendor extensions so that user code can read and round-trip them as first-class fields instead of raw `serde_json::Value` blobs in the generic extensions map. Each new struct has a `validate_with_context` impl wired into its parent's validator and round-trip + validation tests.

| Field | Type | On |
|---|---|---|
| `x-servers` | `Vec<Server>` | `Spec` |
| `x-tagGroups` | `Vec<TagGroup>` | `Spec` |
| `x-logo` | `Logo` | `Info` |
| `x-codeSamples` | `Vec<CodeSample>` | `Operation` |
| `x-displayName` | `Option<String>` | `Tag` |
| `x-summary` | `Option<String>` | `Response` |
| `x-nullable` | `Option<bool>` | every Schema variant |
| `x-examples` | `Option<BTreeMap<String, Value>>` | `Body` and every typed Header / Query / Path / FormData parameter |

## Test coverage (v2 only, `cargo llvm-cov`)

```
v2/parameter.rs        0% → 99.07%
v2/validation.rs       0% → 96.24%   (new file)
v2/schema.rs        ~28% → 95.69%
v2/spec.rs          ~35% → 97.42%
v2/reference.rs       —  → 99.49%   (new file)
v2/security_scheme.rs ~68% → 98.73%
v2/path_item.rs      ~66% → 98.03%
v2/operation.rs      ~77% → 90.94%
v2/items.rs           81% → 88.49%
v2/header.rs          92% → 96.81%
v2/response.rs        94% → 96.08%
v2/info.rs           100% → 100%
v2/tag.rs            100% → 100%
v2/xml.rs            100% → 100%
─────────────────────────────────────
v2 aggregate         73% → 96.78%
```

`cargo clippy --features v2,v3_0,v3_1 --all-targets` is clean.

## Breaking changes (0.x; expected)

- `Spec.paths: BTreeMap<String, PathItem>` → `Spec.paths: Paths`. Most uses still work via `iter()` / `Paths::from(...)`.
- v2 fields previously typed `crate::common::reference::{Ref, RefOr}` are now `crate::v2::reference::*`. Same shape on the wire; type-rename only.
- `Spec.define_*` returns the v2 `RefOr` variants.
- `Integer*.{minimum, maximum}: Option<i64>` → `Option<serde_json::Number>`; tests construct via `Some(0.into())` or `Some(serde_json::Number::from_f64(0.5).unwrap())`.
- `Responses` / `Paths` / `Scopes` are now `Clone+Debug+Default+PartialEq` only (no derive serde); explicit `Serialize`/`Deserialize` impls preserve wire form (and split `x-` keys from data keys where applicable).

Assisted-By: Claude <noreply@anthropic.com>