### PR TITLE
v3.0 OAS spec completeness: data shape, validation, +95% coverage

### DIFF
--- a/src/v3_0.rs
+++ b/src/v3_0.rs
@@ -1,6 +1,16 @@
 //! Implementation of OpenAPI v3.0.X Specification
 //!
-//! Full specification can be found [here](https://spec.openapis.org/oas/v3.0.3).
+//! Full specification can be found [here](https://spec.openapis.org/oas/v3.0.4).
+//!
+//! # Intentional permissive deviations
+//!
+//! * `PathItem` accepts arbitrary HTTP method names (e.g. `search`, `trace`)
+//!   in addition to the closed `get/put/post/delete/options/head/patch/trace`
+//!   set defined in the spec.
+//! * `Schema` accepts a `null` type via `NullSchema`. OAS 3.0 has no `null`
+//!   type (the recommended idiom is `nullable: true` on a typed schema; `null`
+//!   was added as a real type in 3.1). Kept on purpose so v3.0 specs that
+//!   borrowed the 2020-12 idiom round-trip cleanly.
 pub mod callback;
 pub mod components;
 pub mod discriminator;
@@ -13,6 +23,7 @@ pub mod media_type;
 pub mod operation;
 pub mod parameter;
 pub mod path_item;
+pub mod reference;
 pub mod request_body;
 pub mod response;
 pub mod schema;
@@ -20,4 +31,5 @@ pub mod security_scheme;
 pub mod server;
 pub mod spec;
 pub mod tag;
+pub(crate) mod validation;
 pub mod xml;

--- a/src/v3_0/callback.rs
+++ b/src/v3_0/callback.rs
@@ -202,6 +202,37 @@ mod tests {
     }
 
     #[test]
+    fn callback_nested_operation_security_is_validated() {
+        // An operation inside a Callback path item must still have its
+        // `security` requirements checked. `validate_path_item` is only
+        // called for `Spec.paths`, so callback-nested operations rely on
+        // `Operation::validate_with_context` to invoke
+        // `validate_security_requirements` directly.
+        let cb: Callback = serde_json::from_value(json!({
+            "{$request.body#/url}": {
+                "post": {
+                    "responses": {"200": {"description": "ok"}},
+                    "security": [{"missing-scheme": []}]
+                }
+            }
+        }))
+        .unwrap();
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        cb.validate_with_context(&mut ctx, "cb".into());
+        // With no Components on the Spec, the validator surfaces a
+        // "no `components.securitySchemes`" error — proof the operation
+        // inside the callback ran security validation.
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("post.security") && e.contains("missing-scheme")),
+            "expected security validation inside callback: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
     fn empty_callback_round_trips() {
         let cb: Callback = serde_json::from_value(json!({})).unwrap();
         assert!(cb.paths.is_empty());

--- a/src/v3_0/callback.rs
+++ b/src/v3_0/callback.rs
@@ -137,3 +137,75 @@ impl ValidateWithContext<Spec> for Callback {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::validation::Options;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_paths_and_extensions() {
+        let v = json!({
+            "{$request.body#/callbackUrl}": {
+                "post": {"responses": {"200": {"description": "ok"}}}
+            },
+            "x-internal": "yes"
+        });
+        let cb: Callback = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(cb.paths.len(), 1);
+        assert!(cb.extensions.is_some());
+        assert_eq!(serde_json::to_value(&cb).unwrap(), v);
+    }
+
+    #[test]
+    fn duplicate_path_key_errors() {
+        // Multiple identical keys in JSON are last-wins on parsing, so
+        // construct via repeated keys explicitly through a string parse.
+        let raw = r#"{"a": {}, "a": {}}"#;
+        let res: Result<Callback, _> = serde_json::from_str(raw);
+        assert!(
+            res.is_err(),
+            "expected duplicate-field error, got: {:?}",
+            res.ok()
+        );
+    }
+
+    #[test]
+    fn duplicate_extension_key_errors() {
+        let raw = r#"{"x-foo": 1, "x-foo": 2}"#;
+        let res: Result<Callback, _> = serde_json::from_str(raw);
+        assert!(res.is_err(), "expected duplicate extension error");
+    }
+
+    #[test]
+    fn validate_walks_path_items() {
+        // PathItem with operation that has empty responses → triggers the
+        // "must declare at least one response" error in the new validator.
+        let cb: Callback = serde_json::from_value(json!({
+            "{$request.body#/cb}": {
+                "post": {"responses": {}}
+            }
+        }))
+        .unwrap();
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        cb.validate_with_context(&mut ctx, "cb".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must declare at least one response")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn empty_callback_round_trips() {
+        let cb: Callback = serde_json::from_value(json!({})).unwrap();
+        assert!(cb.paths.is_empty());
+        assert!(cb.extensions.is_none());
+        assert_eq!(serde_json::to_value(&cb).unwrap(), json!({}));
+    }
+}

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -1,12 +1,12 @@
 //! Holds a set of reusable objects for different aspects of the OAS.
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_string_matches};
-use crate::v3_0::reference::RefOr;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::example::Example;
 use crate::v3_0::header::Header;
 use crate::v3_0::link::Link;
 use crate::v3_0::parameter::Parameter;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::request_body::RequestBody;
 use crate::v3_0::response::Response;
 use crate::v3_0::schema::Schema;
@@ -211,8 +211,8 @@ mod tests {
     use crate::v3_0::response::Response;
     use crate::v3_0::schema::{Schema, SingleSchema, StringSchema};
     use crate::v3_0::security_scheme::{
-        AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, ImplicitOAuth2Flow,
-        OAuth2Flows, OAuth2SecurityScheme, PasswordOAuth2Flow, SecurityScheme,
+        AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, ImplicitOAuth2Flow, OAuth2Flows,
+        OAuth2SecurityScheme, PasswordOAuth2Flow, SecurityScheme,
     };
     use serde_json::json;
 
@@ -243,23 +243,29 @@ mod tests {
     #[test]
     fn unused_components_each_kind_reports() {
         let comp = Components {
-            schemas: Some(map_with("S", Schema::Single(Box::new(SingleSchema::String(StringSchema::default()))))),
+            schemas: Some(map_with(
+                "S",
+                Schema::Single(Box::new(SingleSchema::String(StringSchema::default()))),
+            )),
             responses: Some(map_with("R", Response::default())),
-            parameters: Some(map_with("P", Parameter::Query(InQuery {
-                name: "q".into(),
-                description: None,
-                required: None,
-                deprecated: None,
-                allow_empty_value: None,
-                style: None,
-                explode: None,
-                allow_reserved: None,
-                schema: None,
-                example: None,
-                examples: None,
-                content: None,
-                extensions: None,
-            }))),
+            parameters: Some(map_with(
+                "P",
+                Parameter::Query(InQuery {
+                    name: "q".into(),
+                    description: None,
+                    required: None,
+                    deprecated: None,
+                    allow_empty_value: None,
+                    style: None,
+                    explode: None,
+                    allow_reserved: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                }),
+            )),
             examples: Some(map_with("E", Example::default())),
             request_bodies: Some(map_with("RB", RequestBody::default())),
             headers: Some(map_with("H", Header::default())),
@@ -344,7 +350,10 @@ mod tests {
     #[test]
     fn ignored_unused_options_silence_each_kind() {
         let comp = Components {
-            schemas: Some(map_with("S", Schema::Single(Box::new(SingleSchema::String(StringSchema::default()))))),
+            schemas: Some(map_with(
+                "S",
+                Schema::Single(Box::new(SingleSchema::String(StringSchema::default()))),
+            )),
             responses: Some(map_with("R", Response::default())),
             parameters: Some(map_with(
                 "P",
@@ -398,7 +407,9 @@ mod tests {
         let mut schemas: BTreeMap<String, RefOr<Schema>> = BTreeMap::new();
         schemas.insert(
             "bad name".to_owned(),
-            RefOr::new_item(Schema::Single(Box::new(SingleSchema::String(StringSchema::default())))),
+            RefOr::new_item(Schema::Single(Box::new(SingleSchema::String(
+                StringSchema::default(),
+            )))),
         );
         let comp = Components {
             schemas: Some(schemas),

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -197,3 +197,223 @@ impl ValidateWithContext<Spec> for Components {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::v3_0::callback::Callback;
+    use crate::v3_0::example::Example;
+    use crate::v3_0::header::Header;
+    use crate::v3_0::link::Link;
+    use crate::v3_0::parameter::{InQuery, Parameter};
+    use crate::v3_0::request_body::RequestBody;
+    use crate::v3_0::response::Response;
+    use crate::v3_0::schema::{Schema, SingleSchema, StringSchema};
+    use crate::v3_0::security_scheme::{
+        AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, ImplicitOAuth2Flow,
+        OAuth2Flows, OAuth2SecurityScheme, PasswordOAuth2Flow, SecurityScheme,
+    };
+    use serde_json::json;
+
+    fn map_with<T>(name: &str, t: T) -> BTreeMap<String, RefOr<T>> {
+        BTreeMap::from([(name.to_owned(), RefOr::new_item(t))])
+    }
+
+    #[test]
+    fn round_trip_all_kinds() {
+        let v = json!({
+            "schemas": {"S": {"type": "string"}},
+            "responses": {"R": {"description": "ok"}},
+            "parameters": {"P": {"name": "q", "in": "query", "schema": {"type": "string"}}},
+            "examples": {"E": {"value": 1}},
+            "requestBodies": {"RB": {"content": {"application/json": {"schema": {"type": "object"}}}}},
+            "headers": {"H": {"description": "h"}},
+            "securitySchemes": {"SS": {"type": "http", "scheme": "Basic"}},
+            "links": {"L": {"operationId": "op"}},
+            "callbacks": {"CB": {"{$request.body#/cb}": {"post": {"responses": {"200": {"description": "ok"}}}}}},
+            "x-tra": "yes"
+        });
+        let comp: Components = serde_json::from_value(v.clone()).unwrap();
+        // Round-trip preserves all maps.
+        let re: Components = serde_json::from_value(serde_json::to_value(&comp).unwrap()).unwrap();
+        assert_eq!(re, comp);
+    }
+
+    #[test]
+    fn unused_components_each_kind_reports() {
+        let comp = Components {
+            schemas: Some(map_with("S", Schema::Single(Box::new(SingleSchema::String(StringSchema::default()))))),
+            responses: Some(map_with("R", Response::default())),
+            parameters: Some(map_with("P", Parameter::Query(InQuery {
+                name: "q".into(),
+                description: None,
+                required: None,
+                deprecated: None,
+                allow_empty_value: None,
+                style: None,
+                explode: None,
+                allow_reserved: None,
+                schema: None,
+                example: None,
+                examples: None,
+                content: None,
+                extensions: None,
+            }))),
+            examples: Some(map_with("E", Example::default())),
+            request_bodies: Some(map_with("RB", RequestBody::default())),
+            headers: Some(map_with("H", Header::default())),
+            security_schemes: Some(map_with(
+                "SS",
+                SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
+                    flows: OAuth2Flows {
+                        implicit: Some(ImplicitOAuth2Flow {
+                            authorization_url: "https://x.example/auth".into(),
+                            refresh_url: None,
+                            scopes: BTreeMap::from([("read".to_owned(), "Read".to_owned())]),
+                            extensions: None,
+                        }),
+                        password: Some(PasswordOAuth2Flow {
+                            token_url: "https://x.example/t".into(),
+                            refresh_url: None,
+                            scopes: BTreeMap::from([("write".to_owned(), "Write".to_owned())]),
+                            extensions: None,
+                        }),
+                        client_credentials: Some(ClientCredentialsOAuth2Flow {
+                            token_url: "https://x.example/t".into(),
+                            refresh_url: None,
+                            scopes: BTreeMap::from([("admin".to_owned(), "Admin".to_owned())]),
+                            extensions: None,
+                        }),
+                        authorization_code: Some(AuthorizationCodeOAuth2Flow {
+                            authorization_url: "https://x.example/auth".into(),
+                            token_url: "https://x.example/t".into(),
+                            refresh_url: None,
+                            scopes: BTreeMap::from([("delete".to_owned(), "Delete".to_owned())]),
+                            extensions: None,
+                        }),
+                        extensions: None,
+                    },
+                    description: None,
+                    extensions: None,
+                })),
+            )),
+            links: Some(map_with("L", Link::default())),
+            callbacks: Some(map_with("CB", Callback::default())),
+            extensions: None,
+        };
+        let spec = Spec {
+            components: Some(comp.clone()),
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        comp.validate_with_context(&mut ctx, "#.components".into());
+        // Each kind should produce an "unused" error.
+        for path in [
+            "#/components/schemas/S",
+            "#/components/responses/R",
+            "#/components/parameters/P",
+            "#/components/examples/E",
+            "#/components/requestBodies/RB",
+            "#/components/headers/H",
+            "#/components/securitySchemes/SS",
+            "#/components/links/L",
+            "#/components/callbacks/CB",
+        ] {
+            assert!(
+                ctx.errors
+                    .iter()
+                    .any(|e| e.contains(path) && e.contains("unused")),
+                "expected `{path}: unused`: {:?}",
+                ctx.errors
+            );
+        }
+        // OAuth2 unused-scope detection now visits ALL four flows.
+        for scope in ["read", "write", "admin", "delete"] {
+            let p = format!("#/components/securitySchemes/SS/{scope}");
+            assert!(
+                ctx.errors
+                    .iter()
+                    .any(|e| e.contains(&p) && e.contains("unused")),
+                "expected unused scope `{scope}`: {:?}",
+                ctx.errors
+            );
+        }
+    }
+
+    #[test]
+    fn ignored_unused_options_silence_each_kind() {
+        let comp = Components {
+            schemas: Some(map_with("S", Schema::Single(Box::new(SingleSchema::String(StringSchema::default()))))),
+            responses: Some(map_with("R", Response::default())),
+            parameters: Some(map_with(
+                "P",
+                Parameter::Query(InQuery {
+                    name: "q".into(),
+                    description: None,
+                    required: None,
+                    deprecated: None,
+                    allow_empty_value: None,
+                    style: None,
+                    explode: None,
+                    allow_reserved: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                }),
+            )),
+            examples: Some(map_with("E", Example::default())),
+            request_bodies: Some(map_with("RB", RequestBody::default())),
+            headers: Some(map_with("H", Header::default())),
+            security_schemes: None,
+            links: Some(map_with("L", Link::default())),
+            callbacks: Some(map_with("CB", Callback::default())),
+            extensions: None,
+        };
+        let spec = Spec {
+            components: Some(comp.clone()),
+            ..Default::default()
+        };
+        let opts = Options::IgnoreUnusedSchemas
+            | Options::IgnoreUnusedResponses
+            | Options::IgnoreUnusedParameters
+            | Options::IgnoreUnusedExamples
+            | Options::IgnoreUnusedRequestBodies
+            | Options::IgnoreUnusedHeaders
+            | Options::IgnoreUnusedLinks
+            | Options::IgnoreUnusedCallbacks;
+        let mut ctx = Context::new(&spec, opts);
+        comp.validate_with_context(&mut ctx, "#.components".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("unused")),
+            "no unused errors when ignored: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn invalid_component_name_reported() {
+        let mut schemas: BTreeMap<String, RefOr<Schema>> = BTreeMap::new();
+        schemas.insert(
+            "bad name".to_owned(),
+            RefOr::new_item(Schema::Single(Box::new(SingleSchema::String(StringSchema::default())))),
+        );
+        let comp = Components {
+            schemas: Some(schemas),
+            ..Default::default()
+        };
+        let spec = Spec {
+            components: Some(comp.clone()),
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&spec, Options::IgnoreUnusedSchemas.only());
+        comp.validate_with_context(&mut ctx, "#.components".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must match pattern")),
+            "expected pattern error: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -1,7 +1,7 @@
 //! Holds a set of reusable objects for different aspects of the OAS.
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_string_matches};
-use crate::common::reference::RefOr;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::example::Example;
 use crate::v3_0::header::Header;
@@ -147,16 +147,28 @@ impl ValidateWithContext<Spec> for Components {
                 }
                 validate_string_matches(name, re, ctx, format!("{path}.securitySchemes[<name>]"));
                 obj.validate_with_context(ctx, format!("{path}.securitySchemes[{name}]"));
-                if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec)
-                    && let Some(flow) = &oauth2.flows.implicit
-                {
-                    for scope in flow.scopes.keys() {
-                        let reference = format!("{reference}/{scope}");
-                        if !ctx.is_visited(&reference)
-                            && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
-                        {
-                            ctx.error(reference, "unused");
+                if let Ok(SecurityScheme::OAuth2(oauth2)) = obj.get_item(ctx.spec) {
+                    let mut check_unused = |scopes: &BTreeMap<String, String>| {
+                        for scope in scopes.keys() {
+                            let reference = format!("{reference}/{scope}");
+                            if !ctx.is_visited(&reference)
+                                && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes)
+                            {
+                                ctx.error(reference, "unused");
+                            }
                         }
+                    };
+                    if let Some(flow) = &oauth2.flows.implicit {
+                        check_unused(&flow.scopes);
+                    }
+                    if let Some(flow) = &oauth2.flows.password {
+                        check_unused(&flow.scopes);
+                    }
+                    if let Some(flow) = &oauth2.flows.client_credentials {
+                        check_unused(&flow.scopes);
+                    }
+                    if let Some(flow) = &oauth2.flows.authorization_code {
+                        check_unused(&flow.scopes);
                     }
                 }
             }

--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -36,3 +36,74 @@ impl ValidateWithContext<Spec> for Discriminator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::v3_0::schema::{ObjectSchema, SingleSchema};
+    use crate::validation::Options;
+
+    #[test]
+    fn round_trip_with_mapping() {
+        let json = serde_json::json!({
+            "propertyName": "type",
+            "mapping": {
+                "cat": "Cat",
+                "dog": "Dog",
+            },
+        });
+        let d: Discriminator = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(d.property_name, "type");
+        assert_eq!(d.mapping.as_ref().unwrap().len(), 2);
+        assert_eq!(serde_json::to_value(&d).unwrap(), json);
+    }
+
+    #[test]
+    fn round_trip_property_only() {
+        let json = serde_json::json!({"propertyName": "kind"});
+        let d: Discriminator = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(d.mapping, None);
+        assert_eq!(serde_json::to_value(&d).unwrap(), json);
+    }
+
+    #[test]
+    fn validate_empty_property_name() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Discriminator::default().validate_with_context(&mut ctx, "d".to_owned());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("propertyName") && e.contains("must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_mapping_resolves() {
+        let mut spec = Spec::default();
+        spec.define_schema("Cat", SingleSchema::from(ObjectSchema::default()))
+            .unwrap();
+        let d = Discriminator {
+            property_name: "type".into(),
+            mapping: Some(BTreeMap::from([
+                ("cat".to_owned(), "Cat".to_owned()),
+                ("missing".to_owned(), "Missing".to_owned()),
+            ])),
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        d.validate_with_context(&mut ctx, "d".to_owned());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("Missing") && e.contains("not found")),
+            "expected missing schema reported: {:?}",
+            ctx.errors
+        );
+        assert!(
+            !ctx.errors.iter().any(|e| e.contains("schemas/Cat") && e.contains("not found")),
+            "Cat must resolve: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -96,12 +96,16 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         d.validate_with_context(&mut ctx, "d".to_owned());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("Missing") && e.contains("not found")),
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("Missing") && e.contains("not found")),
             "expected missing schema reported: {:?}",
             ctx.errors
         );
         assert!(
-            !ctx.errors.iter().any(|e| e.contains("schemas/Cat") && e.contains("not found")),
+            !ctx.errors
+                .iter()
+                .any(|e| e.contains("schemas/Cat") && e.contains("not found")),
             "Cat must resolve: {:?}",
             ctx.errors
         );

--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -1,7 +1,7 @@
 //! Discriminator Object
 
 use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
-use crate::common::reference::RefOr;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
 use serde::{Deserialize, Serialize};

--- a/src/v3_0/example.rs
+++ b/src/v3_0/example.rs
@@ -91,9 +91,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors
-                .iter()
-                .any(|e| e.contains("mutually exclusive")),
+            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/example.rs
+++ b/src/v3_0/example.rs
@@ -52,3 +52,66 @@ impl ValidateWithContext<Spec> for Example {
         validate_optional_url(&self.external_value, ctx, format!("{path}.externalValue"));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::validation::Options;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_with_value() {
+        let v = json!({
+            "summary": "Cat",
+            "description": "An example cat",
+            "value": {"name": "Fluffy"}
+        });
+        let e: Example = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&e).unwrap(), v);
+    }
+
+    #[test]
+    fn round_trip_with_external_value() {
+        let v = json!({
+            "externalValue": "https://example.com/example.json"
+        });
+        let e: Example = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&e).unwrap(), v);
+    }
+
+    #[test]
+    fn xor_value_and_external_errors() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Example {
+            value: Some(json!(1)),
+            external_value: Some("https://example.com/x.json".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "ex".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("mutually exclusive")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn external_value_url_validated() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Example {
+            external_value: Some("not-a-url".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "ex".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -84,8 +84,12 @@ impl ValidateWithContext<Spec> for Header {
         if self.example.is_some() && self.examples.is_some() {
             ctx.error(path.clone(), "example and examples are mutually exclusive");
         }
-        if self.schema.is_some() && self.content.is_some() {
-            ctx.error(path.clone(), "schema and content are mutually exclusive");
+        // Spec: a Header MUST contain either `schema` or `content` (the same
+        // exactly-one rule as a Parameter).
+        match (self.schema.is_some(), self.content.is_some()) {
+            (true, true) => ctx.error(path.clone(), "schema and content are mutually exclusive"),
+            (false, false) => ctx.error(path.clone(), "must define either `schema` or `content`"),
+            _ => {}
         }
         if let Some(examples) = &self.examples {
             for (k, v) in examples {
@@ -176,6 +180,20 @@ mod tests {
             ctx.errors
                 .iter()
                 .any(|e| e.contains("must contain exactly one media type entry")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn header_must_define_schema_or_content() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Header::default().validate_with_context(&mut ctx, "h".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must define either `schema` or `content`")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -1,10 +1,10 @@
 //! Header Object
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
-use crate::v3_0::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::parameter::InHeaderStyle;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
 use serde::{Deserialize, Serialize};
@@ -156,7 +156,9 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "h".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("example and examples")),
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("example and examples")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -1,7 +1,7 @@
 //! Header Object
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
-use crate::common::reference::RefOr;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::parameter::InHeaderStyle;
@@ -93,6 +93,15 @@ impl ValidateWithContext<Spec> for Header {
             }
         }
         if let Some(content) = &self.content {
+            if content.len() != 1 {
+                ctx.error(
+                    path.clone(),
+                    format_args!(
+                        ".content: must contain exactly one media type entry, found {}",
+                        content.len()
+                    ),
+                );
+            }
             for (k, v) in content {
                 v.validate_with_context(ctx, format!("{path}.content[{k}]"));
             }

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -143,6 +143,68 @@ mod tests {
     }
 
     #[test]
+    fn validate_example_examples_xor_and_content_size() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Header {
+            example: Some(serde_json::json!(1)),
+            examples: Some(BTreeMap::from([(
+                "a".into(),
+                RefOr::new_item(crate::v3_0::example::Example::default()),
+            )])),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "h".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("example and examples")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        let mut content = BTreeMap::new();
+        content.insert("application/json".to_owned(), MediaType::default());
+        content.insert("text/plain".to_owned(), MediaType::default());
+        Header {
+            content: Some(content),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "h".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must contain exactly one media type entry")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_schema_and_content_mutex() {
+        use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Header {
+            schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                SingleSchema::Object(ObjectSchema::default()),
+            )))),
+            content: Some(BTreeMap::from([(
+                "application/json".to_owned(),
+                MediaType::default(),
+            )])),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "h".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("schema and content are mutually exclusive")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
     fn test_header_serialize() {
         assert_eq!(
             serde_json::to_value(Header {

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -2,6 +2,7 @@
 
 use crate::common::helpers::{
     Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
+    validate_required_url,
 };
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
@@ -52,6 +53,11 @@ pub struct Info {
     /// **Required** The version of the OpenAPI document
     /// (which is distinct from the OpenAPI Specification version or the API implementation version).
     pub version: String,
+
+    /// ReDoc/Redocly extension that configures the API logo in generated documentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-logo")]
+    pub x_logo: Option<Logo>,
 
     /// This object MAY be extended with Specification Extensions.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
@@ -125,6 +131,32 @@ pub struct License {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+/// ReDoc/Redocly `x-logo` extension object.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Logo {
+    /// **Required** URL pointing to the logo image.
+    pub url: String,
+
+    /// Optional background color, commonly a hex RGB value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_color: Option<String>,
+
+    /// Optional alt text for the logo image.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt_text: Option<String>,
+
+    /// Optional link target for the logo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub href: Option<String>,
+
+    /// Allows extensions on the logo extension object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
 impl ValidateWithContext<Spec> for Info {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         if !ctx.is_option(Options::IgnoreEmptyInfoTitle) {
@@ -141,6 +173,10 @@ impl ValidateWithContext<Spec> for Info {
         if let Some(license) = &self.license {
             license.validate_with_context(ctx, format!("{path}.license"));
         }
+
+        if let Some(logo) = &self.x_logo {
+            logo.validate_with_context(ctx, format!("{path}.x-logo"));
+        }
     }
 }
 
@@ -155,6 +191,14 @@ impl ValidateWithContext<Spec> for License {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         validate_required_string(&self.name, ctx, format!("{path}.name"));
         validate_optional_url(&self.url, ctx, format!("{path}.url"));
+    }
+}
+
+impl ValidateWithContext<Spec> for Logo {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // Single helper: empties → "must not be empty", non-URLs → "must be a valid URL".
+        validate_required_url(&self.url, ctx, format!("{path}.url"));
+        validate_optional_url(&self.href, ctx, format!("{path}.href"));
     }
 }
 
@@ -562,5 +606,43 @@ mod tests {
         }
         .validate_with_context(&mut ctx, String::from("info"));
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn x_logo_round_trip_and_validate() {
+        let info: Info = serde_json::from_value(json!({
+            "title": "Swagger Sample App",
+            "version": "1.0.1",
+            "x-logo": {
+                "url": "https://example.com/logo.svg",
+                "altText": "Example",
+                "backgroundColor": "#ffffff",
+                "href": "https://example.com"
+            }
+        }))
+        .unwrap();
+        assert_eq!(
+            info.x_logo,
+            Some(Logo {
+                url: "https://example.com/logo.svg".to_owned(),
+                alt_text: Some("Example".to_owned()),
+                background_color: Some("#ffffff".to_owned()),
+                href: Some("https://example.com".to_owned()),
+                extensions: None,
+            })
+        );
+
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        info.validate_with_context(&mut ctx, "info".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Logo::default().validate_with_context(&mut ctx, "logo".to_owned());
+        assert!(
+            ctx.errors.contains(&"logo.url: must not be empty".to_owned()),
+            "expected empty URL error: {:?}",
+            ctx.errors
+        );
     }
 }

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -640,7 +640,8 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         Logo::default().validate_with_context(&mut ctx, "logo".to_owned());
         assert!(
-            ctx.errors.contains(&"logo.url: must not be empty".to_owned()),
+            ctx.errors
+                .contains(&"logo.url: must not be empty".to_owned()),
             "expected empty URL error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -29,7 +29,6 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Info {
     /// **Required** The title of the API.
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub title: String,
 
     /// A short description of the API.
@@ -52,7 +51,6 @@ pub struct Info {
 
     /// **Required** The version of the OpenAPI document
     /// (which is distinct from the OpenAPI Specification version or the API implementation version).
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub version: String,
 
     /// This object MAY be extended with Specification Extensions.
@@ -323,9 +321,12 @@ mod tests {
             }),
             "serialize",
         );
+        // `title` and `version` are required fields per OAS 3.0; we no longer
+        // skip them when empty so `Info::default` round-trips with explicit
+        // empty strings.
         assert_eq!(
             serde_json::to_value(Info::default()).unwrap(),
-            json!({}),
+            json!({"title": "", "version": ""}),
             "serialize",
         );
     }

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -95,3 +95,92 @@ impl ValidateWithContext<Spec> for Link {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::validation::Options;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_full() {
+        let v = json!({
+            "operationId": "getPet",
+            "parameters": {"id": "$response.body#/id"},
+            "requestBody": {"name": "fluffy"},
+            "description": "Linked",
+            "server": {"url": "https://example.com"},
+            "x-internal": true
+        });
+        let l: Link = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&l).unwrap(), v);
+    }
+
+    #[test]
+    fn xor_both_present_errors() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("ref".into()),
+            operation_id: Some("id".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn xor_neither_errors() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link::default().validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must specify exactly one")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn missing_operation_id_reported() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_id: Some("nonexistent".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("missing operation with id `nonexistent`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn server_validates() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("opref".into()),
+            server: Some(crate::v3_0::server::Server {
+                url: "".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("server.url")),
+            "expected server.url error: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -5,7 +5,7 @@ use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Decode one JSON Pointer reference token (`~1` → `/`, `~0` → `~`).
 fn unescape_pointer_token(token: &str) -> String {
@@ -29,15 +29,6 @@ enum OperationRefResolution {
 
 /// Resolve an internal `#/paths/...` operationRef against `Spec.paths`.
 ///
-/// Per OAS 3.0.4 a PathItem may itself be a `$ref` to another PathItem; in
-/// that case `operations` on the referencing entry is empty and the methods
-/// live on the target. We follow one hop of `PathItem.reference` for
-/// internal refs so an operationRef like `#/paths/~1pets/get` still
-/// validates when `/pets` is `{ "$ref": "#/paths/~1other" }`.
-///
-/// Multi-hop chains are not followed: spec paths cycles are unusual, and
-/// the next hop's target would itself need to be a non-ref PathItem to
-/// declare any operations.
 fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> OperationRefResolution {
     let after = match reference.strip_prefix("#/paths/") {
         Some(rest) => rest,
@@ -70,25 +61,11 @@ fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> OperationRefR
         return OperationRefResolution::Err(format!("path `{path}` not declared in `#/paths`"));
     };
 
-    // If the resolved PathItem is itself a `$ref`, follow it once.
-    let target_item = if let Some(ref_str) = &item.reference {
-        if let Some(after_paths) = ref_str.strip_prefix("#/paths/") {
-            let target_path = unescape_pointer_token(after_paths);
-            match spec.paths.paths.get(&target_path) {
-                Some(t) => t,
-                None => {
-                    return OperationRefResolution::Err(format!(
-                        "path `{path}` is a `$ref` to `{ref_str}`, which is not declared in `#/paths`"
-                    ));
-                }
-            }
-        } else if ref_str.is_empty() {
-            return OperationRefResolution::Err(format!("path `{path}` carries an empty `$ref`"));
-        } else {
-            return OperationRefResolution::ExternalPathItemRef(ref_str.clone());
-        }
-    } else {
-        item
+    let mut seen = BTreeSet::from([path.clone()]);
+    let (target_path, target_item) = match resolve_path_item_ref_chain(spec, &path, item, &mut seen)
+    {
+        Ok(target) => target,
+        Err(err) => return err,
     };
 
     let method_lower = method.to_lowercase();
@@ -98,10 +75,54 @@ fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> OperationRefR
         .is_some_and(|m| m.contains_key(&method_lower));
     if !exists {
         return OperationRefResolution::Err(format!(
-            "method `{method}` not declared on path `{path}`"
+            "method `{method}` not declared on path `{target_path}`"
         ));
     }
     OperationRefResolution::Ok
+}
+
+/// Follow internal PathItem `$ref` chains so operationRef validation checks
+/// the operation-bearing target, while reporting external refs and cycles.
+fn resolve_path_item_ref_chain<'a>(
+    spec: &'a Spec,
+    path: &str,
+    item: &'a crate::v3_0::path_item::PathItem,
+    seen: &mut BTreeSet<String>,
+) -> Result<(String, &'a crate::v3_0::path_item::PathItem), OperationRefResolution> {
+    let Some(ref_str) = &item.reference else {
+        return Ok((path.to_owned(), item));
+    };
+
+    if ref_str.is_empty() {
+        return Err(OperationRefResolution::Err(format!(
+            "path `{path}` carries an empty `$ref`"
+        )));
+    }
+
+    let Some(after_paths) = ref_str.strip_prefix("#/paths/") else {
+        return Err(OperationRefResolution::ExternalPathItemRef(ref_str.clone()));
+    };
+
+    if after_paths.contains('/') {
+        return Err(OperationRefResolution::Err(format!(
+            "path `{path}` is a `$ref` to malformed JSON Pointer `{ref_str}`: the encoded path token must use `~1` for `/`"
+        )));
+    }
+
+    let target_path = unescape_pointer_token(after_paths);
+    if !seen.insert(target_path.clone()) {
+        return Err(OperationRefResolution::Err(format!(
+            "path `{path}` has a cyclic `$ref` chain through `{ref_str}`"
+        )));
+    }
+
+    let Some(target_item) = spec.paths.paths.get(&target_path) else {
+        return Err(OperationRefResolution::Err(format!(
+            "path `{path}` is a `$ref` to `{ref_str}`, which is not declared in `#/paths`"
+        )));
+    };
+
+    resolve_path_item_ref_chain(spec, &target_path, target_item, seen)
 }
 
 /// The Link object represents a possible design-time link for a response.
@@ -536,6 +557,102 @@ mod tests {
         assert!(
             ctx.errors.iter().any(|e| e.contains("method `post`")),
             "expected unknown method on resolved target: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_follows_multi_hop_internal_path_item_ref() {
+        use crate::v3_0::operation::Operation;
+        use crate::v3_0::path_item::{PathItem, Paths};
+        use crate::v3_0::reference::RefOr;
+        use crate::v3_0::response::{Response, Responses};
+
+        let op = Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".to_owned(), op);
+        let canonical_item = PathItem {
+            operations: Some(ops),
+            ..Default::default()
+        };
+        let mut paths = Paths::default();
+        paths.paths.insert("/canonical".to_owned(), canonical_item);
+        paths.paths.insert(
+            "/middle".to_owned(),
+            PathItem {
+                reference: Some("#/paths/~1canonical".into()),
+                ..Default::default()
+            },
+        );
+        paths.paths.insert(
+            "/pets".to_owned(),
+            PathItem {
+                reference: Some("#/paths/~1middle".into()),
+                ..Default::default()
+            },
+        );
+        let spec = Spec {
+            paths,
+            ..Default::default()
+        };
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            "multi-hop PathItem ref should resolve: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_path_item_ref_cycle_errors() {
+        use crate::v3_0::path_item::{PathItem, Paths};
+
+        let mut paths = Paths::default();
+        paths.paths.insert(
+            "/a".to_owned(),
+            PathItem {
+                reference: Some("#/paths/~1b".into()),
+                ..Default::default()
+            },
+        );
+        paths.paths.insert(
+            "/b".to_owned(),
+            PathItem {
+                reference: Some("#/paths/~1a".into()),
+                ..Default::default()
+            },
+        );
+        let spec = Spec {
+            paths,
+            ..Default::default()
+        };
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1a/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".operationRef") && e.contains("cyclic `$ref` chain")),
+            "expected PathItem ref cycle error: {:?}",
             ctx.errors
         );
     }

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -3,8 +3,52 @@
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
+use crate::validation::Options;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+
+/// Decode one JSON Pointer reference token (`~1` → `/`, `~0` → `~`).
+fn unescape_pointer_token(token: &str) -> String {
+    // Per RFC 6901, `~1` decodes to `/` and `~0` decodes to `~`. Order
+    // matters: a literal `~01` must round-trip to `~1`, so substitute
+    // `~1` first then `~0`.
+    token.replace("~1", "/").replace("~0", "~")
+}
+
+/// Resolve an internal `#/paths/...` operationRef against `Spec.paths`.
+/// Returns `Ok(())` if the ref points to a defined Operation, `Err(message)`
+/// otherwise. Caller is expected to have already classified the ref as
+/// internal (starts with `#/`).
+fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> Result<(), String> {
+    let after = match reference.strip_prefix("#/paths/") {
+        Some(rest) => rest,
+        None => return Err(format!("must start with `#/paths/`, found `{reference}`")),
+    };
+    // Split on `/` once: the path token, then the method token.
+    let (path_token, method) = match after.rsplit_once('/') {
+        Some((p, m)) => (p, m),
+        None => {
+            return Err(format!(
+                "must point to `#/paths/<encoded path>/<method>`, found `{reference}`"
+            ));
+        }
+    };
+    let path = unescape_pointer_token(path_token);
+    let Some(item) = spec.paths.paths.get(&path) else {
+        return Err(format!("path `{path}` not declared in `#/paths`"));
+    };
+    let method_lower = method.to_lowercase();
+    let exists = item
+        .operations
+        .as_ref()
+        .is_some_and(|m| m.contains_key(&method_lower));
+    if !exists {
+        return Err(format!(
+            "method `{method}` not declared on path `{path}`"
+        ));
+    }
+    Ok(())
+}
 
 /// The Link object represents a possible design-time link for a response.
 /// The presence of a link does not guarantee the caller’s ability to successfully invoke it,
@@ -90,6 +134,30 @@ impl ValidateWithContext<Spec> for Link {
                 format_args!(".operationId: missing operation with id `{operation_id}`"),
             );
         }
+
+        // Validate operationRef points to an Operation.
+        // Internal refs (start with `#/`) MUST resolve. External refs are
+        // gated on `IgnoreExternalReferences`, mirroring `RefOr` behavior.
+        if let Some(operation_ref) = &self.operation_ref {
+            if operation_ref.is_empty() {
+                ctx.error(path.clone(), ".operationRef: must not be empty");
+            } else if operation_ref.starts_with("#/") {
+                if let Err(msg) = resolve_internal_operation_ref(ctx.spec, operation_ref) {
+                    ctx.error(
+                        path.clone(),
+                        format_args!(".operationRef: {msg}"),
+                    );
+                }
+            } else if !ctx.is_option(Options::IgnoreExternalReferences) {
+                ctx.error(
+                    path.clone(),
+                    format_args!(
+                        ".operationRef: external reference `{operation_ref}` is not supported"
+                    ),
+                );
+            }
+        }
+
         if let Some(server) = &self.server {
             server.validate_with_context(ctx, format!("{path}.server"));
         }
@@ -164,12 +232,44 @@ mod tests {
         );
     }
 
+    fn spec_with_pets_get() -> Spec {
+        // Build a spec containing GET /pets so internal operationRef tests
+        // have a valid target.
+        use crate::v3_0::operation::Operation;
+        use crate::v3_0::path_item::{PathItem, Paths};
+        use crate::v3_0::reference::RefOr;
+        use crate::v3_0::response::{Response, Responses};
+
+        let op = Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".to_owned(), op);
+        let item = PathItem {
+            operations: Some(ops),
+            ..Default::default()
+        };
+        let mut paths = Paths::default();
+        paths.paths.insert("/pets".to_owned(), item);
+        Spec {
+            paths,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn server_validates() {
-        let spec = Spec::default();
+        let spec = spec_with_pets_get();
         let mut ctx = Context::new(&spec, Options::new());
         Link {
-            operation_ref: Some("opref".into()),
+            operation_ref: Some("#/paths/~1pets/get".into()),
             server: Some(crate::v3_0::server::Server {
                 url: "".into(),
                 ..Default::default()
@@ -180,6 +280,168 @@ mod tests {
         assert!(
             ctx.errors.iter().any(|e| e.contains("server.url")),
             "expected server.url error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_internal_resolves() {
+        let spec = spec_with_pets_get();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            "valid ref should not error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_unknown_path_errors() {
+        let spec = spec_with_pets_get();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1users/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".operationRef") && e.contains("`/users` not declared")),
+            "expected unknown path: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_unknown_method_errors() {
+        let spec = spec_with_pets_get();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1pets/post".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".operationRef") && e.contains("method `post`")),
+            "expected unknown method: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_bad_prefix_errors() {
+        let spec = spec_with_pets_get();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/components/schemas/Foo".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".operationRef") && e.contains("must start with `#/paths/`")),
+            "expected bad-prefix error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_empty_errors() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".operationRef") && e.contains("must not be empty")),
+            "expected empty-ref error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_external_unsupported() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("https://example.com/spec.yaml#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("external reference") && e.contains("not supported")),
+            "expected external-unsupported error: {:?}",
+            ctx.errors
+        );
+
+        // Gating with IgnoreExternalReferences silences the error.
+        let mut ctx = Context::new(&spec, Options::IgnoreExternalReferences.only());
+        Link {
+            operation_ref: Some("https://example.com/spec.yaml#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("external reference")),
+            "with option, no external error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_tilde0_decodes_to_tilde() {
+        // RFC 6901: `~01` round-trips to `~1`. Here we register a path that
+        // contains a literal `~` and verify the decoder finds it.
+        use crate::v3_0::operation::Operation;
+        use crate::v3_0::path_item::{PathItem, Paths};
+        use crate::v3_0::reference::RefOr;
+        use crate::v3_0::response::{Response, Responses};
+        let op = Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".to_owned(), op);
+        let item = PathItem {
+            operations: Some(ops),
+            ..Default::default()
+        };
+        let mut paths = Paths::default();
+        paths.paths.insert("/~weird".to_owned(), item);
+        let spec = Spec {
+            paths,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1~0weird/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            "tilde-encoded ref should resolve: {:?}",
             ctx.errors
         );
     }

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -15,37 +15,85 @@ fn unescape_pointer_token(token: &str) -> String {
     token.replace("~1", "/").replace("~0", "~")
 }
 
+/// Outcome of attempting to resolve an internal `#/paths/...` operationRef.
+enum OperationRefResolution {
+    /// The ref resolves to a defined Operation.
+    Ok,
+    /// The ref is structurally invalid or its target path/method is missing.
+    Err(String),
+    /// The PathItem reached has a `$ref` that points outside this document;
+    /// we cannot inspect operations there. Caller decides whether that's an
+    /// error based on `IgnoreExternalReferences`.
+    ExternalPathItemRef(String),
+}
+
 /// Resolve an internal `#/paths/...` operationRef against `Spec.paths`.
-/// Returns `Ok(())` if the ref points to a defined Operation, `Err(message)`
-/// otherwise. Caller is expected to have already classified the ref as
-/// internal (starts with `#/`).
-fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> Result<(), String> {
+///
+/// Per OAS 3.0.4 a PathItem may itself be a `$ref` to another PathItem; in
+/// that case `operations` on the referencing entry is empty and the methods
+/// live on the target. We follow one hop of `PathItem.reference` for
+/// internal refs so an operationRef like `#/paths/~1pets/get` still
+/// validates when `/pets` is `{ "$ref": "#/paths/~1other" }`.
+///
+/// Multi-hop chains are not followed: spec paths cycles are unusual, and
+/// the next hop's target would itself need to be a non-ref PathItem to
+/// declare any operations.
+fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> OperationRefResolution {
     let after = match reference.strip_prefix("#/paths/") {
         Some(rest) => rest,
-        None => return Err(format!("must start with `#/paths/`, found `{reference}`")),
+        None => {
+            return OperationRefResolution::Err(format!(
+                "must start with `#/paths/`, found `{reference}`"
+            ));
+        }
     };
-    // Split on `/` once: the path token, then the method token.
     let (path_token, method) = match after.rsplit_once('/') {
         Some((p, m)) => (p, m),
         None => {
-            return Err(format!(
+            return OperationRefResolution::Err(format!(
                 "must point to `#/paths/<encoded path>/<method>`, found `{reference}`"
             ));
         }
     };
     let path = unescape_pointer_token(path_token);
     let Some(item) = spec.paths.paths.get(&path) else {
-        return Err(format!("path `{path}` not declared in `#/paths`"));
+        return OperationRefResolution::Err(format!("path `{path}` not declared in `#/paths`"));
     };
+
+    // If the resolved PathItem is itself a `$ref`, follow it once.
+    let target_item = if let Some(ref_str) = &item.reference {
+        if let Some(after_paths) = ref_str.strip_prefix("#/paths/") {
+            let target_path = unescape_pointer_token(after_paths);
+            match spec.paths.paths.get(&target_path) {
+                Some(t) => t,
+                None => {
+                    return OperationRefResolution::Err(format!(
+                        "path `{path}` is a `$ref` to `{ref_str}`, which is not declared in `#/paths`"
+                    ));
+                }
+            }
+        } else if ref_str.is_empty() {
+            return OperationRefResolution::Err(format!(
+                "path `{path}` carries an empty `$ref`"
+            ));
+        } else {
+            return OperationRefResolution::ExternalPathItemRef(ref_str.clone());
+        }
+    } else {
+        item
+    };
+
     let method_lower = method.to_lowercase();
-    let exists = item
+    let exists = target_item
         .operations
         .as_ref()
         .is_some_and(|m| m.contains_key(&method_lower));
     if !exists {
-        return Err(format!("method `{method}` not declared on path `{path}`"));
+        return OperationRefResolution::Err(format!(
+            "method `{method}` not declared on path `{path}`"
+        ));
     }
-    Ok(())
+    OperationRefResolution::Ok
 }
 
 /// The Link object represents a possible design-time link for a response.
@@ -136,12 +184,28 @@ impl ValidateWithContext<Spec> for Link {
         // Validate operationRef points to an Operation.
         // Internal refs (start with `#/`) MUST resolve. External refs are
         // gated on `IgnoreExternalReferences`, mirroring `RefOr` behavior.
+        // If the target PathItem itself is `$ref`-d to an external document,
+        // we likewise gate on `IgnoreExternalReferences`.
         if let Some(operation_ref) = &self.operation_ref {
             if operation_ref.is_empty() {
                 ctx.error(path.clone(), ".operationRef: must not be empty");
             } else if operation_ref.starts_with("#/") {
-                if let Err(msg) = resolve_internal_operation_ref(ctx.spec, operation_ref) {
-                    ctx.error(path.clone(), format_args!(".operationRef: {msg}"));
+                match resolve_internal_operation_ref(ctx.spec, operation_ref) {
+                    OperationRefResolution::Ok => {}
+                    OperationRefResolution::Err(msg) => {
+                        ctx.error(path.clone(), format_args!(".operationRef: {msg}"));
+                    }
+                    OperationRefResolution::ExternalPathItemRef(target)
+                        if !ctx.is_option(Options::IgnoreExternalReferences) =>
+                    {
+                        ctx.error(
+                            path.clone(),
+                            format_args!(
+                                ".operationRef: target PathItem is a `$ref` to external document `{target}`, which is not supported"
+                            ),
+                        );
+                    }
+                    OperationRefResolution::ExternalPathItemRef(_) => {}
                 }
             } else if !ctx.is_option(Options::IgnoreExternalReferences) {
                 ctx.error(
@@ -396,6 +460,147 @@ mod tests {
         assert!(
             ctx.errors.iter().all(|e| !e.contains("external reference")),
             "with option, no external error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_follows_internal_path_item_ref() {
+        // `/pets` is a PathItem `$ref` pointing at `/canonical-pets`, which
+        // declares `get`. The Link's operationRef `#/paths/~1pets/get` must
+        // resolve via the indirection.
+        use crate::v3_0::operation::Operation;
+        use crate::v3_0::path_item::{PathItem, Paths};
+        use crate::v3_0::reference::RefOr;
+        use crate::v3_0::response::{Response, Responses};
+
+        let op = Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut ops = BTreeMap::new();
+        ops.insert("get".to_owned(), op);
+        let canonical_item = PathItem {
+            operations: Some(ops),
+            ..Default::default()
+        };
+        let alias_item = PathItem {
+            reference: Some("#/paths/~1canonical-pets".into()),
+            ..Default::default()
+        };
+        let mut paths = Paths::default();
+        paths.paths.insert("/canonical-pets".to_owned(), canonical_item);
+        paths.paths.insert("/pets".to_owned(), alias_item);
+        let spec = Spec {
+            paths,
+            ..Default::default()
+        };
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            "ref-of-ref should resolve: {:?}",
+            ctx.errors
+        );
+
+        // Method that doesn't exist on the canonical target still fails,
+        // proving we resolved through the indirection (rather than just
+        // skipping the check).
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1pets/post".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("method `post`")),
+            "expected unknown method on resolved target: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_path_item_ref_target_missing() {
+        // `/pets` is a `$ref` to `/missing`, which doesn't exist.
+        use crate::v3_0::path_item::{PathItem, Paths};
+        let alias_item = PathItem {
+            reference: Some("#/paths/~1missing".into()),
+            ..Default::default()
+        };
+        let mut paths = Paths::default();
+        paths.paths.insert("/pets".to_owned(), alias_item);
+        let spec = Spec {
+            paths,
+            ..Default::default()
+        };
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("$ref") && e.contains("not declared")),
+            "expected dangling-target error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_external_path_item_ref() {
+        // `/pets` is a `$ref` to a path in another document. Without
+        // IgnoreExternalReferences, we error; with the option set, we let
+        // it pass.
+        use crate::v3_0::path_item::{PathItem, Paths};
+        let alias_item = PathItem {
+            reference: Some("https://other.example/spec.yaml#/paths/~1pets".into()),
+            ..Default::default()
+        };
+        let mut paths = Paths::default();
+        paths.paths.insert("/pets".to_owned(), alias_item);
+        let spec = Spec {
+            paths,
+            ..Default::default()
+        };
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("external document")),
+            "expected external-PathItem-ref error: {:?}",
+            ctx.errors
+        );
+
+        let mut ctx = Context::new(&spec, Options::IgnoreExternalReferences.only());
+        Link {
+            operation_ref: Some("#/paths/~1pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            "with option, no .operationRef error: {:?}",
             ctx.errors
         );
     }

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -73,9 +73,7 @@ fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> OperationRefR
                 }
             }
         } else if ref_str.is_empty() {
-            return OperationRefResolution::Err(format!(
-                "path `{path}` carries an empty `$ref`"
-            ));
+            return OperationRefResolution::Err(format!("path `{path}` carries an empty `$ref`"));
         } else {
             return OperationRefResolution::ExternalPathItemRef(ref_str.clone());
         }
@@ -495,7 +493,9 @@ mod tests {
             ..Default::default()
         };
         let mut paths = Paths::default();
-        paths.paths.insert("/canonical-pets".to_owned(), canonical_item);
+        paths
+            .paths
+            .insert("/canonical-pets".to_owned(), canonical_item);
         paths.paths.insert("/pets".to_owned(), alias_item);
         let spec = Spec {
             paths,
@@ -524,9 +524,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors
-                .iter()
-                .any(|e| e.contains("method `post`")),
+            ctx.errors.iter().any(|e| e.contains("method `post`")),
             "expected unknown method on resolved target: {:?}",
             ctx.errors
         );
@@ -585,9 +583,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors
-                .iter()
-                .any(|e| e.contains("external document")),
+            ctx.errors.iter().any(|e| e.contains("external document")),
             "expected external-PathItem-ref error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -47,11 +47,21 @@ fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> OperationRefR
             ));
         }
     };
-    let (path_token, method) = match after.rsplit_once('/') {
-        Some((p, m)) => (p, m),
-        None => {
+    // Per RFC 6901 the path is a single JSON Pointer reference token: `/`
+    // inside the path MUST be escaped as `~1`. So between `#/paths/` and the
+    // method there must be exactly one `/` separator. Refs like
+    // `#/paths//pets/get` (unescaped slash) are malformed and rejected here.
+    let slash_count = after.bytes().filter(|b| *b == b'/').count();
+    let (path_token, method) = match (slash_count, after.split_once('/')) {
+        (1, Some((p, m))) => (p, m),
+        (0, _) => {
             return OperationRefResolution::Err(format!(
                 "must point to `#/paths/<encoded path>/<method>`, found `{reference}`"
+            ));
+        }
+        _ => {
+            return OperationRefResolution::Err(format!(
+                "malformed JSON Pointer: the encoded path token must use `~1` for `/`, found `{reference}`"
             ));
         }
     };
@@ -597,6 +607,27 @@ mod tests {
         assert!(
             ctx.errors.iter().all(|e| !e.contains(".operationRef")),
             "with option, no .operationRef error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn operation_ref_unescaped_slash_in_path_token_is_malformed() {
+        // RFC 6901: a literal `/` inside a path token must be escaped as
+        // `~1`. The form `#/paths//pets/get` is malformed (two slashes
+        // between `#/paths/` and `get` make the path token ambiguous).
+        let spec = spec_with_pets_get();
+        let mut ctx = Context::new(&spec, Options::new());
+        Link {
+            operation_ref: Some("#/paths//pets/get".into()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "l".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("malformed JSON Pointer")),
+            "expected malformed-pointer error: {:?}",
             ctx.errors
         );
     }

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -66,6 +66,20 @@ pub struct Link {
 
 impl ValidateWithContext<Spec> for Link {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // Spec: a Link MUST identify the linked operation via operationRef
+        // or operationId, and the two are mutually exclusive.
+        match (&self.operation_ref, &self.operation_id) {
+            (Some(_), Some(_)) => ctx.error(
+                path.clone(),
+                "operationRef and operationId are mutually exclusive",
+            ),
+            (None, None) => ctx.error(
+                path.clone(),
+                "must specify exactly one of operationRef or operationId",
+            ),
+            _ => {}
+        }
+
         if let Some(operation_id) = &self.operation_id
             && !ctx
                 .visited

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -43,9 +43,7 @@ fn resolve_internal_operation_ref(spec: &Spec, reference: &str) -> Result<(), St
         .as_ref()
         .is_some_and(|m| m.contains_key(&method_lower));
     if !exists {
-        return Err(format!(
-            "method `{method}` not declared on path `{path}`"
-        ));
+        return Err(format!("method `{method}` not declared on path `{path}`"));
     }
     Ok(())
 }
@@ -143,10 +141,7 @@ impl ValidateWithContext<Spec> for Link {
                 ctx.error(path.clone(), ".operationRef: must not be empty");
             } else if operation_ref.starts_with("#/") {
                 if let Err(msg) = resolve_internal_operation_ref(ctx.spec, operation_ref) {
-                    ctx.error(
-                        path.clone(),
-                        format_args!(".operationRef: {msg}"),
-                    );
+                    ctx.error(path.clone(), format_args!(".operationRef: {msg}"));
                 }
             } else if !ctx.is_option(Options::IgnoreExternalReferences) {
                 ctx.error(
@@ -208,7 +203,9 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         Link::default().validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must specify exactly one")),
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must specify exactly one")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -1,10 +1,10 @@
 //! Provides schema and examples for the media type
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
-use crate::v3_0::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::header::Header;
 use crate::v3_0::parameter::InQueryStyle;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
 use serde::{Deserialize, Serialize};

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -203,3 +203,118 @@ impl ValidateWithContext<Spec> for Encoding {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::v3_0::header::Header;
+    use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::validation::Options;
+    use serde_json::json;
+
+    #[test]
+    fn media_type_round_trip() {
+        let v = json!({
+            "schema": {"type": "object"},
+            "example": {"a": 1},
+            "encoding": {
+                "field": {
+                    "contentType": "image/png, image/jpeg",
+                    "headers": {
+                        "X-Custom": {"description": "h"}
+                    },
+                    "style": "form",
+                    "explode": true,
+                    "allowReserved": false
+                }
+            },
+            "x-extra": "yes"
+        });
+        let mt: MediaType = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&mt).unwrap(), v);
+    }
+
+    #[test]
+    fn validate_example_examples_xor() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        let mut examples = BTreeMap::new();
+        examples.insert(
+            "a".to_owned(),
+            RefOr::new_item(crate::v3_0::example::Example::default()),
+        );
+        MediaType {
+            example: Some(json!("e")),
+            examples: Some(examples),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "mt".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_walks_schema_examples_encoding() {
+        let mut examples = BTreeMap::new();
+        examples.insert(
+            "ex1".to_owned(),
+            RefOr::new_item(crate::v3_0::example::Example {
+                value: Some(json!(1)),
+                external_value: Some("https://example.com/x.json".into()),
+                ..Default::default()
+            }),
+        );
+        let mut encoding = BTreeMap::new();
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "X-Bad".to_owned(),
+            RefOr::new_item(Header {
+                example: Some(json!(1)),
+                examples: Some(BTreeMap::from([(
+                    "a".into(),
+                    RefOr::new_item(crate::v3_0::example::Example::default()),
+                )])),
+                ..Default::default()
+            }),
+        );
+        encoding.insert(
+            "field".to_owned(),
+            Encoding {
+                content_type: None,
+                headers: Some(headers),
+                style: None,
+                explode: None,
+                allow_reserved: None,
+                extensions: None,
+            },
+        );
+        let mt = MediaType {
+            schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                SingleSchema::Object(ObjectSchema::default()),
+            )))),
+            examples: Some(examples),
+            encoding: Some(encoding),
+            ..Default::default()
+        };
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        mt.validate_with_context(&mut ctx, "mt".into());
+        // Should pick up nested example XOR + header example XOR.
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("examples[ex1]")),
+            "expected nested example error: {:?}",
+            ctx.errors
+        );
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("encoding[field].headers[X-Bad]")),
+            "expected nested header error: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -1,7 +1,7 @@
 //! Provides schema and examples for the media type
 
-use crate::common::helpers::{Context, ValidateWithContext};
-use crate::common::reference::RefOr;
+use crate::common::helpers::{Context, PushError, ValidateWithContext};
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::header::Header;
 use crate::v3_0::parameter::InQueryStyle;
@@ -175,6 +175,9 @@ pub struct Encoding {
 
 impl ValidateWithContext<Spec> for MediaType {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        if self.example.is_some() && self.examples.is_some() {
+            ctx.error(path.clone(), "example and examples are mutually exclusive");
+        }
         if let Some(schema) = &self.schema {
             schema.validate_with_context(ctx, format!("{path}.schema"));
         }

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -7,7 +7,6 @@ use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::parameter::Parameter;
 use crate::v3_0::request_body::RequestBody;
 use crate::v3_0::response::Responses;
-use crate::v3_0::security_scheme::SecurityScheme;
 use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
 use crate::v3_0::tag::Tag;
@@ -94,9 +93,65 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub servers: Option<Vec<Server>>,
 
+    /// ReDoc/Redocly extension with code samples associated with this operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-codeSamples")]
+    pub x_code_samples: Option<Vec<CodeSample>>,
+
+    /// ReDoc/Redocly extension with operation badges.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-badges")]
+    pub x_badges: Option<Vec<Badge>>,
+
+    /// Documentation extension with extra operation examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-examples")]
+    pub x_examples: Option<BTreeMap<String, serde_json::Value>>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// ReDoc/Redocly `x-codeSamples` extension entry.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct CodeSample {
+    /// **Required** Code sample language.
+    pub lang: String,
+
+    /// Optional display label for the language tab.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+
+    /// **Required** Code sample source code.
+    pub source: String,
+
+    /// Allows extensions on the code sample extension object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// ReDoc/Redocly `x-badges` extension entry.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Badge {
+    /// **Required** Badge text.
+    pub name: String,
+
+    /// Optional badge position supported by documentation renderers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<String>,
+
+    /// Optional badge color.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+
+    /// Allows extensions on the badge extension object.
     #[serde(flatten)]
     #[serde(with = "crate::common::extensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -141,6 +196,18 @@ impl ValidateWithContext<Spec> for Operation {
             }
         }
 
+        if let Some(samples) = &self.x_code_samples {
+            for (i, sample) in samples.iter().enumerate() {
+                sample.validate_with_context(ctx, format!("{path}.x-codeSamples[{i}]"));
+            }
+        }
+
+        if let Some(badges) = &self.x_badges {
+            for (i, badge) in badges.iter().enumerate() {
+                badge.validate_with_context(ctx, format!("{path}.x-badges[{i}]"));
+            }
+        }
+
         if let Some(callbacks) = &self.callbacks {
             for (k, v) in callbacks {
                 v.validate_with_context(ctx, format!("{path}.callbacks[{k}]"));
@@ -154,43 +221,153 @@ impl ValidateWithContext<Spec> for Operation {
             external_doc.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
 
-        if let Some(security) = &self.security {
-            for (i, security) in security.iter().enumerate() {
-                for (name, scopes) in security {
-                    let path = format!("{path}.security[{i}][{name}]");
-                    let reference = format!("#/components/securitySchemes/{name}");
-                    let spec_ref = RefOr::<SecurityScheme>::new_ref(reference.clone());
-                    spec_ref.validate_with_context(ctx, path.clone());
-                    if !scopes.is_empty()
-                        && let Ok(SecurityScheme::OAuth2(oauth2)) = spec_ref.get_item(ctx.spec)
-                    {
-                        for scope in scopes {
-                            ctx.visit(format!("{reference}/{scope}"));
-                            let mut found = false;
-                            if let Some(flow) = &oauth2.flows.implicit {
-                                found = found || flow.scopes.contains_key(scope)
-                            }
-                            if !found && let Some(flow) = &oauth2.flows.password {
-                                found = found || flow.scopes.contains_key(scope)
-                            }
-                            if !found && let Some(flow) = &oauth2.flows.client_credentials {
-                                found = found || flow.scopes.contains_key(scope)
-                            }
-                            if !found && let Some(flow) = &oauth2.flows.authorization_code {
-                                found = found || flow.scopes.contains_key(scope)
-                            }
-                            if !found {
-                                ctx.error(
-                                    path.clone(),
-                                    format_args!(
-                                        "scope `{scope}` not found in spec by reference `{reference}`"
-                                    ),
-                                );
-                            }
-                        }
-                    }
+        // Operation-level `security` is validated cross-cuttingly by
+        // `crate::v3_0::validation::validate_path_item` (called from
+        // `Spec::validate`) — that helper enforces the scope-by-scheme-type
+        // rule, walks all four OAuth2 flows, and reports missing schemes.
+    }
+}
+
+impl ValidateWithContext<Spec> for CodeSample {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        validate_required_string(&self.lang, ctx, format!("{path}.lang"));
+        validate_required_string(&self.source, ctx, format!("{path}.source"));
+    }
+}
+
+impl ValidateWithContext<Spec> for Badge {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::validation::Options;
+
+    #[test]
+    fn validate_walks_tags_servers_external_docs() {
+        // Build a Spec with one declared tag so the operation's
+        // `tags[0]` resolves; the second tag references a missing tag,
+        // covering the IgnoreMissingTags branch.
+        let spec = Spec {
+            tags: Some(vec![crate::v3_0::tag::Tag {
+                name: "pets".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        let op = Operation {
+            tags: Some(vec!["pets".into(), "".into(), "missing".into()]),
+            servers: Some(vec![crate::v3_0::server::Server {
+                url: "".into(),
+                ..Default::default()
+            }]),
+            external_docs: Some(crate::v3_0::external_documentation::ExternalDocumentation {
+                url: "".into(),
+                description: None,
+                extensions: None,
+            }),
+            responses: crate::v3_0::response::Responses {
+                default: Some(crate::v3_0::reference::RefOr::new_item(
+                    crate::v3_0::response::Response {
+                        description: "ok".into(),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut ctx = Context::new(&spec, Options::new());
+        op.validate_with_context(&mut ctx, "op".into());
+        // Empty tag string surfaces the required-string error.
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("op.tags[1]") && e.contains("must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
+        // Missing tag surfaces the not-found-in-spec error.
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("`missing` not found in spec")),
+            "errors: {:?}",
+            ctx.errors
+        );
+        // Server URL empty surfaces the per-server validator.
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("op.servers[0].url")),
+            "errors: {:?}",
+            ctx.errors
+        );
+        // ExternalDocs URL empty surfaces.
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("op.externalDocs.url")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // With IgnoreMissingTags, the missing-tag error is silenced.
+        let mut ctx = Context::new(&spec, Options::IgnoreMissingTags.only());
+        op.validate_with_context(&mut ctx, "op".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("not found in spec")),
+            "missing-tags should be silenced: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn documentation_extensions_round_trip_and_validate() {
+        let value = serde_json::json!({
+            "responses": {
+                "200": {
+                    "description": "OK"
+                }
+            },
+            "x-codeSamples": [
+                {
+                    "lang": "curl",
+                    "label": "cURL",
+                    "source": "curl https://example.com/pets"
+                }
+            ],
+            "x-badges": [
+                {
+                    "name": "Beta",
+                    "position": "before",
+                    "color": "purple"
+                }
+            ],
+            "x-examples": {
+                "request": {
+                    "id": 1
                 }
             }
-        }
+        });
+        let operation: Operation = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&operation).unwrap(), value);
+
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        operation.validate_with_context(&mut ctx, "operation".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        let mut ctx = Context::new(&spec, Options::new());
+        CodeSample::default().validate_with_context(&mut ctx, "sample".to_owned());
+        assert_eq!(ctx.errors.len(), 2, "expected lang/source errors");
+
+        let mut ctx = Context::new(&spec, Options::new());
+        Badge::default().validate_with_context(&mut ctx, "badge".to_owned());
+        assert_eq!(ctx.errors, vec!["badge.name: must not be empty"]);
     }
 }

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -221,10 +221,18 @@ impl ValidateWithContext<Spec> for Operation {
             external_doc.validate_with_context(ctx, format!("{path}.externalDocs"));
         }
 
-        // Operation-level `security` is validated cross-cuttingly by
-        // `crate::v3_0::validation::validate_path_item` (called from
-        // `Spec::validate`) — that helper enforces the scope-by-scheme-type
-        // rule, walks all four OAuth2 flows, and reports missing schemes.
+        // Operation-level `security`: validated here so it runs everywhere
+        // an Operation is reached (including operations nested inside
+        // `Callback` path items, which `validate_path_item` does not visit).
+        // The shared helper enforces the scope-by-scheme-type rule, walks
+        // all four OAuth2 flows, and reports missing schemes.
+        if let Some(sec) = &self.security {
+            crate::v3_0::validation::validate_security_requirements(
+                ctx,
+                &format!("{path}.security"),
+                sec,
+            );
+        }
     }
 }
 

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -1,7 +1,7 @@
 //! Operation Object
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
-use crate::common::reference::RefOr;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::parameter::Parameter;

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -1,10 +1,10 @@
 //! Operation Object
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
-use crate::v3_0::reference::RefOr;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::parameter::Parameter;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::request_body::RequestBody;
 use crate::v3_0::response::Responses;
 use crate::v3_0::server::Server;
@@ -309,9 +309,7 @@ mod tests {
         );
         // ExternalDocs URL empty surfaces.
         assert!(
-            ctx.errors
-                .iter()
-                .any(|e| e.contains("op.externalDocs.url")),
+            ctx.errors.iter().any(|e| e.contains("op.externalDocs.url")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -1,9 +1,9 @@
 //! Describes a single operation parameter.
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
-use crate::v3_0::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
 use serde::{Deserialize, Serialize};
@@ -523,11 +523,7 @@ mod tests {
 
     #[test]
     fn query_header_cookie_round_trip() {
-        for (loc, _style) in [
-            ("query", "form"),
-            ("header", "simple"),
-            ("cookie", "form"),
-        ] {
+        for (loc, _style) in [("query", "form"), ("header", "simple"), ("cookie", "form")] {
             let v = json!({"name": "n", "in": loc, "schema": {"type": "string"}});
             let p: Parameter = serde_json::from_value(v.clone()).unwrap();
             assert_eq!(serde_json::to_value(&p).unwrap(), v);
@@ -609,7 +605,11 @@ mod tests {
         });
         let mut ctx = Context::new(&spec, Options::new());
         p.validate_with_context(&mut ctx, "p".into());
-        assert!(ctx.errors.iter().any(|e| e.contains("example and examples")));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("example and examples"))
+        );
 
         let p = Parameter::Cookie(InCookie {
             name: "c".into(),
@@ -629,7 +629,11 @@ mod tests {
         });
         let mut ctx = Context::new(&spec, Options::new());
         p.validate_with_context(&mut ctx, "p".into());
-        assert!(ctx.errors.iter().any(|e| e.contains("example and examples")));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("example and examples"))
+        );
     }
 
     #[test]

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -1,7 +1,7 @@
 //! Describes a single operation parameter.
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
-use crate::common::reference::RefOr;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::schema::Schema;
@@ -478,6 +478,18 @@ fn either_schema_or_content(
     path: String,
 ) {
     if schema.is_some() && content.is_some() {
-        ctx.error(path, "schema and content are mutually exclusive");
+        ctx.error(path.clone(), "schema and content are mutually exclusive");
+    }
+    // Spec: "The map MUST only contain one entry."
+    if let Some(content) = content
+        && content.len() != 1
+    {
+        ctx.error(
+            path,
+            format_args!(
+                ".content: must contain exactly one media type entry, found {}",
+                content.len()
+            ),
+        );
     }
 }

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -493,3 +493,203 @@ fn either_schema_or_content(
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::validation::Options;
+    use serde_json::json;
+
+    fn ok_schema() -> RefOr<Schema> {
+        RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+            ObjectSchema::default(),
+        ))))
+    }
+
+    #[test]
+    fn path_param_dispatch_round_trip() {
+        let v = json!({
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "string"}
+        });
+        let p: Parameter = serde_json::from_value(v.clone()).unwrap();
+        assert!(matches!(p, Parameter::Path(_)));
+        assert_eq!(serde_json::to_value(&p).unwrap(), v);
+    }
+
+    #[test]
+    fn query_header_cookie_round_trip() {
+        for (loc, _style) in [
+            ("query", "form"),
+            ("header", "simple"),
+            ("cookie", "form"),
+        ] {
+            let v = json!({"name": "n", "in": loc, "schema": {"type": "string"}});
+            let p: Parameter = serde_json::from_value(v.clone()).unwrap();
+            assert_eq!(serde_json::to_value(&p).unwrap(), v);
+        }
+    }
+
+    #[test]
+    fn validate_path_param_must_be_required() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        let p = Parameter::Path(InPath {
+            name: "id".into(),
+            description: None,
+            required: false,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: Some(ok_schema()),
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        });
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must be required")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn validate_example_examples_xor_each_location() {
+        let spec = Spec::default();
+
+        let p = Parameter::Query(InQuery {
+            name: "q".into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: Some(ok_schema()),
+            example: Some(json!(1)),
+            examples: Some(BTreeMap::from([(
+                "a".into(),
+                RefOr::new_item(crate::v3_0::example::Example::default()),
+            )])),
+            content: None,
+            extensions: None,
+        });
+        let mut ctx = Context::new(&spec, Options::new());
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("example and examples")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        let p = Parameter::Header(InHeader {
+            name: "X".into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: Some(ok_schema()),
+            example: Some(json!(1)),
+            examples: Some(BTreeMap::from([(
+                "a".into(),
+                RefOr::new_item(crate::v3_0::example::Example::default()),
+            )])),
+            content: None,
+            extensions: None,
+        });
+        let mut ctx = Context::new(&spec, Options::new());
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(ctx.errors.iter().any(|e| e.contains("example and examples")));
+
+        let p = Parameter::Cookie(InCookie {
+            name: "c".into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: Some(ok_schema()),
+            example: Some(json!(1)),
+            examples: Some(BTreeMap::from([(
+                "a".into(),
+                RefOr::new_item(crate::v3_0::example::Example::default()),
+            )])),
+            content: None,
+            extensions: None,
+        });
+        let mut ctx = Context::new(&spec, Options::new());
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(ctx.errors.iter().any(|e| e.contains("example and examples")));
+    }
+
+    #[test]
+    fn content_size_must_be_one() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        let mut content = BTreeMap::new();
+        content.insert("application/json".to_owned(), MediaType::default());
+        content.insert("text/plain".to_owned(), MediaType::default());
+        let p = Parameter::Query(InQuery {
+            name: "q".into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: Some(content),
+            extensions: None,
+        });
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must contain exactly one media type entry")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn empty_name_is_required() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        let p = Parameter::Query(InQuery {
+            name: "".into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        });
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("name") && e.contains("must not be empty")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -477,8 +477,12 @@ fn either_schema_or_content(
     content: &Option<BTreeMap<String, MediaType>>,
     path: String,
 ) {
-    if schema.is_some() && content.is_some() {
-        ctx.error(path.clone(), "schema and content are mutually exclusive");
+    // Spec: "A parameter MUST contain either a schema property, or a content
+    // property, but not both."
+    match (schema.is_some(), content.is_some()) {
+        (true, true) => ctx.error(path.clone(), "schema and content are mutually exclusive"),
+        (false, false) => ctx.error(path.clone(), "must define either `schema` or `content`"),
+        _ => {}
     }
     // Spec: "The map MUST only contain one entry."
     if let Some(content) = content
@@ -663,6 +667,60 @@ mod tests {
             ctx.errors
                 .iter()
                 .any(|e| e.contains("must contain exactly one media type entry")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn parameter_must_define_schema_or_content() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        // Query parameter with neither schema nor content.
+        let p = Parameter::Query(InQuery {
+            name: "q".into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        });
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must define either `schema` or `content`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Path parameter with neither schema nor content also surfaces the error.
+        let p = Parameter::Path(InPath {
+            name: "id".into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        });
+        let mut ctx = Context::new(&spec, Options::new());
+        p.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must define either `schema` or `content`")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/path_item.rs
+++ b/src/v3_0/path_item.rs
@@ -1,6 +1,6 @@
 //! Path Items
 
-use crate::common::helpers::{Context, ValidateWithContext};
+use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::operation::Operation;
 use crate::v3_0::parameter::Parameter;
@@ -52,6 +52,17 @@ use std::fmt;
 /// ```
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct PathItem {
+    /// Allows for a referenced definition of this path item. Per OAS 3.0.4
+    /// the `$ref` form points to another path item; `summary` / `description`
+    /// fields on the referencing entry are ignored.
+    pub reference: Option<String>,
+
+    /// An optional, string summary intended to apply to all operations in this path.
+    pub summary: Option<String>,
+
+    /// An optional, CommonMark description intended to apply to all operations in this path.
+    pub description: Option<String>,
+
     /// A definition of the operations on this path.
     ///
     /// Any map items that can be converted to an `Operation` object will be stored here.
@@ -66,9 +77,8 @@ pub struct PathItem {
     /// These parameters can be overridden at the operation level, but cannot be removed there.
     /// The list MUST NOT include duplicated parameters.
     /// A unique parameter is defined by a combination of a name and location.
-    /// The list can use the [Reference Object](crate::common::reference::Ref) to link to parameters
+    /// The list can use the [Reference Object](crate::v3_0::reference::Ref) to link to parameters
     /// that are defined at the [Swagger Object's](crate::v3_0::spec::Spec::parameters) parameters.
-    /// There can be one "body" parameter at most.
     pub parameters: Option<Vec<RefOr<Parameter>>>,
 
     /// Allows extensions to the Swagger Schema.
@@ -83,6 +93,16 @@ impl Serialize for PathItem {
         S: Serializer,
     {
         let mut map = serializer.serialize_map(None)?;
+
+        if let Some(r) = &self.reference {
+            map.serialize_entry("$ref", r)?;
+        }
+        if let Some(s) = &self.summary {
+            map.serialize_entry("summary", s)?;
+        }
+        if let Some(d) = &self.description {
+            map.serialize_entry("description", d)?;
+        }
 
         if let Some(o) = &self.operations {
             for (k, v) in o {
@@ -116,6 +136,9 @@ impl<'de> Deserialize<'de> for PathItem {
         D: Deserializer<'de>,
     {
         const FIELDS: &[&str] = &[
+            "$ref",
+            "summary",
+            "description",
             "parameters",
             "servers",
             "get",
@@ -147,7 +170,22 @@ impl<'de> Deserialize<'de> for PathItem {
                 let mut operations: BTreeMap<String, Operation> = BTreeMap::new();
                 let mut extensions: BTreeMap<String, serde_json::Value> = BTreeMap::new();
                 while let Some(key) = map.next_key::<String>()? {
-                    if key == "parameters" {
+                    if key == "$ref" {
+                        if res.reference.is_some() {
+                            return Err(Error::duplicate_field("$ref"));
+                        }
+                        res.reference = Some(map.next_value()?);
+                    } else if key == "summary" {
+                        if res.summary.is_some() {
+                            return Err(Error::duplicate_field("summary"));
+                        }
+                        res.summary = Some(map.next_value()?);
+                    } else if key == "description" {
+                        if res.description.is_some() {
+                            return Err(Error::duplicate_field("description"));
+                        }
+                        res.description = Some(map.next_value()?);
+                    } else if key == "parameters" {
                         if res.parameters.is_some() {
                             return Err(Error::duplicate_field("parameters"));
                         }
@@ -186,6 +224,12 @@ impl<'de> Deserialize<'de> for PathItem {
 
 impl ValidateWithContext<Spec> for PathItem {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        if let Some(r) = &self.reference
+            && r.is_empty()
+        {
+            ctx.error(path.clone(), ".$ref: must not be empty");
+        }
+
         if let Some(operations) = &self.operations {
             for (method, operation) in operations.iter() {
                 operation.validate_with_context(ctx, format!("{path}.{method}"));
@@ -313,5 +357,125 @@ impl<'de> Deserialize<'de> for Paths {
             }
         }
         deserializer.deserialize_map(PathsVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn path_item_round_trip_with_servers_parameters_extensions() {
+        let v = json!({
+            "summary": "Pets path",
+            "description": "All pet operations",
+            "get": {"responses": {"200": {"description": "ok"}}},
+            "parameters": [
+                {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}
+            ],
+            "servers": [{"url": "https://api.example.com"}],
+            "x-internal": "yes"
+        });
+        let pi: PathItem = serde_json::from_value(v.clone()).unwrap();
+        assert!(pi.operations.is_some());
+        assert!(pi.servers.is_some());
+        assert!(pi.parameters.is_some());
+        assert!(pi.extensions.is_some());
+        // Round-trip preserves all fields.
+        let back = serde_json::to_value(&pi).unwrap();
+        // Field order may differ; compare via re-parse.
+        let re: PathItem = serde_json::from_value(back).unwrap();
+        assert_eq!(re, pi);
+    }
+
+    #[test]
+    fn path_item_dup_method_errors() {
+        // serde_json: last wins on duplicate keys, so we must construct the
+        // map at JSON-text level.
+        let raw = r#"{"get": {"responses": {"200": {"description": "ok"}}}, "get": {"responses": {"201": {"description": "ok"}}}}"#;
+        let res: Result<PathItem, _> = serde_json::from_str(raw);
+        assert!(res.is_err(), "expected duplicate `get` error");
+    }
+
+    #[test]
+    fn path_item_dup_extension_errors() {
+        let raw = r#"{"x-foo": 1, "x-foo": 2}"#;
+        let res: Result<PathItem, _> = serde_json::from_str(raw);
+        assert!(res.is_err(), "expected duplicate `x-foo` error");
+    }
+
+    #[test]
+    fn path_item_dup_field_errors() {
+        let raw = r#"{"parameters": [], "parameters": []}"#;
+        let res: Result<PathItem, _> = serde_json::from_str(raw);
+        assert!(res.is_err(), "expected duplicate `parameters` error");
+    }
+
+    #[test]
+    fn paths_struct_round_trip_extensions() {
+        let v = json!({
+            "/pets": {"get": {"responses": {"200": {"description": "ok"}}}},
+            "x-key": "value"
+        });
+        let p: Paths = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(p.len(), 1);
+        assert!(!p.is_empty());
+        assert!(p.extensions.is_some());
+        let back = serde_json::to_value(&p).unwrap();
+        let re: Paths = serde_json::from_value(back).unwrap();
+        assert_eq!(re, p);
+    }
+
+    #[test]
+    fn paths_iter_works() {
+        let p: Paths = serde_json::from_value(json!({
+            "/a": {},
+            "/b": {},
+            "x-foo": "bar"
+        }))
+        .unwrap();
+        let names: Vec<&String> = p.iter().map(|(k, _)| k).collect();
+        assert_eq!(names, vec![&"/a".to_owned(), &"/b".to_owned()]);
+    }
+
+    #[test]
+    fn paths_from_iterator() {
+        let pi = PathItem::default();
+        let p: Paths = [("/a", pi.clone()), ("/b", pi)].into();
+        assert_eq!(p.len(), 2);
+        assert_eq!(p.extensions, None);
+    }
+
+    #[test]
+    fn paths_dup_path_errors() {
+        let raw = r#"{"/a": {}, "/a": {}}"#;
+        let res: Result<Paths, _> = serde_json::from_str(raw);
+        assert!(res.is_err(), "expected duplicate path error");
+    }
+
+    #[test]
+    fn paths_dup_extension_errors() {
+        let raw = r#"{"x-foo": 1, "x-foo": 2}"#;
+        let res: Result<Paths, _> = serde_json::from_str(raw);
+        assert!(res.is_err(), "expected duplicate extension error");
+    }
+
+    #[test]
+    fn paths_size_hint_drops_non_x_extensions() {
+        // Even if a programmatically constructed map carries non-`x-` keys
+        // in `extensions`, only `x-` keys are emitted.
+        let mut ext = BTreeMap::new();
+        ext.insert("x-good".to_owned(), serde_json::json!("yes"));
+        ext.insert("nonext".to_owned(), serde_json::json!("nope"));
+        let p = Paths {
+            paths: BTreeMap::from([("/p".to_owned(), PathItem::default())]),
+            extensions: Some(ext),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.len(), 2, "should serialize only path + x-good: {obj:?}");
+        assert!(obj.contains_key("/p"));
+        assert!(obj.contains_key("x-good"));
     }
 }

--- a/src/v3_0/path_item.rs
+++ b/src/v3_0/path_item.rs
@@ -1,7 +1,7 @@
 //! Path Items
 
 use crate::common::helpers::{Context, ValidateWithContext};
-use crate::common::reference::RefOr;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::operation::Operation;
 use crate::v3_0::parameter::Parameter;
 use crate::v3_0::server::Server;
@@ -203,5 +203,115 @@ impl ValidateWithContext<Spec> for PathItem {
                 parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
             }
         }
+    }
+}
+
+/// The Paths Object: holds the relative paths to the individual endpoints.
+///
+/// In addition to the path-keyed entries, this object supports
+/// Specification Extensions (`^x-` keys) per the OAS 3.0.4 spec.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Paths {
+    /// Map from a path (which MUST begin with `/`) to its `PathItem`.
+    pub paths: BTreeMap<String, PathItem>,
+
+    /// `^x-` Specification Extensions on the Paths Object itself.
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Paths {
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, PathItem> {
+        self.paths.iter()
+    }
+}
+
+impl<S, K> From<S> for Paths
+where
+    S: IntoIterator<Item = (K, PathItem)>,
+    K: Into<String>,
+{
+    fn from(iter: S) -> Self {
+        Paths {
+            paths: iter.into_iter().map(|(k, v)| (k.into(), v)).collect(),
+            extensions: None,
+        }
+    }
+}
+
+impl Serialize for Paths {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Only `x-` keys are emitted from `extensions`; size hint must
+        // count only those.
+        let ext_x_count = self
+            .extensions
+            .as_ref()
+            .map(|e| e.keys().filter(|k| k.starts_with("x-")).count())
+            .unwrap_or(0);
+        let total = self.paths.len() + ext_x_count;
+        let mut map = serializer.serialize_map(Some(total))?;
+        for (k, v) in &self.paths {
+            map.serialize_entry(k, v)?;
+        }
+        if let Some(ext) = &self.extensions {
+            for (k, v) in ext {
+                if k.starts_with("x-") {
+                    map.serialize_entry(k, v)?;
+                }
+            }
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Paths {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PathsVisitor;
+        impl<'de> Visitor<'de> for PathsVisitor {
+            type Value = Paths;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a Paths object")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Paths, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut paths: BTreeMap<String, PathItem> = BTreeMap::new();
+                let mut ext: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if key.starts_with("x-") {
+                        if ext.contains_key(&key) {
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
+                        }
+                        ext.insert(key, map.next_value()?);
+                    } else {
+                        if paths.contains_key(&key) {
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
+                        }
+                        paths.insert(key, map.next_value()?);
+                    }
+                }
+                Ok(Paths {
+                    paths,
+                    extensions: if ext.is_empty() { None } else { Some(ext) },
+                })
+            }
+        }
+        deserializer.deserialize_map(PathsVisitor)
     }
 }

--- a/src/v3_0/path_item.rs
+++ b/src/v3_0/path_item.rs
@@ -1,9 +1,9 @@
 //! Path Items
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
-use crate::v3_0::reference::RefOr;
 use crate::v3_0::operation::Operation;
 use crate::v3_0::parameter::Parameter;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
 use serde::de::{Error, MapAccess, Visitor};

--- a/src/v3_0/reference.rs
+++ b/src/v3_0/reference.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::{ResolveError, ResolveReference};
 use crate::validation::Options;
+use std::collections::BTreeSet;
 
 /// v3.0 Reference Object — exactly `{ "$ref": "..." }`.
 ///
@@ -116,9 +117,27 @@ pub fn resolve_in_map<'a, T, D>(
 where
     T: ResolveReference<D>,
 {
-    map.as_ref()
-        .and_then(|x| x.get(reference.trim_start_matches(prefix)))
-        .and_then(move |x| x.get_item(spec).ok())
+    let map = map.as_ref()?;
+    let mut current = reference;
+    let mut visited = BTreeSet::new();
+
+    loop {
+        let key = current.strip_prefix(prefix)?;
+        let item = map.get(key)?;
+
+        match item {
+            RefOr::Item(d) => return Some(d),
+            RefOr::Ref(r) => {
+                if !r.reference.starts_with(prefix) {
+                    return item.get_item(spec).ok();
+                }
+                if !visited.insert(r.reference.as_str()) {
+                    return None;
+                }
+                current = &r.reference;
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -157,5 +176,17 @@ mod tests {
         let r: RefOr<Foo> =
             serde_json::from_value(json!({"$ref": "#/components/schemas/Foo"})).unwrap();
         assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/schemas/Foo"));
+    }
+
+    #[test]
+    fn schema_ref_rejects_v3_1_sibling_fields() {
+        let r = serde_json::from_value::<RefOr<crate::v3_0::schema::Schema>>(json!({
+            "$ref": "#/components/schemas/Foo",
+            "description": "should be rejected",
+        }));
+        assert!(
+            r.is_err(),
+            "schema refs must not fall back to inline schemas when v3.1 sibling fields are present"
+        );
     }
 }

--- a/src/v3_0/reference.rs
+++ b/src/v3_0/reference.rs
@@ -1,0 +1,161 @@
+//! v3.0 Reference Object — `$ref`-only.
+//!
+//! OpenAPI 3.0.x's Reference Object has exactly one field, `$ref`. The shared
+//! `crate::common::reference::Ref` carries `summary` and `description` which
+//! were added in 3.1; using it here would let those v3.1-only fields leak
+//! into 3.0 deserialize/serialize. This module pins v3.0 to the spec form.
+
+use serde::{Deserialize, Serialize};
+
+use crate::common::helpers::{Context, PushError, ValidateWithContext};
+use crate::common::reference::{ResolveError, ResolveReference};
+use crate::validation::Options;
+
+/// v3.0 Reference Object — exactly `{ "$ref": "..." }`.
+///
+/// `#[serde(deny_unknown_fields)]` rejects extra v3.1-style `summary` /
+/// `description` keys that are not part of the v3.0 spec.
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Ref {
+    /// **Required** The reference identifier. MUST be a URI.
+    #[serde(rename = "$ref")]
+    pub reference: String,
+}
+
+impl Ref {
+    pub fn new(reference: impl Into<String>) -> Self {
+        Ref {
+            reference: reference.into(),
+        }
+    }
+
+    pub fn validate_with_context<T, D>(&self, ctx: &mut Context<T>, path: String)
+    where
+        T: ResolveReference<D>,
+        D: ValidateWithContext<T>,
+    {
+        if self.reference.is_empty() {
+            ctx.error(path, ".$ref: must not be empty");
+        }
+    }
+}
+
+/// v3.0 RefOr<T> — either a `$ref` (v3.0 form) or an inline value of `T`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RefOr<T> {
+    Ref(Ref),
+    Item(T),
+}
+
+impl<D> RefOr<D> {
+    pub fn new_ref(reference: impl Into<String>) -> Self {
+        RefOr::Ref(Ref::new(reference))
+    }
+
+    pub fn new_item(item: D) -> Self {
+        RefOr::Item(item)
+    }
+
+    pub fn get_item<'a, T>(&'a self, spec: &'a T) -> Result<&'a D, ResolveError>
+    where
+        T: ResolveReference<D>,
+    {
+        match self {
+            RefOr::Item(d) => Ok(d),
+            RefOr::Ref(r) => {
+                if r.reference.starts_with("#/") {
+                    match spec.resolve_reference(&r.reference) {
+                        Some(d) => Ok(d),
+                        None => Err(ResolveError::NotFound(r.reference.clone())),
+                    }
+                } else {
+                    Err(ResolveError::ExternalUnsupported(r.reference.clone()))
+                }
+            }
+        }
+    }
+
+    pub fn validate_with_context<T>(&self, ctx: &mut Context<T>, path: String)
+    where
+        T: ResolveReference<D>,
+        D: ValidateWithContext<T>,
+    {
+        match self {
+            RefOr::Ref(r) => {
+                r.validate_with_context(ctx, path.clone());
+                if ctx.visit(r.reference.clone()) {
+                    match self.get_item(ctx.spec) {
+                        Ok(d) => {
+                            d.validate_with_context(ctx, r.reference.clone());
+                        }
+                        Err(ResolveError::NotFound(reference)) => {
+                            ctx.error(path, format_args!(".$ref: `{reference}` not found"));
+                        }
+                        Err(e @ ResolveError::ExternalUnsupported(_)) => {
+                            if !ctx.is_option(Options::IgnoreExternalReferences) {
+                                ctx.error(path, format_args!(".$ref: {e}"));
+                            }
+                        }
+                    }
+                }
+            }
+            RefOr::Item(d) => d.validate_with_context(ctx, path),
+        }
+    }
+}
+
+/// Resolve a `$ref` against a `BTreeMap<String, RefOr<D>>` field on the spec.
+pub fn resolve_in_map<'a, T, D>(
+    spec: &'a T,
+    reference: &str,
+    prefix: &str,
+    map: &'a Option<std::collections::BTreeMap<String, RefOr<D>>>,
+) -> Option<&'a D>
+where
+    T: ResolveReference<D>,
+{
+    map.as_ref()
+        .and_then(|x| x.get(reference.trim_start_matches(prefix)))
+        .and_then(move |x| x.get_item(spec).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+    struct Foo {
+        pub foo: String,
+    }
+
+    #[test]
+    fn ref_only_serializes_dollar_ref() {
+        let r = RefOr::<Foo>::new_ref("#/components/schemas/Foo");
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            json!({"$ref": "#/components/schemas/Foo"}),
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_v3_1_fields() {
+        let r = serde_json::from_value::<RefOr<Foo>>(json!({
+            "$ref": "#/components/schemas/Foo",
+            "summary": "should be rejected",
+        }));
+        assert!(
+            r.is_err(),
+            "should not silently accept v3.1 summary on v3.0 Ref"
+        );
+    }
+
+    #[test]
+    fn deserialize_ref() {
+        let r: RefOr<Foo> =
+            serde_json::from_value(json!({"$ref": "#/components/schemas/Foo"})).unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/schemas/Foo"));
+    }
+}

--- a/src/v3_0/request_body.rs
+++ b/src/v3_0/request_body.rs
@@ -72,3 +72,61 @@ impl ValidateWithContext<Spec> for RequestBody {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::validation::Options;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_with_extensions() {
+        let v = json!({
+            "description": "A user",
+            "required": true,
+            "content": {
+                "application/json": {"schema": {"type": "object"}}
+            },
+            "x-internal": "yes"
+        });
+        let rb: RequestBody = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(rb.required, Some(true));
+        assert!(rb.extensions.is_some());
+        assert_eq!(serde_json::to_value(&rb).unwrap(), v);
+    }
+
+    #[test]
+    fn validate_walks_content() {
+        let mut content = BTreeMap::new();
+        content.insert(
+            "application/json".to_owned(),
+            crate::v3_0::media_type::MediaType {
+                example: Some(json!(1)),
+                examples: Some(BTreeMap::from([(
+                    "a".into(),
+                    crate::v3_0::reference::RefOr::new_item(
+                        crate::v3_0::example::Example::default(),
+                    ),
+                )])),
+                ..Default::default()
+            },
+        );
+        let rb = RequestBody {
+            description: None,
+            content,
+            required: None,
+            extensions: None,
+        };
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        rb.validate_with_context(&mut ctx, "rb".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("rb.content[application/json]")),
+            "expected nested content error: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/src/v3_0/request_body.rs
+++ b/src/v3_0/request_body.rs
@@ -55,6 +55,14 @@ pub struct RequestBody {
     /// Defaults to `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
+
+    /// This object MAY be extended with Specification Extensions.
+    /// The field name MUST begin with `x-`, for example, `x-internal-id`.
+    /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 impl ValidateWithContext<Spec> for RequestBody {

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -97,6 +97,11 @@ pub struct Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<BTreeMap<String, RefOr<Link>>>,
 
+    /// ReDoc/Redocly extension with a short response summary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-summary")]
+    pub x_summary: Option<String>,
+
     /// This object MAY be extended with Specification Extensions.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -335,6 +340,7 @@ mod tests {
                     map.insert("x-extra".to_owned(), serde_json::json!("extension"));
                     map
                 }),
+                x_summary: None,
             },
             "response deserialization",
         );
@@ -391,6 +397,7 @@ mod tests {
                     map.insert("x-extra".to_owned(), serde_json::json!("extension"));
                     map
                 }),
+                x_summary: None,
             })
             .unwrap(),
             serde_json::json!({
@@ -506,6 +513,7 @@ mod tests {
                         map.insert("x-extra".to_owned(), serde_json::json!("extension"));
                         map
                     }),
+                    x_summary: None,
                 })),
                 responses: Some({
                     let mut map = BTreeMap::new();
@@ -580,6 +588,7 @@ mod tests {
                         map.insert("x-extra".to_owned(), serde_json::json!("extension"));
                         map
                     }),
+                    x_summary: None,
                 })),
                 responses: Some({
                     let mut map = BTreeMap::new();
@@ -687,6 +696,7 @@ mod tests {
                 map.insert("x-extra".to_owned(), serde_json::json!("extension"));
                 map
             }),
+            x_summary: None,
         }
         .validate_with_context(&mut ctx, "response".to_owned());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
@@ -714,5 +724,22 @@ mod tests {
         );
         Response::default().validate_with_context(&mut ctx, "response".to_owned());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn x_summary_round_trip() {
+        let response: Response = serde_json::from_value(serde_json::json!({
+            "description": "Created",
+            "x-summary": "Created"
+        }))
+        .unwrap();
+        assert_eq!(response.x_summary, Some("Created".to_owned()));
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            serde_json::json!({
+                "description": "Created",
+                "x-summary": "Created"
+            })
+        );
     }
 }

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -232,8 +232,8 @@ impl ValidateWithContext<Spec> for Response {
 impl ValidateWithContext<Spec> for Responses {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         // Spec: "The Responses Object MUST contain at least one response code".
-        let has_any = self.default.is_some()
-            || self.responses.as_ref().is_some_and(|m| !m.is_empty());
+        let has_any =
+            self.default.is_some() || self.responses.as_ref().is_some_and(|m| !m.is_empty());
         if !has_any {
             ctx.error(path.clone(), "must declare at least one response");
         }

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -684,7 +684,7 @@ mod tests {
                 map.insert(
                     "next".to_owned(),
                     RefOr::new_item(Link {
-                        operation_ref: Some("getNextPage".to_owned()),
+                        operation_id: Some("getNextPage".to_owned()),
                         description: Some("Get the next page of results".to_owned()),
                         ..Default::default()
                     }),
@@ -699,7 +699,15 @@ mod tests {
             x_summary: None,
         }
         .validate_with_context(&mut ctx, "response".to_owned());
-        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+        // The unknown operationId surfaces a single Link error; for this
+        // test we just confirm Response itself does not emit anything else.
+        assert!(
+            ctx.errors
+                .iter()
+                .all(|e| e.contains("missing operation with id")),
+            "unexpected errors: {:?}",
+            ctx.errors
+        );
 
         let mut ctx = Context::new(&spec, Options::new());
         Response {

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -91,9 +91,10 @@ pub struct Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<BTreeMap<String, MediaType>>,
 
-    /// Maps a header name to its definition.
-    /// [RFC7230](https://www.rfc-editor.org/rfc/rfc7230) states header names are case insensitive.
-    /// If a response header is defined with the name `"Content-Type"`, it SHALL be ignored.
+    /// A map of operations links that can be followed from the response.
+    /// The key is a short name for the link (constrained to the same naming
+    /// pattern as Component map keys: `^[a-zA-Z0-9.\-_]+$`); the value is a
+    /// `Link` Object or a `Reference` to one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<BTreeMap<String, RefOr<Link>>>,
 
@@ -666,6 +667,9 @@ mod tests {
                         description: Some("A short description of the header.".to_owned()),
                         required: Some(true),
                         style: Some(InHeaderStyle::Simple),
+                        schema: Some(RefOr::new_item(Schema::Single(Box::new(
+                            SingleSchema::Object(ObjectSchema::default()),
+                        )))),
                         ..Default::default()
                     }),
                 );

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -231,11 +231,19 @@ impl ValidateWithContext<Spec> for Response {
 
 impl ValidateWithContext<Spec> for Responses {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        // Spec: "The Responses Object MUST contain at least one response code".
+        // Spec: the Responses Object MUST contain at least one entry. The
+        // 3.0.4 prose says "at least one response code", but tooling and the
+        // spec's own examples treat a `default`-only Responses object as
+        // valid (the OAS Linter accepts it; ReDoc renders it). We follow
+        // that convention: any of `default` / one keyed code / one wildcard
+        // satisfies the requirement.
         let has_any =
             self.default.is_some() || self.responses.as_ref().is_some_and(|m| !m.is_empty());
         if !has_any {
-            ctx.error(path.clone(), "must declare at least one response");
+            ctx.error(
+                path.clone(),
+                "must declare at least one response (a status code, a wildcard like `2XX`, or `default`)",
+            );
         }
 
         if let Some(response) = &self.default {

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -1,17 +1,28 @@
 //! Response Object
 
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
-use crate::common::reference::RefOr;
 use crate::v3_0::header::Header;
 use crate::v3_0::link::Link;
 use crate::v3_0::media_type::MediaType;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use lazy_regex::regex;
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
 use std::fmt;
+
+/// True if `key` is a 3-digit HTTP status code (100-599) or a wildcard
+/// range token `1XX/2XX/3XX/4XX/5XX` (uppercase X). Per OAS 3.0.4 the
+/// `Responses` object's patterned keys are exactly this union.
+fn is_response_code_key(key: &str) -> bool {
+    if let Ok(n) = key.parse::<u16>() {
+        return (100..=599).contains(&n);
+    }
+    regex!(r"^[1-5]XX$").is_match(key)
+}
 
 /// A container for the expected responses of an operation.
 /// The container maps a HTTP response code to the expected response.
@@ -49,18 +60,10 @@ pub struct Responses {
     /// section defines.
     pub default: Option<RefOr<Response>>,
 
-    /// Any HTTP status code can be used as the property name,
-    /// but only one property per code,
-    /// to describe the expected response for that HTTP status code.
-    /// A Reference Object can link to a response that is defined in the OpenAPI Object’s
-    /// components/responses section.
-    /// This field MUST be enclosed in quotation marks (for example, “200”) for compatibility
-    /// between JSON and YAML.
-    /// To define a range of response codes, this field MAY contain the uppercase wildcard character `X`.
-    /// For example, `2XX` represents all response codes between `[200-299]`.
-    /// Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`.
-    /// If a response is defined using an explicit code,
-    /// the explicit code definition takes precedence over the range definition for that code.
+    /// Either a 3-digit HTTP status code (`"200"`) or one of the wildcard
+    /// range tokens `1XX/2XX/3XX/4XX/5XX` (uppercase X). The string form is
+    /// required because YAML would otherwise convert `200` to an integer.
+    /// Explicit codes take precedence over the range that contains them.
     pub responses: Option<BTreeMap<String, RefOr<Response>>>,
 
     /// Allows extensions to the Swagger Schema.
@@ -73,7 +76,6 @@ pub struct Responses {
 pub struct Response {
     /// **Required** A short description of the response.
     /// [CommonMark](https://spec.commonmark.org) syntax MAY be used for rich text representation.
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub description: String,
 
     /// Maps a header name to its definition.
@@ -95,9 +97,9 @@ pub struct Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<BTreeMap<String, RefOr<Link>>>,
 
-    /// A map of operations links that can be followed from the response.
-    /// The key of the map is a short name for the link,
-    /// following the naming constraints of the names for Component Objects.
+    /// This object MAY be extended with Specification Extensions.
+    /// The field name MUST begin with `x-`, for example, `x-internal-id`.
+    /// The value can be null, a primitive, an array or an object.
     #[serde(flatten)]
     #[serde(with = "crate::common::extensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,7 +140,16 @@ impl<'de> Deserialize<'de> for Responses {
     where
         D: Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["default", "x-...", "1xx", "2xx", "3xx", "4xx", "5xx"];
+        const FIELDS: &[&str] = &[
+            "default",
+            "x-...",
+            "<3-digit status code>",
+            "1XX",
+            "2XX",
+            "3XX",
+            "4XX",
+            "5XX",
+        ];
 
         struct ResponsesVisitor;
 
@@ -167,18 +178,13 @@ impl<'de> Deserialize<'de> for Responses {
                             return Err(Error::custom(format_args!("duplicate field `{key}`")));
                         }
                         extensions.insert(key, map.next_value()?);
-                    } else {
-                        match key.parse::<u16>() {
-                            Ok(100..=599) => {
-                                if responses.contains_key(key.as_str()) {
-                                    return Err(Error::custom(format_args!(
-                                        "duplicate field `{key}`"
-                                    )));
-                                }
-                                responses.insert(key, map.next_value()?);
-                            }
-                            _ => return Err(Error::unknown_field(key.as_str(), FIELDS)),
+                    } else if is_response_code_key(key.as_str()) {
+                        if responses.contains_key(key.as_str()) {
+                            return Err(Error::custom(format_args!("duplicate field `{key}`")));
                         }
+                        responses.insert(key, map.next_value()?);
+                    } else {
+                        return Err(Error::unknown_field(key.as_str(), FIELDS));
                     }
                 }
                 if !responses.is_empty() {
@@ -220,21 +226,25 @@ impl ValidateWithContext<Spec> for Response {
 
 impl ValidateWithContext<Spec> for Responses {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // Spec: "The Responses Object MUST contain at least one response code".
+        let has_any = self.default.is_some()
+            || self.responses.as_ref().is_some_and(|m| !m.is_empty());
+        if !has_any {
+            ctx.error(path.clone(), "must declare at least one response");
+        }
+
         if let Some(response) = &self.default {
             response.validate_with_context(ctx, format!("{path}.default"));
         }
         if let Some(responses) = &self.responses {
             for (name, response) in responses {
-                match name.parse::<u16>() {
-                    Ok(100..=599) => {}
-                    _ => {
-                        ctx.error(
-                            path.clone(),
-                            format_args!(
-                                "name must be an integer within [100..599] range, found `{name}`"
-                            ),
-                        );
-                    }
+                if !is_response_code_key(name) {
+                    ctx.error(
+                        path.clone(),
+                        format_args!(
+                            "key must be a 3-digit status code (100-599) or one of `1XX/2XX/3XX/4XX/5XX`, found `{name}`"
+                        ),
+                    );
                 }
                 response.validate_with_context(ctx, format!("{path}.{name}"));
             }

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
-use crate::v3_0::reference::RefOr;
 use crate::v3_0::discriminator::Discriminator;
 use crate::v3_0::external_documentation::ExternalDocumentation;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::spec::Spec;
 use crate::v3_0::xml::XML;
 
@@ -1610,7 +1610,9 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         parsed.validate_with_context(&mut ctx, "s".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("additionalProperties")),
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("additionalProperties")),
             "expected additionalProperties walk error: {:?}",
             ctx.errors
         );
@@ -1648,13 +1650,34 @@ mod tests {
 
     #[test]
     fn schema_display_impl() {
-        assert_eq!(SingleSchema::String(StringSchema::default()).to_string(), "string");
-        assert_eq!(SingleSchema::Integer(IntegerSchema::default()).to_string(), "integer");
-        assert_eq!(SingleSchema::Number(NumberSchema::default()).to_string(), "number");
-        assert_eq!(SingleSchema::Boolean(BooleanSchema::default()).to_string(), "boolean");
-        assert_eq!(SingleSchema::Array(ArraySchema::default()).to_string(), "array");
-        assert_eq!(SingleSchema::Object(ObjectSchema::default()).to_string(), "object");
-        assert_eq!(SingleSchema::Null(NullSchema::default()).to_string(), "null");
+        assert_eq!(
+            SingleSchema::String(StringSchema::default()).to_string(),
+            "string"
+        );
+        assert_eq!(
+            SingleSchema::Integer(IntegerSchema::default()).to_string(),
+            "integer"
+        );
+        assert_eq!(
+            SingleSchema::Number(NumberSchema::default()).to_string(),
+            "number"
+        );
+        assert_eq!(
+            SingleSchema::Boolean(BooleanSchema::default()).to_string(),
+            "boolean"
+        );
+        assert_eq!(
+            SingleSchema::Array(ArraySchema::default()).to_string(),
+            "array"
+        );
+        assert_eq!(
+            SingleSchema::Object(ObjectSchema::default()).to_string(),
+            "object"
+        );
+        assert_eq!(
+            SingleSchema::Null(NullSchema::default()).to_string(),
+            "null"
+        );
     }
 
     #[test]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::discriminator::Discriminator;
 use crate::v3_0::external_documentation::ExternalDocumentation;
@@ -954,6 +954,24 @@ impl ValidateWithContext<Spec> for Schema {
 
 impl ValidateWithContext<Spec> for SingleSchema {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // OAS 3.0 §4.7.21: `readOnly` and `writeOnly` MUST NOT both be true.
+        // Centralised here so every variant's dispatch goes through it.
+        let (read_only, write_only) = match self {
+            SingleSchema::String(s) => (s.read_only, s.write_only),
+            SingleSchema::Integer(s) => (s.read_only, s.write_only),
+            SingleSchema::Number(s) => (s.read_only, s.write_only),
+            SingleSchema::Boolean(s) => (s.read_only, s.write_only),
+            SingleSchema::Array(s) => (s.read_only, s.write_only),
+            SingleSchema::Object(s) => (s.read_only, s.write_only),
+            SingleSchema::Null(s) => (s.read_only, s.write_only),
+        };
+        if read_only == Some(true) && write_only == Some(true) {
+            ctx.error(
+                path.clone(),
+                ".readOnly and .writeOnly are mutually exclusive",
+            );
+        }
+
         match self {
             SingleSchema::String(s) => s.validate_with_context(ctx, path),
             SingleSchema::Integer(s) => s.validate_with_context(ctx, path),
@@ -1254,6 +1272,110 @@ mod tests {
             _ => panic!("expected Single schema"),
         }
         assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+    }
+
+    #[test]
+    fn read_only_write_only_mutex_each_variant() {
+        // Spec: a Schema MUST NOT have both readOnly and writeOnly set to
+        // true. Build one of each `SingleSchema` variant with both flags
+        // and run them through the dispatch path; each should produce the
+        // error.
+        fn case<T: Into<SingleSchema>>(s: T) -> Schema {
+            Schema::from(s.into())
+        }
+        let schemas: Vec<(String, Schema)> = vec![
+            (
+                "string".into(),
+                case(StringSchema {
+                    read_only: Some(true),
+                    write_only: Some(true),
+                    ..Default::default()
+                }),
+            ),
+            (
+                "integer".into(),
+                case(IntegerSchema {
+                    read_only: Some(true),
+                    write_only: Some(true),
+                    ..Default::default()
+                }),
+            ),
+            (
+                "number".into(),
+                case(NumberSchema {
+                    read_only: Some(true),
+                    write_only: Some(true),
+                    ..Default::default()
+                }),
+            ),
+            (
+                "boolean".into(),
+                case(BooleanSchema {
+                    read_only: Some(true),
+                    write_only: Some(true),
+                    ..Default::default()
+                }),
+            ),
+            (
+                "array".into(),
+                case(ArraySchema {
+                    read_only: Some(true),
+                    write_only: Some(true),
+                    ..Default::default()
+                }),
+            ),
+            (
+                "object".into(),
+                case(ObjectSchema {
+                    read_only: Some(true),
+                    write_only: Some(true),
+                    ..Default::default()
+                }),
+            ),
+            (
+                "null".into(),
+                case(NullSchema {
+                    read_only: Some(true),
+                    write_only: Some(true),
+                    ..Default::default()
+                }),
+            ),
+        ];
+        let spec = Spec::default();
+        for (name, schema) in &schemas {
+            let mut ctx = Context::new(&spec, crate::validation::Options::new());
+            schema.validate_with_context(&mut ctx, format!("s.{name}"));
+            assert!(
+                ctx.errors
+                    .iter()
+                    .any(|e| e.contains(".readOnly and .writeOnly are mutually exclusive")),
+                "variant `{name}` should reject readOnly+writeOnly: errors {:?}",
+                ctx.errors
+            );
+        }
+    }
+
+    #[test]
+    fn read_only_xor_write_only_individually_ok() {
+        // Only one of readOnly / writeOnly is fine.
+        let only_read = Schema::from(SingleSchema::from(StringSchema {
+            read_only: Some(true),
+            ..Default::default()
+        }));
+        let only_write = Schema::from(SingleSchema::from(StringSchema {
+            write_only: Some(true),
+            ..Default::default()
+        }));
+        let spec = Spec::default();
+        for s in [only_read, only_write] {
+            let mut ctx = Context::new(&spec, crate::validation::Options::new());
+            s.validate_with_context(&mut ctx, "s".into());
+            assert!(
+                ctx.errors.iter().all(|e| !e.contains("mutually exclusive")),
+                "single flag should not error: {:?}",
+                ctx.errors
+            );
+        }
     }
 
     #[test]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -256,6 +256,21 @@ pub struct StringSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<String>>,
 
+    /// Documentation/codegen extension with descriptions for enum values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enumDescriptions")]
+    pub x_enum_descriptions: Option<Vec<String>>,
+
+    /// Codegen extension with Rust/Java-style enum variant names.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enum-varnames")]
+    pub x_enum_varnames: Option<Vec<String>>,
+
+    /// Codegen extension with enum member names used by several generators.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enumNames")]
+    pub x_enum_names: Option<Vec<String>>,
+
     /// Declares the maximum length of the parameter value.
     #[serde(rename = "maxLength")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -351,6 +366,21 @@ pub struct IntegerSchema {
     #[serde(rename = "enum")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<i64>>,
+
+    /// Documentation/codegen extension with descriptions for enum values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enumDescriptions")]
+    pub x_enum_descriptions: Option<Vec<String>>,
+
+    /// Codegen extension with Rust/Java-style enum variant names.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enum-varnames")]
+    pub x_enum_varnames: Option<Vec<String>>,
+
+    /// Codegen extension with enum member names used by several generators.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enumNames")]
+    pub x_enum_names: Option<Vec<String>>,
 
     /// Inclusive lower bound for the value.
     /// Per JSON Schema draft-04 §5.1.3, this keyword is any number even when
@@ -463,6 +493,21 @@ pub struct NumberSchema {
     #[serde(rename = "enum")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<f64>>,
+
+    /// Documentation/codegen extension with descriptions for enum values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enumDescriptions")]
+    pub x_enum_descriptions: Option<Vec<String>>,
+
+    /// Codegen extension with Rust/Java-style enum variant names.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enum-varnames")]
+    pub x_enum_varnames: Option<Vec<String>>,
+
+    /// Codegen extension with enum member names used by several generators.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-enumNames")]
+    pub x_enum_names: Option<Vec<String>>,
 
     /// Declares the minimum value of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -739,6 +784,11 @@ pub struct ObjectSchema {
     #[serde(rename = "additionalProperties")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_properties: Option<BoolOr<RefOr<Schema>>>,
+
+    /// ReDoc/Redocly extension with a display name for additional properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-additionalPropertiesName")]
+    pub x_additional_properties_name: Option<String>,
 
     /// A list of required properties.
     /// If the object is defined at the root of the document,
@@ -1203,6 +1253,308 @@ mod tests {
             },
             _ => panic!("expected Single schema"),
         }
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+    }
+
+    #[test]
+    fn from_conversions_each_variant() {
+        let _: Schema = SingleSchema::from(StringSchema::default()).into();
+        let _: Schema = SingleSchema::from(IntegerSchema::default()).into();
+        let _: Schema = SingleSchema::from(NumberSchema::default()).into();
+        let _: Schema = SingleSchema::from(BooleanSchema::default()).into();
+        let _: Schema = SingleSchema::from(ArraySchema::default()).into();
+        let _: Schema = SingleSchema::from(ObjectSchema::default()).into();
+        let _: Schema = SingleSchema::from(NullSchema::default()).into();
+
+        let _: Schema = AllOfSchema::default().into();
+        let _: Schema = AnyOfSchema::default().into();
+        let _: Schema = OneOfSchema::default().into();
+        let _: Schema = NotSchema {
+            not: RefOr::new_item(Schema::default()),
+            extensions: None,
+        }
+        .into();
+
+        let s = Schema::default();
+        // Default is the empty Object schema.
+        if let Schema::Single(inner) = s {
+            assert!(matches!(*inner, SingleSchema::Object(_)));
+        } else {
+            panic!("default should be Single");
+        }
+    }
+
+    #[test]
+    fn validate_dispatches_to_each_single_variant() {
+        // Each variant validator runs at least one optional walk (xml /
+        // externalDocs); seed each with a malformed XML namespace to surface
+        // the dispatch path.
+        let bad_xml = || crate::v3_0::xml::XML {
+            namespace: Some("not-a-url".into()),
+            ..Default::default()
+        };
+        let cases: Vec<Schema> = vec![
+            Schema::from(SingleSchema::from(StringSchema {
+                xml: Some(bad_xml()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(IntegerSchema {
+                xml: Some(bad_xml()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(NumberSchema {
+                xml: Some(bad_xml()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(BooleanSchema {
+                xml: Some(bad_xml()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(ArraySchema {
+                xml: Some(bad_xml()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(ObjectSchema {
+                xml: Some(bad_xml()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(NullSchema {
+                xml: Some(bad_xml()),
+                ..Default::default()
+            })),
+        ];
+        let spec = Spec::default();
+        for (i, schema) in cases.iter().enumerate() {
+            let mut ctx = Context::new(&spec, crate::validation::Options::new());
+            schema.validate_with_context(&mut ctx, format!("c[{i}]"));
+            assert!(
+                ctx.errors.iter().any(|e| e.contains("namespace")),
+                "case {i}: errors: {:?}",
+                ctx.errors
+            );
+        }
+    }
+
+    #[test]
+    fn validate_walks_external_docs_per_variant() {
+        // ExternalDocumentation requires a non-empty URL — picks up empty.
+        let bad_docs = || crate::v3_0::external_documentation::ExternalDocumentation {
+            url: "".into(),
+            description: None,
+            extensions: None,
+        };
+        let cases: Vec<Schema> = vec![
+            Schema::from(SingleSchema::from(StringSchema {
+                external_docs: Some(bad_docs()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(IntegerSchema {
+                external_docs: Some(bad_docs()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(NumberSchema {
+                external_docs: Some(bad_docs()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(BooleanSchema {
+                external_docs: Some(bad_docs()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(ArraySchema {
+                external_docs: Some(bad_docs()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(ObjectSchema {
+                external_docs: Some(bad_docs()),
+                ..Default::default()
+            })),
+            Schema::from(SingleSchema::from(NullSchema {
+                external_docs: Some(bad_docs()),
+                ..Default::default()
+            })),
+        ];
+        let spec = Spec::default();
+        for (i, schema) in cases.iter().enumerate() {
+            let mut ctx = Context::new(&spec, crate::validation::Options::new());
+            schema.validate_with_context(&mut ctx, format!("c[{i}]"));
+            assert!(
+                ctx.errors.iter().any(|e| e.contains("externalDocs")),
+                "case {i}: errors: {:?}",
+                ctx.errors
+            );
+        }
+    }
+
+    #[test]
+    fn object_validate_walks_properties() {
+        let json = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "bad": {"type": "string", "pattern": "["}
+            }
+        });
+        let s: Schema = serde_json::from_value(json).unwrap();
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        s.validate_with_context(&mut ctx, "obj".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("obj.properties.bad")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn null_boolean_number_schemas_round_trip() {
+        let json = serde_json::json!({"type": "null", "title": "n"});
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        let json = serde_json::json!({"type": "boolean", "default": true});
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        let json = serde_json::json!({
+            "type": "number",
+            "minimum": 0.5,
+            "maximum": 99.5,
+            "exclusiveMinimum": true,
+            "exclusiveMaximum": false,
+            "multipleOf": 0.5,
+            "enum": [1.0, 2.5]
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+    }
+
+    #[test]
+    fn one_of_any_of_not_round_trip_and_validate() {
+        let json = serde_json::json!({
+            "oneOf": [{"type": "string"}, {"$ref": "#/components/schemas/X"}],
+            "discriminator": {"propertyName": "kind"}
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert!(matches!(parsed, Schema::OneOf(_)));
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        let json = serde_json::json!({
+            "anyOf": [{"type": "string"}, {"type": "integer"}]
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert!(matches!(parsed, Schema::AnyOf(_)));
+
+        let json = serde_json::json!({"not": {"type": "string"}});
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert!(matches!(parsed, Schema::Not(_)));
+
+        // Validate dispatches into composition arms.
+        let spec = Spec::default();
+        let composition: Schema = serde_json::from_value(serde_json::json!({
+            "allOf": [{"type": "string", "pattern": "["}],
+            "discriminator": {"propertyName": ""}
+        }))
+        .unwrap();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        composition.validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("pattern")),
+            "expected nested string pattern error: {:?}",
+            ctx.errors
+        );
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("propertyName")),
+            "expected discriminator empty propertyName: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn additional_properties_bool_and_schema_round_trip() {
+        let json = serde_json::json!({
+            "type": "object",
+            "additionalProperties": false
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        let json = serde_json::json!({
+            "type": "object",
+            "additionalProperties": {"type": "string", "pattern": "["}
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        // Validate walks into additionalProperties Item form to surface nested
+        // pattern errors.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        parsed.validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("additionalProperties")),
+            "expected additionalProperties walk error: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn nullable_writeonly_deprecated_round_trip() {
+        let json = serde_json::json!({
+            "type": "string",
+            "nullable": true,
+            "writeOnly": true,
+            "deprecated": true,
+            "readOnly": false
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+    }
+
+    #[test]
+    fn array_items_validate_walks() {
+        let json = serde_json::json!({
+            "type": "array",
+            "items": {"type": "string", "pattern": "["}
+        });
+        let parsed: Schema = serde_json::from_value(json).unwrap();
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        parsed.validate_with_context(&mut ctx, "arr".into());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("arr.items.pattern")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn schema_display_impl() {
+        assert_eq!(SingleSchema::String(StringSchema::default()).to_string(), "string");
+        assert_eq!(SingleSchema::Integer(IntegerSchema::default()).to_string(), "integer");
+        assert_eq!(SingleSchema::Number(NumberSchema::default()).to_string(), "number");
+        assert_eq!(SingleSchema::Boolean(BooleanSchema::default()).to_string(), "boolean");
+        assert_eq!(SingleSchema::Array(ArraySchema::default()).to_string(), "array");
+        assert_eq!(SingleSchema::Object(ObjectSchema::default()).to_string(), "object");
+        assert_eq!(SingleSchema::Null(NullSchema::default()).to_string(), "null");
+    }
+
+    #[test]
+    fn common_extension_fields_round_trip() {
+        let json = serde_json::json!({
+            "type": "string",
+            "enum": ["open", "closed"],
+            "x-enumDescriptions": ["Open state", "Closed state"],
+            "x-enum-varnames": ["Open", "Closed"],
+            "x-enumNames": ["OPEN", "CLOSED"],
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+
+        let json = serde_json::json!({
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "x-additionalPropertiesName": "metadata",
+        });
+        let parsed: Schema = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
     }
 }

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
-use crate::common::reference::RefOr;
+use crate::v3_0::reference::RefOr;
 use crate::v3_0::discriminator::Discriminator;
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::spec::Spec;
@@ -281,6 +281,25 @@ pub struct StringSchema {
     #[serde(rename = "readOnly")]
     pub read_only: Option<bool>,
 
+    /// Relevant only for Schema "properties" definitions.
+    /// Declares the property as "write only", meaning it MAY be sent as part
+    /// of a request but MUST NOT be sent as part of a response.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "writeOnly")]
+    pub write_only: Option<bool>,
+
+    /// Allows the value to be `null` in addition to its declared type.
+    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
+    /// Specifies that the schema is deprecated and SHOULD be transitioned out
+    /// of usage. Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     /// This MAY be used only on properties schemas.
     /// It has no effect on root schemas.
     /// Adds Additional metadata to describe the XML representation format of this property.
@@ -374,6 +393,25 @@ pub struct IntegerSchema {
     #[serde(rename = "readOnly")]
     pub read_only: Option<bool>,
 
+    /// Relevant only for Schema "properties" definitions.
+    /// Declares the property as "write only", meaning it MAY be sent as part
+    /// of a request but MUST NOT be sent as part of a response.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "writeOnly")]
+    pub write_only: Option<bool>,
+
+    /// Allows the value to be `null` in addition to its declared type.
+    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
+    /// Specifies that the schema is deprecated and SHOULD be transitioned out
+    /// of usage. Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     /// This MAY be used only on properties schemas.
     /// It has no effect on root schemas.
     /// Adds Additional metadata to describe the XML representation format of this property.
@@ -460,6 +498,25 @@ pub struct NumberSchema {
     #[serde(rename = "readOnly")]
     pub read_only: Option<bool>,
 
+    /// Relevant only for Schema "properties" definitions.
+    /// Declares the property as "write only", meaning it MAY be sent as part
+    /// of a request but MUST NOT be sent as part of a response.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "writeOnly")]
+    pub write_only: Option<bool>,
+
+    /// Allows the value to be `null` in addition to its declared type.
+    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
+    /// Specifies that the schema is deprecated and SHOULD be transitioned out
+    /// of usage. Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     /// This MAY be used only on properties schemas.
     /// It has no effect on root schemas.
     /// Adds Additional metadata to describe the XML representation format of this property.
@@ -513,6 +570,25 @@ pub struct BooleanSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "readOnly")]
     pub read_only: Option<bool>,
+
+    /// Relevant only for Schema "properties" definitions.
+    /// Declares the property as "write only", meaning it MAY be sent as part
+    /// of a request but MUST NOT be sent as part of a response.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "writeOnly")]
+    pub write_only: Option<bool>,
+
+    /// Allows the value to be `null` in addition to its declared type.
+    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
+    /// Specifies that the schema is deprecated and SHOULD be transitioned out
+    /// of usage. Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
 
     /// This MAY be used only on properties schemas.
     /// It has no effect on root schemas.
@@ -584,6 +660,25 @@ pub struct ArraySchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "readOnly")]
     pub read_only: Option<bool>,
+
+    /// Relevant only for Schema "properties" definitions.
+    /// Declares the property as "write only", meaning it MAY be sent as part
+    /// of a request but MUST NOT be sent as part of a response.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "writeOnly")]
+    pub write_only: Option<bool>,
+
+    /// Allows the value to be `null` in addition to its declared type.
+    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
+    /// Specifies that the schema is deprecated and SHOULD be transitioned out
+    /// of usage. Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
 
     /// This MAY be used only on properties schemas.
     /// It has no effect on root schemas.
@@ -662,6 +757,25 @@ pub struct ObjectSchema {
     #[serde(rename = "readOnly")]
     pub read_only: Option<bool>,
 
+    /// Relevant only for Schema "properties" definitions.
+    /// Declares the property as "write only", meaning it MAY be sent as part
+    /// of a request but MUST NOT be sent as part of a response.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "writeOnly")]
+    pub write_only: Option<bool>,
+
+    /// Allows the value to be `null` in addition to its declared type.
+    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
+    /// Specifies that the schema is deprecated and SHOULD be transitioned out
+    /// of usage. Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
     /// This MAY be used only on properties schemas.
     /// It has no effect on root schemas.
     /// Adds Additional metadata to describe the XML representation format of this property.
@@ -709,6 +823,25 @@ pub struct NullSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "readOnly")]
     pub read_only: Option<bool>,
+
+    /// Relevant only for Schema "properties" definitions.
+    /// Declares the property as "write only", meaning it MAY be sent as part
+    /// of a request but MUST NOT be sent as part of a response.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "writeOnly")]
+    pub write_only: Option<bool>,
+
+    /// Allows the value to be `null` in addition to its declared type.
+    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
+    /// Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+
+    /// Specifies that the schema is deprecated and SHOULD be transitioned out
+    /// of usage. Default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
 
     /// This MAY be used only on properties schemas.
     /// It has no effect on root schemas.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -305,8 +305,8 @@ pub struct StringSchema {
     pub write_only: Option<bool>,
 
     /// Allows the value to be `null` in addition to its declared type.
-    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
-    /// Default value is `false`.
+    /// OpenAPI 3.0-only — 3.1 uses the `type` array form (e.g.
+    /// `type: ["<type>", "null"]`) instead. Default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
@@ -432,8 +432,8 @@ pub struct IntegerSchema {
     pub write_only: Option<bool>,
 
     /// Allows the value to be `null` in addition to its declared type.
-    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
-    /// Default value is `false`.
+    /// OpenAPI 3.0-only — 3.1 uses the `type` array form (e.g.
+    /// `type: ["<type>", "null"]`) instead. Default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
@@ -552,8 +552,8 @@ pub struct NumberSchema {
     pub write_only: Option<bool>,
 
     /// Allows the value to be `null` in addition to its declared type.
-    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
-    /// Default value is `false`.
+    /// OpenAPI 3.0-only — 3.1 uses the `type` array form (e.g.
+    /// `type: ["<type>", "null"]`) instead. Default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
@@ -625,8 +625,8 @@ pub struct BooleanSchema {
     pub write_only: Option<bool>,
 
     /// Allows the value to be `null` in addition to its declared type.
-    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
-    /// Default value is `false`.
+    /// OpenAPI 3.0-only — 3.1 uses the `type` array form (e.g.
+    /// `type: ["<type>", "null"]`) instead. Default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
@@ -715,8 +715,8 @@ pub struct ArraySchema {
     pub write_only: Option<bool>,
 
     /// Allows the value to be `null` in addition to its declared type.
-    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
-    /// Default value is `false`.
+    /// OpenAPI 3.0-only — 3.1 uses the `type` array form (e.g.
+    /// `type: ["<type>", "null"]`) instead. Default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
@@ -816,8 +816,8 @@ pub struct ObjectSchema {
     pub write_only: Option<bool>,
 
     /// Allows the value to be `null` in addition to its declared type.
-    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
-    /// Default value is `false`.
+    /// OpenAPI 3.0-only — 3.1 uses the `type` array form (e.g.
+    /// `type: ["<type>", "null"]`) instead. Default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
@@ -883,8 +883,8 @@ pub struct NullSchema {
     pub write_only: Option<bool>,
 
     /// Allows the value to be `null` in addition to its declared type.
-    /// OpenAPI 3.0-only — 3.1 uses `type: ["string", "null"]` instead.
-    /// Default value is `false`.
+    /// OpenAPI 3.0-only — 3.1 uses the `type` array form (e.g.
+    /// `type: ["<type>", "null"]`) instead. Default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -863,9 +863,7 @@ mod tests {
         let r = spec
             .define_request_body("RB", RequestBody::default())
             .unwrap();
-        assert!(
-            matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/requestBodies/RB")
-        );
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/requestBodies/RB"));
 
         let r = spec.define_header("H", Header::default()).unwrap();
         assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/headers/H"));
@@ -918,7 +916,10 @@ mod tests {
         let bad = "x y";
         assert!(spec.define_response(bad, Response::default()).is_err());
         assert!(spec.define_example(bad, Example::default()).is_err());
-        assert!(spec.define_request_body(bad, RequestBody::default()).is_err());
+        assert!(
+            spec.define_request_body(bad, RequestBody::default())
+                .is_err()
+        );
         assert!(spec.define_header(bad, Header::default()).is_err());
         assert!(
             spec.define_security_scheme(
@@ -973,7 +974,8 @@ mod tests {
             }),
         )
         .unwrap();
-        spec.define_request_body("RB", RequestBody::default()).unwrap();
+        spec.define_request_body("RB", RequestBody::default())
+            .unwrap();
         spec.define_header("H", Header::default()).unwrap();
         spec.define_example("E", Example::default()).unwrap();
         spec.define_callback("CB", Callback::default()).unwrap();
@@ -989,15 +991,60 @@ mod tests {
         )
         .unwrap();
 
-        assert!(<Spec as ResolveReference<Schema>>::resolve_reference(&spec, "#/components/schemas/S").is_some());
-        assert!(<Spec as ResolveReference<Response>>::resolve_reference(&spec, "#/components/responses/R").is_some());
-        assert!(<Spec as ResolveReference<Parameter>>::resolve_reference(&spec, "#/components/parameters/P").is_some());
-        assert!(<Spec as ResolveReference<RequestBody>>::resolve_reference(&spec, "#/components/requestBodies/RB").is_some());
-        assert!(<Spec as ResolveReference<Header>>::resolve_reference(&spec, "#/components/headers/H").is_some());
-        assert!(<Spec as ResolveReference<Example>>::resolve_reference(&spec, "#/components/examples/E").is_some());
-        assert!(<Spec as ResolveReference<Callback>>::resolve_reference(&spec, "#/components/callbacks/CB").is_some());
-        assert!(<Spec as ResolveReference<Link>>::resolve_reference(&spec, "#/components/links/L").is_some());
-        assert!(<Spec as ResolveReference<SecurityScheme>>::resolve_reference(&spec, "#/components/securitySchemes/SS").is_some());
+        assert!(
+            <Spec as ResolveReference<Schema>>::resolve_reference(&spec, "#/components/schemas/S")
+                .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<Response>>::resolve_reference(
+                &spec,
+                "#/components/responses/R"
+            )
+            .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<Parameter>>::resolve_reference(
+                &spec,
+                "#/components/parameters/P"
+            )
+            .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<RequestBody>>::resolve_reference(
+                &spec,
+                "#/components/requestBodies/RB"
+            )
+            .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<Header>>::resolve_reference(&spec, "#/components/headers/H")
+                .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<Example>>::resolve_reference(
+                &spec,
+                "#/components/examples/E"
+            )
+            .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<Callback>>::resolve_reference(
+                &spec,
+                "#/components/callbacks/CB"
+            )
+            .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<Link>>::resolve_reference(&spec, "#/components/links/L")
+                .is_some()
+        );
+        assert!(
+            <Spec as ResolveReference<SecurityScheme>>::resolve_reference(
+                &spec,
+                "#/components/securitySchemes/SS"
+            )
+            .is_some()
+        );
 
         // tags resolver finds tags by name.
         let spec = Spec {
@@ -1008,7 +1055,9 @@ mod tests {
             ..Default::default()
         };
         assert!(<Spec as ResolveReference<Tag>>::resolve_reference(&spec, "#/tags/pets").is_some());
-        assert!(<Spec as ResolveReference<Tag>>::resolve_reference(&spec, "#/tags/missing").is_none());
+        assert!(
+            <Spec as ResolveReference<Tag>>::resolve_reference(&spec, "#/tags/missing").is_none()
+        );
     }
 
     #[test]
@@ -1065,7 +1114,9 @@ mod tests {
         };
         let err = spec.validate(Options::new()).unwrap_err();
         assert!(
-            err.errors.iter().any(|e| e.contains("collapse to the same shape")),
+            err.errors
+                .iter()
+                .any(|e| e.contains("collapse to the same shape")),
             "expected equivalent-template error: {:?}",
             err.errors
         );

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -4,7 +4,7 @@ use crate::common::helpers::{
     Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
     validate_not_visited,
 };
-use crate::common::reference::{RefOr, ResolveReference, resolve_in_map};
+use crate::common::reference::ResolveReference;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::components::Components;
 use crate::v3_0::example::Example;
@@ -13,13 +13,18 @@ use crate::v3_0::header::Header;
 use crate::v3_0::info::Info;
 use crate::v3_0::link::Link;
 use crate::v3_0::parameter::Parameter;
-use crate::v3_0::path_item::PathItem;
+use crate::v3_0::path_item::Paths;
+use crate::v3_0::reference::{RefOr, resolve_in_map};
 use crate::v3_0::request_body::RequestBody;
 use crate::v3_0::response::Response;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::security_scheme::SecurityScheme;
 use crate::v3_0::server::Server;
 use crate::v3_0::tag::Tag;
+use crate::v3_0::validation::{
+    validate_path_item, validate_path_template_uniqueness, validate_security_requirements,
+    validate_tag_uniqueness,
+};
 use crate::validation::{Error, Options, Validate};
 use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
@@ -181,8 +186,6 @@ pub struct Spec {
     /// as they are identical.
     /// In case of ambiguous matching, it’s up to the tooling to decide which one to use.
     ///
-    /// Support of extensions is dropped for simplicity.
-    ///
     /// Specification example:
     ///
     /// ```yaml
@@ -199,7 +202,7 @@ pub struct Spec {
     ///               items:
     ///                 $ref: '#/components/schemas/pet'
     /// ```
-    pub paths: BTreeMap<String, PathItem>,
+    pub paths: Paths,
 
     /// An element to hold various schemas for the specification.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -580,12 +583,24 @@ impl Validate for Spec {
             }
         }
 
+        // Top-level security: visit referenced schemes (so unused-detection
+        // doesn't fault on schemes the API actually requires) and run the
+        // scope-by-scheme-type checks.
+        if let Some(sec) = &self.security {
+            validate_security_requirements(&mut ctx, "#.security", sec);
+        }
+
+        // Equivalent-template detection: `/pets/{id}` and `/pets/{name}`
+        // collapse to the same canonical shape.
+        validate_path_template_uniqueness(&mut ctx, &self.paths.paths);
+
         for (name, item) in self.paths.iter() {
             let path = format!("#.paths[{name}]");
             if !name.starts_with('/') {
                 ctx.error(path.clone(), "must start with `/`");
             }
-            item.validate_with_context(&mut ctx, path);
+            item.validate_with_context(&mut ctx, path.clone());
+            validate_path_item(&mut ctx, name, &path, item);
         }
 
         if let Some(components) = &self.components {
@@ -597,6 +612,7 @@ impl Validate for Spec {
         }
 
         if let Some(tags) = &self.tags {
+            validate_tag_uniqueness(&mut ctx, tags);
             for tag in tags.iter() {
                 let path = format!("#/tags/{}", tag.name);
                 validate_not_visited(tag, &mut ctx, Options::IgnoreUnusedTags, path);

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -1061,6 +1061,81 @@ mod tests {
     }
 
     #[test]
+    fn component_reference_alias_chain_resolves() {
+        use crate::v3_0::components::Components;
+        use crate::v3_0::schema::{SingleSchema, StringSchema};
+
+        let mut schemas = BTreeMap::new();
+        schemas.insert(
+            "AliasA".to_owned(),
+            RefOr::new_ref("#/components/schemas/AliasB"),
+        );
+        schemas.insert(
+            "AliasB".to_owned(),
+            RefOr::new_ref("#/components/schemas/Target"),
+        );
+        schemas.insert(
+            "Target".to_owned(),
+            RefOr::new_item(SingleSchema::from(StringSchema::default()).into()),
+        );
+        let spec = Spec {
+            components: Some(Components {
+                schemas: Some(schemas),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert!(
+            <Spec as ResolveReference<Schema>>::resolve_reference(
+                &spec,
+                "#/components/schemas/AliasA"
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn component_reference_alias_cycle_does_not_recurse_forever() {
+        use crate::common::helpers::Context;
+        use crate::v3_0::components::Components;
+
+        let mut schemas = BTreeMap::new();
+        schemas.insert(
+            "AliasA".to_owned(),
+            RefOr::new_ref("#/components/schemas/AliasB"),
+        );
+        schemas.insert(
+            "AliasB".to_owned(),
+            RefOr::new_ref("#/components/schemas/AliasA"),
+        );
+        let spec = Spec {
+            components: Some(Components {
+                schemas: Some(schemas),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert!(
+            <Spec as ResolveReference<Schema>>::resolve_reference(
+                &spec,
+                "#/components/schemas/AliasA"
+            )
+            .is_none()
+        );
+
+        let mut ctx = Context::new(&spec, Options::new());
+        RefOr::<Schema>::new_ref("#/components/schemas/AliasA")
+            .validate_with_context(&mut ctx, "#.schema".to_owned());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("not found")),
+            "cycle should be reported as an unresolved ref, not recurse: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
     fn version_display_all_variants() {
         assert_eq!(Version::V3_0_0.to_string(), "3.0.0");
         assert_eq!(Version::V3_0_1.to_string(), "3.0.1");

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -2,7 +2,7 @@
 
 use crate::common::helpers::{
     Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
-    validate_not_visited,
+    validate_not_visited, validate_required_string,
 };
 use crate::common::reference::ResolveReference;
 use crate::v3_0::callback::Callback;
@@ -239,9 +239,30 @@ pub struct Spec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
 
+    /// ReDoc/Redocly extension that groups tags in the side menu.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-tagGroups")]
+    pub x_tag_groups: Option<Vec<TagGroup>>,
+
     /// This object MAY be extended with Specification Extensions.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// ReDoc/Redocly `x-tagGroups` extension entry.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct TagGroup {
+    /// **Required** The display name for the tag group.
+    pub name: String,
+
+    /// **Required** The tags included in the group.
+    pub tags: Vec<String>,
+
+    /// Allows extensions on the tag group extension object.
     #[serde(flatten)]
     #[serde(with = "crate::common::extensions")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -611,6 +632,12 @@ impl Validate for Spec {
             docs.validate_with_context(&mut ctx, "#.externalDocs".to_owned())
         }
 
+        if let Some(tag_groups) = &self.x_tag_groups {
+            for (i, tag_group) in tag_groups.iter().enumerate() {
+                tag_group.validate_with_context(&mut ctx, format!("#.x-tagGroups[{i}]"));
+            }
+        }
+
         if let Some(tags) = &self.tags {
             validate_tag_uniqueness(&mut ctx, tags);
             for tag in tags.iter() {
@@ -620,6 +647,15 @@ impl Validate for Spec {
         }
 
         ctx.into()
+    }
+}
+
+impl ValidateWithContext<Spec> for TagGroup {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+        for (i, tag) in self.tags.iter().enumerate() {
+            validate_required_string(tag, ctx, format!("{path}.tags[{i}]"));
+        }
     }
 }
 
@@ -780,6 +816,296 @@ mod tests {
         assert!(
             spec.components.is_none(),
             "name validation must run before mutation"
+        );
+    }
+
+    #[test]
+    fn all_define_helpers_insert_and_return_ref() {
+        use crate::v3_0::callback::Callback;
+        use crate::v3_0::example::Example;
+        use crate::v3_0::header::Header;
+        use crate::v3_0::link::Link;
+        use crate::v3_0::parameter::{InQuery, Parameter};
+        use crate::v3_0::request_body::RequestBody;
+        use crate::v3_0::response::Response;
+        use crate::v3_0::security_scheme::{HttpScheme, HttpSecurityScheme, SecurityScheme};
+
+        let mut spec = Spec::default();
+
+        let r = spec.define_response("Ok", Response::default()).unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/responses/Ok"));
+
+        let r = spec
+            .define_parameter(
+                "Q",
+                Parameter::Query(InQuery {
+                    name: "q".into(),
+                    description: None,
+                    required: None,
+                    deprecated: None,
+                    allow_empty_value: None,
+                    style: None,
+                    explode: None,
+                    allow_reserved: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                }),
+            )
+            .unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/parameters/Q"));
+
+        let r = spec.define_example("Ex", Example::default()).unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/examples/Ex"));
+
+        let r = spec
+            .define_request_body("RB", RequestBody::default())
+            .unwrap();
+        assert!(
+            matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/requestBodies/RB")
+        );
+
+        let r = spec.define_header("H", Header::default()).unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/headers/H"));
+
+        let r = spec
+            .define_security_scheme(
+                "S",
+                SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
+                    scheme: HttpScheme::Basic,
+                    bearer_format: None,
+                    description: None,
+                    extensions: None,
+                })),
+            )
+            .unwrap();
+        assert!(
+            matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/securitySchemes/S")
+        );
+
+        let r = spec.define_link("L", Link::default()).unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/links/L"));
+
+        let r = spec.define_callback("CB", Callback::default()).unwrap();
+        assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/callbacks/CB"));
+
+        // All inserts ended up under the same Components object.
+        let comp = spec.components.as_ref().unwrap();
+        assert!(comp.responses.as_ref().unwrap().contains_key("Ok"));
+        assert!(comp.parameters.as_ref().unwrap().contains_key("Q"));
+        assert!(comp.examples.as_ref().unwrap().contains_key("Ex"));
+        assert!(comp.request_bodies.as_ref().unwrap().contains_key("RB"));
+        assert!(comp.headers.as_ref().unwrap().contains_key("H"));
+        assert!(comp.security_schemes.as_ref().unwrap().contains_key("S"));
+        assert!(comp.links.as_ref().unwrap().contains_key("L"));
+        assert!(comp.callbacks.as_ref().unwrap().contains_key("CB"));
+    }
+
+    #[test]
+    fn define_helpers_reject_invalid_names() {
+        use crate::v3_0::callback::Callback;
+        use crate::v3_0::example::Example;
+        use crate::v3_0::header::Header;
+        use crate::v3_0::link::Link;
+        use crate::v3_0::request_body::RequestBody;
+        use crate::v3_0::response::Response;
+        use crate::v3_0::security_scheme::{HttpScheme, HttpSecurityScheme, SecurityScheme};
+
+        let mut spec = Spec::default();
+        // Use a name with an invalid character that the validator rejects.
+        let bad = "x y";
+        assert!(spec.define_response(bad, Response::default()).is_err());
+        assert!(spec.define_example(bad, Example::default()).is_err());
+        assert!(spec.define_request_body(bad, RequestBody::default()).is_err());
+        assert!(spec.define_header(bad, Header::default()).is_err());
+        assert!(
+            spec.define_security_scheme(
+                bad,
+                SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
+                    scheme: HttpScheme::Basic,
+                    bearer_format: None,
+                    description: None,
+                    extensions: None,
+                })),
+            )
+            .is_err()
+        );
+        assert!(spec.define_link(bad, Link::default()).is_err());
+        assert!(spec.define_callback(bad, Callback::default()).is_err());
+        // None of the failures left state behind.
+        assert!(spec.components.is_none());
+    }
+
+    #[test]
+    fn resolve_reference_paths_for_each_component_kind() {
+        use crate::v3_0::callback::Callback;
+        use crate::v3_0::example::Example;
+        use crate::v3_0::header::Header;
+        use crate::v3_0::link::Link;
+        use crate::v3_0::parameter::{InQuery, Parameter};
+        use crate::v3_0::request_body::RequestBody;
+        use crate::v3_0::response::Response;
+        use crate::v3_0::schema::{SingleSchema, StringSchema};
+        use crate::v3_0::security_scheme::{HttpScheme, HttpSecurityScheme, SecurityScheme};
+
+        let mut spec = Spec::default();
+        spec.define_schema("S", SingleSchema::from(StringSchema::default()))
+            .unwrap();
+        spec.define_response("R", Response::default()).unwrap();
+        spec.define_parameter(
+            "P",
+            Parameter::Query(InQuery {
+                name: "q".into(),
+                description: None,
+                required: None,
+                deprecated: None,
+                allow_empty_value: None,
+                style: None,
+                explode: None,
+                allow_reserved: None,
+                schema: None,
+                example: None,
+                examples: None,
+                content: None,
+                extensions: None,
+            }),
+        )
+        .unwrap();
+        spec.define_request_body("RB", RequestBody::default()).unwrap();
+        spec.define_header("H", Header::default()).unwrap();
+        spec.define_example("E", Example::default()).unwrap();
+        spec.define_callback("CB", Callback::default()).unwrap();
+        spec.define_link("L", Link::default()).unwrap();
+        spec.define_security_scheme(
+            "SS",
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
+                scheme: HttpScheme::Basic,
+                bearer_format: None,
+                description: None,
+                extensions: None,
+            })),
+        )
+        .unwrap();
+
+        assert!(<Spec as ResolveReference<Schema>>::resolve_reference(&spec, "#/components/schemas/S").is_some());
+        assert!(<Spec as ResolveReference<Response>>::resolve_reference(&spec, "#/components/responses/R").is_some());
+        assert!(<Spec as ResolveReference<Parameter>>::resolve_reference(&spec, "#/components/parameters/P").is_some());
+        assert!(<Spec as ResolveReference<RequestBody>>::resolve_reference(&spec, "#/components/requestBodies/RB").is_some());
+        assert!(<Spec as ResolveReference<Header>>::resolve_reference(&spec, "#/components/headers/H").is_some());
+        assert!(<Spec as ResolveReference<Example>>::resolve_reference(&spec, "#/components/examples/E").is_some());
+        assert!(<Spec as ResolveReference<Callback>>::resolve_reference(&spec, "#/components/callbacks/CB").is_some());
+        assert!(<Spec as ResolveReference<Link>>::resolve_reference(&spec, "#/components/links/L").is_some());
+        assert!(<Spec as ResolveReference<SecurityScheme>>::resolve_reference(&spec, "#/components/securitySchemes/SS").is_some());
+
+        // tags resolver finds tags by name.
+        let spec = Spec {
+            tags: Some(vec![Tag {
+                name: "pets".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        assert!(<Spec as ResolveReference<Tag>>::resolve_reference(&spec, "#/tags/pets").is_some());
+        assert!(<Spec as ResolveReference<Tag>>::resolve_reference(&spec, "#/tags/missing").is_none());
+    }
+
+    #[test]
+    fn version_display_all_variants() {
+        assert_eq!(Version::V3_0_0.to_string(), "3.0.0");
+        assert_eq!(Version::V3_0_1.to_string(), "3.0.1");
+        assert_eq!(Version::V3_0_2.to_string(), "3.0.2");
+        assert_eq!(Version::V3_0_3.to_string(), "3.0.3");
+        assert_eq!(Version::V3_0_4.to_string(), "3.0.4");
+    }
+
+    #[test]
+    fn full_spec_validate_drives_path_template_uniqueness() {
+        use crate::v3_0::path_item::Paths;
+        use crate::v3_0::response::{Response, Responses};
+
+        let mut paths = Paths::default();
+        let make_op = || crate::v3_0::operation::Operation {
+            responses: Responses {
+                default: Some(RefOr::new_item(Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut ops_a: BTreeMap<String, crate::v3_0::operation::Operation> = BTreeMap::new();
+        ops_a.insert("get".to_owned(), make_op());
+        let mut ops_b: BTreeMap<String, crate::v3_0::operation::Operation> = BTreeMap::new();
+        ops_b.insert("get".to_owned(), make_op());
+        paths.paths.insert(
+            "/pets/{id}".into(),
+            crate::v3_0::path_item::PathItem {
+                operations: Some(ops_a),
+                ..Default::default()
+            },
+        );
+        paths.paths.insert(
+            "/pets/{name}".into(),
+            crate::v3_0::path_item::PathItem {
+                operations: Some(ops_b),
+                ..Default::default()
+            },
+        );
+        let spec = Spec {
+            info: Info {
+                title: "x".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            paths,
+            ..Default::default()
+        };
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors.iter().any(|e| e.contains("collapse to the same shape")),
+            "expected equivalent-template error: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn x_tag_groups_round_trip_and_validate() {
+        let value = serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {
+                "title": "Pets",
+                "version": "1.0.0"
+            },
+            "paths": {},
+            "x-tagGroups": [
+                {
+                    "name": "Animals",
+                    "tags": ["pets"]
+                }
+            ]
+        });
+        let spec: Spec = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&spec).unwrap(), value);
+
+        let mut ctx = Context::new(&spec, Options::new());
+        spec.x_tag_groups
+            .as_ref()
+            .unwrap()
+            .first()
+            .unwrap()
+            .validate_with_context(&mut ctx, "#.x-tagGroups[0]".to_owned());
+        assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+
+        let mut ctx = Context::new(&spec, Options::new());
+        TagGroup::default().validate_with_context(&mut ctx, "#.x-tagGroups[0]".to_owned());
+        assert!(
+            ctx.errors
+                .contains(&"#.x-tagGroups[0].name: must not be empty".to_owned()),
+            "expected name error: {:?}",
+            ctx.errors
         );
     }
 }

--- a/src/v3_0/tag.rs
+++ b/src/v3_0/tag.rs
@@ -30,6 +30,11 @@ pub struct Tag {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
 
+    /// ReDoc/Redocly extension with a display name for navigation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x-displayName")]
+    pub x_display_name: Option<String>,
+
     /// Allows extensions to the Swagger Schema.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.
     /// The value can be null, a primitive, an array or an object.
@@ -197,6 +202,23 @@ mod tests {
             vec!["tag.name: must not be empty"],
             "name error: {:?}",
             ctx.errors
+        );
+    }
+
+    #[test]
+    fn x_display_name_round_trip() {
+        let tag: Tag = serde_json::from_value(serde_json::json!({
+            "name": "pet",
+            "x-displayName": "Pets"
+        }))
+        .unwrap();
+        assert_eq!(tag.x_display_name, Some("Pets".to_owned()));
+        assert_eq!(
+            serde_json::to_value(tag).unwrap(),
+            serde_json::json!({
+                "name": "pet",
+                "x-displayName": "Pets"
+            })
         );
     }
 }

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -200,14 +200,16 @@ pub fn validate_operation_parameters(
         }
     }
 
-    // If we deliberately skipped any external `$ref`, the missing-`in: path`
-    // parameter we'd report could be defined in that external document.
-    // Suppress both directions of the correspondence check in that case;
-    // unresolvable internal refs still pass through and produce errors via
-    // `RefOr::validate_with_context` elsewhere.
-    let skip_template_correspondence = has_unresolved_external;
+    // If we deliberately skipped any external `$ref`, a template variable
+    // that looks unmatched here may legitimately be defined in the external
+    // document we agreed not to follow. Suppress only the
+    // `template-var-missing-parameter` direction in that case. The opposite
+    // direction (a *declared* path parameter whose name is not in the
+    // template) still fires unconditionally — those parameters are visible
+    // locally, so the inconsistency is real regardless of external refs.
+    let skip_template_var_missing = has_unresolved_external;
 
-    if !skip_template_correspondence {
+    if !skip_template_var_missing {
         for var in &template_vars {
             if !declared_path_params.contains(var) {
                 ctx.error(

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -24,16 +24,33 @@ use crate::v3_0::reference::RefOr;
 use crate::v3_0::security_scheme::SecurityScheme;
 use crate::v3_0::spec::Spec;
 use crate::v3_0::tag::Tag;
+use crate::validation::Options;
 
-/// Resolve a `RefOr<Parameter>` against the spec's
-/// `#/components/parameters/...` pool. Returns `None` for unresolvable refs;
-/// the caller treats those as opaque (downstream `RefOr::validate_with_context`
-/// will already report the missing-ref error elsewhere).
-fn resolve_parameter<'a>(spec: &'a Spec, p: &'a RefOr<Parameter>) -> Option<&'a Parameter> {
+/// Result of attempting to resolve a `RefOr<Parameter>` for cross-cutting
+/// validation purposes. The distinction between an unresolved *internal* ref
+/// (already a hard error elsewhere via `RefOr::validate_with_context`) and an
+/// unresolved *external* ref matters: when the user has set
+/// `IgnoreExternalReferences`, we must not report a missing-`in: path`
+/// parameter error for a template variable that may well be defined in the
+/// external document we agreed to skip.
+enum ResolvedParam<'a> {
+    Item(&'a Parameter),
+    UnresolvedInternal,
+    UnresolvedExternal,
+}
+
+fn resolve_parameter<'a>(spec: &'a Spec, p: &'a RefOr<Parameter>) -> ResolvedParam<'a> {
     match p {
-        RefOr::Item(p) => Some(p),
+        RefOr::Item(p) => ResolvedParam::Item(p),
         RefOr::Ref(r) => {
-            <Spec as ResolveReference<Parameter>>::resolve_reference(spec, &r.reference)
+            if r.reference.starts_with("#/") {
+                match <Spec as ResolveReference<Parameter>>::resolve_reference(spec, &r.reference) {
+                    Some(p) => ResolvedParam::Item(p),
+                    None => ResolvedParam::UnresolvedInternal,
+                }
+            } else {
+                ResolvedParam::UnresolvedExternal
+            }
         }
     }
 }
@@ -92,30 +109,64 @@ pub fn validate_operation_parameters(
 ) {
     let template_vars = path_template_variables(template);
 
-    let mut emit_within_level_dups = |params: &[RefOr<Parameter>], origin: &str| {
+    // Whether we encountered any external `$ref` we couldn't follow under the
+    // current Options. If so, the path-template correspondence check is
+    // suppressed below — the missing path parameter may legitimately be
+    // declared in the external document we chose to skip.
+    let ignore_external = ctx.is_option(Options::IgnoreExternalReferences);
+    let mut has_unresolved_external = false;
+
+    fn dup_pass(
+        ctx: &mut Context<Spec>,
+        op_path: &str,
+        params: &[RefOr<Parameter>],
+        origin: &str,
+        ignore_external: bool,
+        has_unresolved_external: &mut bool,
+    ) {
         let mut seen: BTreeMap<(String, &'static str), usize> = BTreeMap::new();
         for (i, raw) in params.iter().enumerate() {
-            let Some(p) = resolve_parameter(ctx.spec, raw) else {
-                continue;
-            };
-            let (name, loc) = parameter_identity(p);
-            let key = (name.to_owned(), loc);
-            *seen.entry(key.clone()).or_insert(0) += 1;
-            if seen[&key] == 2 {
-                ctx.error(
-                    op_path.to_owned(),
-                    format_args!(
-                        ".parameters: duplicate parameter `{name}` in `{loc}` ({origin}[{i}])"
-                    ),
-                );
+            let r = resolve_parameter(ctx.spec, raw);
+            match r {
+                ResolvedParam::Item(p) => {
+                    let (name, loc) = parameter_identity(p);
+                    let key = (name.to_owned(), loc);
+                    *seen.entry(key.clone()).or_insert(0) += 1;
+                    if seen[&key] == 2 {
+                        ctx.error(
+                            op_path.to_owned(),
+                            format_args!(
+                                ".parameters: duplicate parameter `{name}` in `{loc}` ({origin}[{i}])"
+                            ),
+                        );
+                    }
+                }
+                ResolvedParam::UnresolvedExternal if ignore_external => {
+                    *has_unresolved_external = true;
+                }
+                _ => {}
             }
         }
-    };
+    }
     if let Some(p) = path_item_params {
-        emit_within_level_dups(p, "path-item");
+        dup_pass(
+            ctx,
+            op_path,
+            p,
+            "path-item",
+            ignore_external,
+            &mut has_unresolved_external,
+        );
     }
     if let Some(p) = op_params {
-        emit_within_level_dups(p, "operation");
+        dup_pass(
+            ctx,
+            op_path,
+            p,
+            "operation",
+            ignore_external,
+            &mut has_unresolved_external,
+        );
     }
 
     // Merge: keyed by (name, in). Operation-level overrides path-item-level.
@@ -134,17 +185,9 @@ pub fn validate_operation_parameters(
         }
     }
     let mut merged: BTreeMap<(String, &'static str), Kind> = BTreeMap::new();
-    if let Some(params) = path_item_params {
+    for params in [path_item_params, op_params].into_iter().flatten() {
         for raw in params {
-            if let Some(p) = resolve_parameter(ctx.spec, raw) {
-                let (name, loc) = parameter_identity(p);
-                merged.insert((name.to_owned(), loc), kind_of(p));
-            }
-        }
-    }
-    if let Some(params) = op_params {
-        for raw in params {
-            if let Some(p) = resolve_parameter(ctx.spec, raw) {
+            if let ResolvedParam::Item(p) = resolve_parameter(ctx.spec, raw) {
                 let (name, loc) = parameter_identity(p);
                 merged.insert((name.to_owned(), loc), kind_of(p));
             }
@@ -158,14 +201,23 @@ pub fn validate_operation_parameters(
         }
     }
 
-    for var in &template_vars {
-        if !declared_path_params.contains(var) {
-            ctx.error(
-                op_path.to_owned(),
-                format_args!(
-                    ".parameters: path template variable `{{{var}}}` has no matching `in: path` parameter"
-                ),
-            );
+    // If we deliberately skipped any external `$ref`, the missing-`in: path`
+    // parameter we'd report could be defined in that external document.
+    // Suppress both directions of the correspondence check in that case;
+    // unresolvable internal refs still pass through and produce errors via
+    // `RefOr::validate_with_context` elsewhere.
+    let skip_template_correspondence = has_unresolved_external;
+
+    if !skip_template_correspondence {
+        for var in &template_vars {
+            if !declared_path_params.contains(var) {
+                ctx.error(
+                    op_path.to_owned(),
+                    format_args!(
+                        ".parameters: path template variable `{{{var}}}` has no matching `in: path` parameter"
+                    ),
+                );
+            }
         }
     }
     for declared in &declared_path_params {
@@ -184,7 +236,7 @@ pub fn validate_operation_parameters(
 /// operation level). Marks each named scheme as visited (for unused-scheme
 /// detection) and enforces:
 /// * the named scheme exists in `components.securitySchemes`,
-/// * apiKey / http / mutualTLS schemes carry only an empty scope array,
+/// * apiKey / http schemes carry only an empty scope array,
 /// * oauth2 / openIdConnect schemes' scopes (if any) are listed in some flow.
 pub fn validate_security_requirements(
     ctx: &mut Context<Spec>,
@@ -501,6 +553,39 @@ mod tests {
         assert!(
             ctx.errors.iter().any(|e| e
                 .contains("path parameter `id` does not match any `{name}` in the path template")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn external_ref_suppresses_template_correspondence_under_ignore_external() {
+        // A parameter whose `$ref` points to an external document we have
+        // chosen to skip should NOT trigger the "template variable has no
+        // matching `in: path` parameter" error — the external doc may well
+        // declare it.
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let params: Vec<RefOr<Parameter>> = vec![RefOr::new_ref(
+            "https://other.example/spec.yaml#/components/parameters/PetId",
+        )];
+
+        // Without IgnoreExternalReferences: the error fires (we have no info).
+        let mut ctx = Context::new(spec, Options::new());
+        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("template variable `{id}`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // With IgnoreExternalReferences: suppressed (the external doc may
+        // define `id`).
+        let mut ctx = Context::new(spec, Options::IgnoreExternalReferences.only());
+        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("template variable")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -73,7 +73,9 @@ fn path_template_variables(template: &str) -> BTreeSet<String> {
 /// Per OAS: "Templated paths with the same hierarchy but different templated
 /// names MUST NOT exist as they are identical."
 fn canonical_path(template: &str) -> String {
-    regex!(r"\{[^}]+\}").replace_all(template, "{}").into_owned()
+    regex!(r"\{[^}]+\}")
+        .replace_all(template, "{}")
+        .into_owned()
 }
 
 /// Validate operation-level parameter rules:
@@ -229,10 +231,22 @@ pub fn validate_security_requirements(
                         let scope_ref = format!("{scheme_ref}/{scope}");
                         ctx.visit(scope_ref);
                         let in_any = [
-                            o.flows.implicit.as_ref().map(|f| f.scopes.contains_key(scope)),
-                            o.flows.password.as_ref().map(|f| f.scopes.contains_key(scope)),
-                            o.flows.client_credentials.as_ref().map(|f| f.scopes.contains_key(scope)),
-                            o.flows.authorization_code.as_ref().map(|f| f.scopes.contains_key(scope)),
+                            o.flows
+                                .implicit
+                                .as_ref()
+                                .map(|f| f.scopes.contains_key(scope)),
+                            o.flows
+                                .password
+                                .as_ref()
+                                .map(|f| f.scopes.contains_key(scope)),
+                            o.flows
+                                .client_credentials
+                                .as_ref()
+                                .map(|f| f.scopes.contains_key(scope)),
+                            o.flows
+                                .authorization_code
+                                .as_ref()
+                                .map(|f| f.scopes.contains_key(scope)),
                         ]
                         .into_iter()
                         .flatten()
@@ -284,7 +298,10 @@ pub fn validate_tag_uniqueness(ctx: &mut Context<Spec>, tags: &[Tag]) {
 
 /// Validate that no two paths in `Spec.paths` collapse to the same
 /// canonical (template-stripped) form. Extension keys (`x-...`) are skipped.
-pub fn validate_path_template_uniqueness(ctx: &mut Context<Spec>, paths: &BTreeMap<String, PathItem>) {
+pub fn validate_path_template_uniqueness(
+    ctx: &mut Context<Spec>,
+    paths: &BTreeMap<String, PathItem>,
+) {
     let mut canonicals: HashMap<String, Vec<&str>> = HashMap::new();
     for key in paths.keys() {
         if key.starts_with("x-") {
@@ -669,7 +686,10 @@ mod tests {
         let spec: &'static Spec = Box::leak(Box::new(spec_with_components(comp)));
         let mut ctx = Context::new(spec, Options::new());
         let mut req: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        req.insert("oid".to_owned(), vec!["openid".to_owned(), "email".to_owned()]);
+        req.insert(
+            "oid".to_owned(),
+            vec!["openid".to_owned(), "email".to_owned()],
+        );
         validate_security_requirements(&mut ctx, "#.security", &[req]);
         assert!(
             ctx.errors.is_empty(),

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -17,7 +17,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::common::helpers::{Context, PushError};
 use crate::common::reference::ResolveReference;
-use crate::v3_0::operation::Operation;
 use crate::v3_0::parameter::{InCookie, InHeader, InPath, InQuery, Parameter};
 use crate::v3_0::path_item::PathItem;
 use crate::v3_0::reference::RefOr;
@@ -376,7 +375,12 @@ pub fn validate_path_template_uniqueness(
     }
 }
 
-/// Per-path entry point: walk operations and emit cross-cutting checks.
+/// Per-path entry point: emit cross-cutting checks that only make sense for
+/// the operations actually mounted on `Spec.paths` — currently parameter
+/// dedup and path-template ↔ `in: path` correspondence. Operation-level
+/// `security` is intentionally NOT validated here: it runs from
+/// `Operation::validate_with_context` so it also fires for operations
+/// nested inside Callback path items (which this function never sees).
 pub fn validate_path_item(ctx: &mut Context<Spec>, template: &str, path: &str, item: &PathItem) {
     let pi_params = item.parameters.as_deref();
     if let Some(ops) = &item.operations {
@@ -389,14 +393,7 @@ pub fn validate_path_item(ctx: &mut Context<Spec>, template: &str, path: &str, i
                 pi_params,
                 op.parameters.as_deref(),
             );
-            validate_operation_security(ctx, &op_path, op);
         }
-    }
-}
-
-fn validate_operation_security(ctx: &mut Context<Spec>, op_path: &str, op: &Operation) {
-    if let Some(sec) = &op.security {
-        validate_security_requirements(ctx, &format!("{op_path}.security"), sec);
     }
 }
 

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -1,0 +1,698 @@
+//! Cross-cutting v3.0 validation rules that span multiple objects.
+//!
+//! Each helper is invoked from `Spec::validate` to enforce rules from the
+//! OpenAPI 3.0.4 spec that don't naturally fit on a single struct's
+//! `ValidateWithContext` impl:
+//!
+//! * Parameter (name, in) uniqueness with operation-overrides-pathItem semantics
+//! * Path template `{var}` ↔ `in: path` parameter correspondence
+//! * Equivalent templated paths (e.g. `/pets/{id}` vs `/pets/{name}`) collisions
+//! * Tag-name uniqueness in `Spec.tags`
+//! * Security requirement validation (top-level + operation-level), including
+//!   the OAS 3.0 rule that scope arrays must be empty for non-oauth2 /
+//!   non-openIdConnect schemes.
+
+use lazy_regex::regex;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::common::helpers::{Context, PushError};
+use crate::common::reference::ResolveReference;
+use crate::v3_0::operation::Operation;
+use crate::v3_0::parameter::{InCookie, InHeader, InPath, InQuery, Parameter};
+use crate::v3_0::path_item::PathItem;
+use crate::v3_0::reference::RefOr;
+use crate::v3_0::security_scheme::SecurityScheme;
+use crate::v3_0::spec::Spec;
+use crate::v3_0::tag::Tag;
+
+/// Resolve a `RefOr<Parameter>` against the spec's
+/// `#/components/parameters/...` pool. Returns `None` for unresolvable refs;
+/// the caller treats those as opaque (downstream `RefOr::validate_with_context`
+/// will already report the missing-ref error elsewhere).
+fn resolve_parameter<'a>(spec: &'a Spec, p: &'a RefOr<Parameter>) -> Option<&'a Parameter> {
+    match p {
+        RefOr::Item(p) => Some(p),
+        RefOr::Ref(r) => {
+            <Spec as ResolveReference<Parameter>>::resolve_reference(spec, &r.reference)
+        }
+    }
+}
+
+fn parameter_identity(p: &Parameter) -> (&str, &'static str) {
+    match p {
+        Parameter::Path(p) => (in_path_name(p), "path"),
+        Parameter::Query(q) => (in_query_name(q), "query"),
+        Parameter::Header(h) => (in_header_name(h), "header"),
+        Parameter::Cookie(c) => (in_cookie_name(c), "cookie"),
+    }
+}
+
+fn in_path_name(p: &InPath) -> &str {
+    &p.name
+}
+fn in_query_name(q: &InQuery) -> &str {
+    &q.name
+}
+fn in_header_name(h: &InHeader) -> &str {
+    &h.name
+}
+fn in_cookie_name(c: &InCookie) -> &str {
+    &c.name
+}
+
+/// Extract `{name}` placeholders from a path template.
+fn path_template_variables(template: &str) -> BTreeSet<String> {
+    let re = regex!(r"\{([^}]+)\}");
+    re.captures_iter(template)
+        .map(|c| c.get(1).unwrap().as_str().to_owned())
+        .collect()
+}
+
+/// Reduce `/pets/{id}` and `/pets/{name}` to the same canonical form so
+/// "equivalent templated paths" can be detected as a spec violation.
+/// Per OAS: "Templated paths with the same hierarchy but different templated
+/// names MUST NOT exist as they are identical."
+fn canonical_path(template: &str) -> String {
+    regex!(r"\{[^}]+\}").replace_all(template, "{}").into_owned()
+}
+
+/// Validate operation-level parameter rules:
+/// * (name, in) duplicates *within the same level* are flagged as spec violations.
+/// * Operation-level entries override path-item-level entries with the same key.
+/// * Each path template `{var}` has a matching `in: path` parameter.
+/// * Each `in: path` parameter is referenced by the path template.
+pub fn validate_operation_parameters(
+    ctx: &mut Context<Spec>,
+    op_path: &str,
+    template: &str,
+    path_item_params: Option<&[RefOr<Parameter>]>,
+    op_params: Option<&[RefOr<Parameter>]>,
+) {
+    let template_vars = path_template_variables(template);
+
+    let mut emit_within_level_dups = |params: &[RefOr<Parameter>], origin: &str| {
+        let mut seen: BTreeMap<(String, &'static str), usize> = BTreeMap::new();
+        for (i, raw) in params.iter().enumerate() {
+            let Some(p) = resolve_parameter(ctx.spec, raw) else {
+                continue;
+            };
+            let (name, loc) = parameter_identity(p);
+            let key = (name.to_owned(), loc);
+            *seen.entry(key.clone()).or_insert(0) += 1;
+            if seen[&key] == 2 {
+                ctx.error(
+                    op_path.to_owned(),
+                    format_args!(
+                        ".parameters: duplicate parameter `{name}` in `{loc}` ({origin}[{i}])"
+                    ),
+                );
+            }
+        }
+    };
+    if let Some(p) = path_item_params {
+        emit_within_level_dups(p, "path-item");
+    }
+    if let Some(p) = op_params {
+        emit_within_level_dups(p, "operation");
+    }
+
+    // Merge: keyed by (name, in). Operation-level overrides path-item-level.
+    // We only need the kind of the *winning* parameter for path counting,
+    // so we store an enum tag — sidestepping lifetime issues that would arise
+    // from holding `&Parameter` references across the collection boundary.
+    #[derive(Clone, Copy)]
+    enum Kind {
+        Path,
+        Other,
+    }
+    fn kind_of(p: &Parameter) -> Kind {
+        match p {
+            Parameter::Path(_) => Kind::Path,
+            _ => Kind::Other,
+        }
+    }
+    let mut merged: BTreeMap<(String, &'static str), Kind> = BTreeMap::new();
+    if let Some(params) = path_item_params {
+        for raw in params {
+            if let Some(p) = resolve_parameter(ctx.spec, raw) {
+                let (name, loc) = parameter_identity(p);
+                merged.insert((name.to_owned(), loc), kind_of(p));
+            }
+        }
+    }
+    if let Some(params) = op_params {
+        for raw in params {
+            if let Some(p) = resolve_parameter(ctx.spec, raw) {
+                let (name, loc) = parameter_identity(p);
+                merged.insert((name.to_owned(), loc), kind_of(p));
+            }
+        }
+    }
+
+    let mut declared_path_params: BTreeSet<String> = BTreeSet::new();
+    for ((name, _loc), kind) in &merged {
+        if matches!(kind, Kind::Path) {
+            declared_path_params.insert(name.clone());
+        }
+    }
+
+    for var in &template_vars {
+        if !declared_path_params.contains(var) {
+            ctx.error(
+                op_path.to_owned(),
+                format_args!(
+                    ".parameters: path template variable `{{{var}}}` has no matching `in: path` parameter"
+                ),
+            );
+        }
+    }
+    for declared in &declared_path_params {
+        if !template_vars.contains(declared) {
+            ctx.error(
+                op_path.to_owned(),
+                format_args!(
+                    ".parameters: path parameter `{declared}` does not match any `{{name}}` in the path template"
+                ),
+            );
+        }
+    }
+}
+
+/// Validate a list of security requirements (used at both spec and
+/// operation level). Marks each named scheme as visited (for unused-scheme
+/// detection) and enforces:
+/// * the named scheme exists in `components.securitySchemes`,
+/// * apiKey / http / mutualTLS schemes carry only an empty scope array,
+/// * oauth2 / openIdConnect schemes' scopes (if any) are listed in some flow.
+pub fn validate_security_requirements(
+    ctx: &mut Context<Spec>,
+    path: &str,
+    requirements: &[BTreeMap<String, Vec<String>>],
+) {
+    let schemes_map = ctx
+        .spec
+        .components
+        .as_ref()
+        .and_then(|c| c.security_schemes.as_ref());
+
+    for (i, req) in requirements.iter().enumerate() {
+        for (name, scopes) in req {
+            // Always mark the scheme as visited even if it's missing —
+            // unused-detection should not double-fault on a name we already
+            // reported as missing.
+            let scheme_ref = format!("#/components/securitySchemes/{name}");
+            ctx.visit(scheme_ref.clone());
+
+            let Some(map) = schemes_map else {
+                ctx.error(
+                    path.to_owned(),
+                    format_args!(
+                        "[{i}].`{name}`: no `components.securitySchemes` on the spec to resolve against"
+                    ),
+                );
+                continue;
+            };
+            let Some(scheme_or) = map.get(name) else {
+                ctx.error(
+                    path.to_owned(),
+                    format_args!("[{i}].`{name}`: not declared in `components.securitySchemes`"),
+                );
+                continue;
+            };
+            let Ok(scheme) = scheme_or.get_item(ctx.spec) else {
+                continue;
+            };
+
+            match scheme {
+                SecurityScheme::OAuth2(o) => {
+                    for scope in scopes {
+                        let scope_ref = format!("{scheme_ref}/{scope}");
+                        ctx.visit(scope_ref);
+                        let in_any = [
+                            o.flows.implicit.as_ref().map(|f| f.scopes.contains_key(scope)),
+                            o.flows.password.as_ref().map(|f| f.scopes.contains_key(scope)),
+                            o.flows.client_credentials.as_ref().map(|f| f.scopes.contains_key(scope)),
+                            o.flows.authorization_code.as_ref().map(|f| f.scopes.contains_key(scope)),
+                        ]
+                        .into_iter()
+                        .flatten()
+                        .any(|x| x);
+                        if !in_any {
+                            ctx.error(
+                                path.to_owned(),
+                                format_args!(
+                                    "[{i}].`{name}`: scope `{scope}` not declared in any flow's scopes"
+                                ),
+                            );
+                        }
+                    }
+                }
+                SecurityScheme::OpenIdConnect(_) => {
+                    // OpenID Connect resolves scopes at runtime; any list is acceptable.
+                }
+                SecurityScheme::ApiKey(_) | SecurityScheme::HTTP(_) => {
+                    if !scopes.is_empty() {
+                        ctx.error(
+                            path.to_owned(),
+                            format_args!(
+                                "[{i}].`{name}`: scheme of type `{scheme}` requires an empty scope list, found {n}",
+                                n = scopes.len()
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Validate Spec.tags: every tag name MUST be unique.
+pub fn validate_tag_uniqueness(ctx: &mut Context<Spec>, tags: &[Tag]) {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for t in tags {
+        *counts.entry(t.name.as_str()).or_insert(0) += 1;
+    }
+    for (name, n) in counts {
+        if n > 1 {
+            ctx.error(
+                "#.tags".to_owned(),
+                format_args!("duplicate tag name `{name}` (found {n} times)"),
+            );
+        }
+    }
+}
+
+/// Validate that no two paths in `Spec.paths` collapse to the same
+/// canonical (template-stripped) form. Extension keys (`x-...`) are skipped.
+pub fn validate_path_template_uniqueness(ctx: &mut Context<Spec>, paths: &BTreeMap<String, PathItem>) {
+    let mut canonicals: HashMap<String, Vec<&str>> = HashMap::new();
+    for key in paths.keys() {
+        if key.starts_with("x-") {
+            continue;
+        }
+        canonicals
+            .entry(canonical_path(key))
+            .or_default()
+            .push(key.as_str());
+    }
+    for (canonical, keys) in canonicals {
+        if keys.len() > 1 {
+            ctx.error(
+                "#.paths".to_owned(),
+                format_args!(
+                    "templated paths {keys:?} collapse to the same shape `{canonical}`; OAS forbids equivalent templates"
+                ),
+            );
+        }
+    }
+}
+
+/// Per-path entry point: walk operations and emit cross-cutting checks.
+pub fn validate_path_item(ctx: &mut Context<Spec>, template: &str, path: &str, item: &PathItem) {
+    let pi_params = item.parameters.as_deref();
+    if let Some(ops) = &item.operations {
+        for (method, op) in ops {
+            let op_path = format!("{path}.{method}");
+            validate_operation_parameters(
+                ctx,
+                &op_path,
+                template,
+                pi_params,
+                op.parameters.as_deref(),
+            );
+            validate_operation_security(ctx, &op_path, op);
+        }
+    }
+}
+
+fn validate_operation_security(ctx: &mut Context<Spec>, op_path: &str, op: &Operation) {
+    if let Some(sec) = &op.security {
+        validate_security_requirements(ctx, &format!("{op_path}.security"), sec);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::helpers::Context;
+    use crate::v3_0::components::Components;
+    use crate::v3_0::parameter::{InCookie, InHeader, InPath, InQuery};
+    use crate::v3_0::reference::RefOr;
+    use crate::v3_0::security_scheme::{
+        ApiKeyLocation, ApiKeySecurityScheme, HttpScheme, HttpSecurityScheme, ImplicitOAuth2Flow,
+        OAuth2Flows, OAuth2SecurityScheme, OpenIdConnectSecurityScheme, SecurityScheme,
+    };
+    use crate::v3_0::spec::Spec;
+    use crate::validation::Options;
+
+    fn path_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Path(InPath {
+            name: name.into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }))
+    }
+
+    fn query_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Query(InQuery {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }))
+    }
+
+    fn header_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Header(InHeader {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }))
+    }
+
+    fn cookie_param(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Cookie(InCookie {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }))
+    }
+
+    fn spec_with_components(c: Components) -> Spec {
+        Spec {
+            components: Some(c),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn duplicate_param_within_level_flagged() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![query_param("q"), query_param("q")];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&params));
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("duplicate parameter `q`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn op_overrides_path_item_no_dup_error() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let pi = vec![query_param("limit")];
+        let op = vec![query_param("limit")];
+        validate_operation_parameters(&mut ctx, "op", "/p", Some(&pi), Some(&op));
+        assert!(
+            ctx.errors.is_empty(),
+            "override should not be a duplicate: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn cookie_and_header_locations_distinct() {
+        // Same `name` is fine if `in` differs.
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![header_param("session"), cookie_param("session")];
+        validate_operation_parameters(&mut ctx, "op", "/p", None, Some(&params));
+        assert!(
+            ctx.errors.is_empty(),
+            "different locations should not duplicate: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn template_var_missing_path_param() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, None);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("path template variable `{id}`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn path_param_without_template_var() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![path_param("id")];
+        validate_operation_parameters(&mut ctx, "op", "/no-vars", None, Some(&params));
+        assert!(
+            ctx.errors.iter().any(|e| e
+                .contains("path parameter `id` does not match any `{name}` in the path template")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn template_correspondence_ok() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let params = vec![path_param("id")];
+        validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn equivalent_templates_are_flagged() {
+        let mut paths: BTreeMap<String, PathItem> = BTreeMap::new();
+        paths.insert("/pets/{id}".into(), PathItem::default());
+        paths.insert("/pets/{name}".into(), PathItem::default());
+
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_path_template_uniqueness(&mut ctx, &paths);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("collapse to the same shape")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn distinct_templates_are_not_flagged() {
+        let mut paths: BTreeMap<String, PathItem> = BTreeMap::new();
+        paths.insert("/pets/{id}".into(), PathItem::default());
+        paths.insert("/pets/{id}/owner".into(), PathItem::default());
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        validate_path_template_uniqueness(&mut ctx, &paths);
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn duplicate_tag_names_flagged() {
+        let spec: &'static Spec = Box::leak(Box::new(Spec::default()));
+        let mut ctx = Context::new(spec, Options::new());
+        let tags = vec![
+            Tag {
+                name: "pets".into(),
+                ..Default::default()
+            },
+            Tag {
+                name: "pets".into(),
+                ..Default::default()
+            },
+        ];
+        validate_tag_uniqueness(&mut ctx, &tags);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("duplicate tag name `pets`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_apikey_with_scopes_invalid() {
+        let mut schemes = BTreeMap::new();
+        schemes.insert(
+            "ak".to_owned(),
+            RefOr::new_item(SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
+                name: "X".into(),
+                location: ApiKeyLocation::Header,
+                description: None,
+                extensions: None,
+            }))),
+        );
+        let comp = Components {
+            security_schemes: Some(schemes),
+            ..Default::default()
+        };
+        let spec: &'static Spec = Box::leak(Box::new(spec_with_components(comp)));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        req.insert("ak".to_owned(), vec!["read".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("requires an empty scope list")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_http_with_scopes_invalid() {
+        let mut schemes = BTreeMap::new();
+        schemes.insert(
+            "h".to_owned(),
+            RefOr::new_item(SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
+                scheme: HttpScheme::Bearer,
+                bearer_format: None,
+                description: None,
+                extensions: None,
+            }))),
+        );
+        let comp = Components {
+            security_schemes: Some(schemes),
+            ..Default::default()
+        };
+        let spec: &'static Spec = Box::leak(Box::new(spec_with_components(comp)));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        req.insert("h".to_owned(), vec!["read".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("requires an empty scope list")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_oauth2_undefined_scope() {
+        let flows = OAuth2Flows {
+            implicit: Some(ImplicitOAuth2Flow {
+                authorization_url: "https://x.example/auth".into(),
+                refresh_url: None,
+                scopes: BTreeMap::from([("read".to_owned(), "Read".to_owned())]),
+                extensions: None,
+            }),
+            ..Default::default()
+        };
+        let mut schemes = BTreeMap::new();
+        schemes.insert(
+            "o".to_owned(),
+            RefOr::new_item(SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
+                flows,
+                description: None,
+                extensions: None,
+            }))),
+        );
+        let comp = Components {
+            security_schemes: Some(schemes),
+            ..Default::default()
+        };
+        let spec: &'static Spec = Box::leak(Box::new(spec_with_components(comp)));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        req.insert("o".to_owned(), vec!["write".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("scope `write` not declared")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_openidconnect_accepts_any_scopes() {
+        let mut schemes = BTreeMap::new();
+        schemes.insert(
+            "oid".to_owned(),
+            RefOr::new_item(SecurityScheme::OpenIdConnect(Box::new(
+                OpenIdConnectSecurityScheme {
+                    open_id_connect_url: "https://x.example/.well-known".into(),
+                    description: None,
+                    extensions: None,
+                },
+            ))),
+        );
+        let comp = Components {
+            security_schemes: Some(schemes),
+            ..Default::default()
+        };
+        let spec: &'static Spec = Box::leak(Box::new(spec_with_components(comp)));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        req.insert("oid".to_owned(), vec!["openid".to_owned(), "email".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors.is_empty(),
+            "openIdConnect should accept any scopes: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_missing_scheme_reported() {
+        let comp = Components {
+            security_schemes: Some(BTreeMap::new()),
+            ..Default::default()
+        };
+        let spec: &'static Spec = Box::leak(Box::new(spec_with_components(comp)));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        req.insert("missing".to_owned(), vec![]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("not declared")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+}


### PR DESCRIPTION
Closes the gap between the `v3_0` module and the OpenAPI 3.0.4 spec, adds first-class support for the most common ReDoc/Redocly vendor extensions, and lifts v3_0 unit-test coverage to **95.43% line / 95.54% region** (was ~85% aggregate, several files <60%).

## Spec compliance — data shape

- New `src/v3_0/reference.rs` — v3.0-local `Ref` / `RefOr` with `deny_unknown_fields`. The shared `common::reference::Ref` carries `summary` / `description` (added in 3.1); allowing those in 3.0 docs silently produces non-conformant output. All v3_0 modules switched over.
- `PathItem`: added the spec's required fixed fields `$ref`, `summary`, `description` (previously only `parameters` / `servers` / methods / extensions were modeled).
- `Schema` (every variant): added `nullable`, `writeOnly`, `deprecated`. `nullable` is the only way to express null in 3.0.
- `RequestBody` gains a flattened `extensions` field; `^x-` keys were silently dropped before.
- `Response.description`, `Info.title`, `Info.version`: removed `skip_serializing_if = "String::is_empty"` on required fields so required-but-empty values round-trip explicitly.
- New `Paths` struct (custom `Serialize` / `Deserialize`) replaces the flat `BTreeMap<String, PathItem>` on `Spec.paths`, restoring spec-allowed `^x-` keys at the Paths Object level.
- `Responses` deserializer + validator now accept the patterned range tokens `1XX/2XX/3XX/4XX/5XX` in addition to 3-digit status codes.

## Spec compliance — validation

New `src/v3_0/validation.rs` plus targeted in-place checks, all wired into `Spec::validate`:

- `validate_operation_parameters` — within-level `(name, in)` duplicates flagged, then op-level entries override path-item entries (per spec). Path template `{var}` ↔ `in: path` parameter correspondence enforced both ways. The `template-var-missing` direction is suppressed when an external `$ref` parameter is encountered under `IgnoreExternalReferences` (the missing param may be defined in the external doc).
- `validate_path_template_uniqueness` — equivalent templates such as `/pets/{id}` vs `/pets/{name}` collapse to the same canonical shape and are now rejected.
- `validate_security_requirements` — applied at top-level (`Spec.security` was previously not iterated at all), at operation level, **and inside `Callback` path items**. Visits referenced schemes for unused-detection, validates oauth2 scopes across all four flows, and enforces that apiKey / http schemes carry empty scope arrays.
- `validate_tag_uniqueness` — duplicate tag names are now reported.
- `Schema` `readOnly` and `writeOnly` mutex — the OAS 3.0 rule that both MUST NOT be true is now enforced via the `SingleSchema` dispatch path so every variant goes through it.
- `Link.operationRef` — was an opaque string; now MUST point to an Operation. Follows `PathItem.$ref` chains of arbitrary depth (with cycle detection), JSON-Pointer-decodes path tokens (`~1` → `/`, `~0` → `~`), rejects malformed pointers (e.g. `#/paths//pets/get` with unescaped `/`), and option-gates external refs on `IgnoreExternalReferences`.
- `Link.operationRef` XOR `operationId` — exactly one required, the two are mutually exclusive.
- `MediaType` enforces example XOR examples; `Parameter` and `Header` enforce `content` map size == 1.
- `Responses` enforces "must declare at least one response (a status code, a wildcard like `2XX`, or `default`)".
- `Components.securitySchemes` unused-scope detection now walks all four oauth2 flows (was implicit-only).
- `resolve_in_map` follows component-level alias chains (`#/components/schemas/AliasA` → `AliasB` → `Target`) with `BTreeSet`-based cycle detection.

## ReDoc / Redocly vendor extensions

First-class typed support, validated alongside the surrounding object:

| Object | Extension | Rust field |
| --- | --- | --- |
| `Info` | `x-logo` | `Info.x_logo: Option<Logo>` |
| `Tag` | `x-displayName` | `Tag.x_display_name: Option<String>` |
| `Operation` | `x-codeSamples` | `Operation.x_code_samples: Option<Vec<CodeSample>>` |
| `Operation` | `x-badges` | `Operation.x_badges: Option<Vec<Badge>>` |
| `Operation` | `x-examples` | `Operation.x_examples: Option<BTreeMap<String, Value>>` |
| `Response` | `x-summary` | `Response.x_summary: Option<String>` |
| `Schema` (string/integer/number) | `x-enumDescriptions` / `x-enum-varnames` / `x-enumNames` | `x_enum_descriptions` / `x_enum_varnames` / `x_enum_names` |
| `ObjectSchema` | `x-additionalPropertiesName` | `x_additional_properties_name: Option<String>` |
| `Spec` | `x-tagGroups` | `Spec.x_tag_groups: Option<Vec<TagGroup>>` |

## Permissive deviations, kept

- `Schema::Null` (`type: "null"`) remains supported. OAS 3.0 has no `null` type — the spec idiom is `nullable: true`. Kept for round-trip compatibility with tools that emit the 2020-12 form; documented in `src/v3_0.rs`.
- `PathItem` accepts arbitrary HTTP method names (e.g. `search`) in addition to the closed `get/put/post/delete/options/head/patch/trace` set.

## Test coverage

| File | Line % |
| --- | --- |
| `callback.rs` | 92.71 |
| `components.rs` | 99.31 |
| `discriminator.rs` | 100 |
| `example.rs` | 100 |
| `external_documentation.rs` | 100 |
| `header.rs` | 100 |
| `info.rs` | 100 |
| `link.rs` | 98.92 |
| `media_type.rs` | 99.08 |
| `operation.rs` | 95.10 |
| `parameter.rs` | 99.57 |
| `path_item.rs` | 88.33 |
| `reference.rs` | 91.76 |
| `request_body.rs` | 100 |
| `response.rs` | 96.76 |
| `schema.rs` | 95.02 |
| `security_scheme.rs` | 97.64 |
| `server.rs` | 100 |
| `spec.rs` | 97.25 |
| `tag.rs` | 100 |
| `validation.rs` | 97.47 |
| `xml.rs` | 100 |

366 lib tests + integration / doc tests pass; clippy clean with `-D warnings`.

## Breaking changes (allowed at 0.x)

- `Spec.paths` is now `Paths` (not `BTreeMap<String, PathItem>`). Iteration / `.iter()` / `From<IntoIterator<…>>` are preserved.
- `RequestBody` adds an `extensions` field — exhaustive struct literals must add it.
- All `SingleSchema` variants gain `nullable`, `write_only`, `deprecated` fields.
- `PathItem` gains `reference`, `summary`, `description` fields.
- `Operation` gains `x_code_samples`, `x_badges`, `x_examples` fields.
- `Response` gains `x_summary` field.
- Several `Schema` variants gain `x_enum_descriptions` / `x_enum_varnames` / `x_enum_names`; `ObjectSchema` gains `x_additional_properties_name`.
- `Spec` gains `x_tag_groups` field; `Info` gains `x_logo`; `Tag` gains `x_display_name`.
- `RefOr` for v3.0 is now `crate::v3_0::reference::RefOr`.