### PR TITLE
Treat schema with no `type` as object (v2/v3.0/v3.1)

### DIFF
--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -563,7 +563,12 @@ pub struct ArraySchema {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ObjectSchema {
-    #[serde(rename = "type")]
+    /// `type: "object"`. The field is also accepted as **absent** —
+    /// per common practice, a Schema with no declared `type` is
+    /// treated as an object schema. When missing, serde fills in the
+    /// default value, so the parsed value round-trips with an explicit
+    /// `type: "object"`.
+    #[serde(rename = "type", default)]
     pub schema_type: MustBe!("object"),
 
     /// A title to explain the purpose of the schema.
@@ -901,6 +906,43 @@ mod tests {
         } else {
             panic!("expected ObjectSchema");
         }
+    }
+
+    #[test]
+    fn schema_without_type_parses_as_object() {
+        // A schema with no `type` field is treated as an object schema
+        // (matches Spectral / Stoplight / Redocly tooling behavior). For v2
+        // this also affects the relative dispatch order between `Object` and
+        // top-level `AllOf`: since `ObjectSchema` itself carries an `allOf`
+        // field, a missing-type schema with `allOf` is now routed to
+        // `Object` (its data — properties, required, allOf — is preserved).
+        let json = serde_json::json!({
+            "title": "Untyped",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"]
+        });
+        let parsed: Schema = serde_json::from_value(json).expect("must parse");
+        match &parsed {
+            Schema::Object(o) => {
+                assert_eq!(o.title.as_deref(), Some("Untyped"));
+                assert_eq!(o.required.as_deref(), Some(&["name".to_owned()][..]));
+                assert!(o.properties.is_some());
+            }
+            other => panic!("expected Object, got {other:?}"),
+        }
+
+        // Bare `{}` parses as the default ObjectSchema.
+        let parsed: Schema = serde_json::from_value(serde_json::json!({})).expect("must parse");
+        assert!(matches!(parsed, Schema::Object(_)));
+    }
+
+    #[test]
+    fn schema_typed_string_still_dispatches_correctly_v2() {
+        let parsed: Schema =
+            serde_json::from_value(serde_json::json!({"type": "string"})).expect("must parse");
+        assert!(matches!(parsed, Schema::String(_)));
     }
 
     #[test]

--- a/src/v3_0/reference.rs
+++ b/src/v3_0/reference.rs
@@ -43,11 +43,46 @@ impl Ref {
 }
 
 /// v3.0 RefOr<T> — either a `$ref` (v3.0 form) or an inline value of `T`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+///
+/// Deserialization routes by **presence of `$ref` in the input** rather than
+/// by serde's untagged fallthrough. Inputs containing `$ref` MUST validate as
+/// a `Ref` (which rejects 3.1-only sibling fields via `deny_unknown_fields`);
+/// they will not be silently re-interpreted as an inline `T` if the `Ref`
+/// form fails. This protects the v3.0 strictness guarantee even when `T`'s
+/// own deserialization is permissive (for example, an ObjectSchema with a
+/// defaulted `type` field would otherwise eat a stray `$ref` as an unknown
+/// key).
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum RefOr<T> {
     Ref(Ref),
     Item(T),
+}
+
+impl<'de, T> Deserialize<'de> for RefOr<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Materialise the input as JSON Value so we can peek for `$ref` and
+        // then try the appropriate variant. The single allocation is
+        // acceptable for the deserialization path (and matches what other
+        // OAS parsers do internally).
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let has_ref = matches!(&value, serde_json::Value::Object(m) if m.contains_key("$ref"));
+        if has_ref {
+            Ref::deserialize(value)
+                .map(RefOr::Ref)
+                .map_err(serde::de::Error::custom)
+        } else {
+            T::deserialize(value)
+                .map(RefOr::Item)
+                .map_err(serde::de::Error::custom)
+        }
+    }
 }
 
 impl<D> RefOr<D> {
@@ -176,6 +211,34 @@ mod tests {
         let r: RefOr<Foo> =
             serde_json::from_value(json!({"$ref": "#/components/schemas/Foo"})).unwrap();
         assert!(matches!(r, RefOr::Ref(ref rr) if rr.reference == "#/components/schemas/Foo"));
+    }
+
+    #[test]
+    fn schema_with_no_type_parses_as_inline_object() {
+        // Sanity: with the "missing type = object" relaxation in
+        // ObjectSchema, an inline schema with no `$ref` and no `type`
+        // still parses as `Item(ObjectSchema)`.
+        let r: RefOr<crate::v3_0::schema::Schema> =
+            serde_json::from_value(json!({"properties": {}})).expect("must parse");
+        assert!(matches!(r, RefOr::Item(_)), "expected inline Item form");
+    }
+
+    #[test]
+    fn schema_ref_with_extras_does_not_fall_back_to_inline() {
+        // Even though ObjectSchema's `type` is now optional (a schema with
+        // no `type` is treated as object), an input that *does* contain
+        // `$ref` MUST validate as a Ref. Routing-by-`$ref`-presence
+        // prevents `{"$ref": "...", "description": "..."}` from being
+        // silently parsed as an inline ObjectSchema with the `$ref`
+        // dropped.
+        let r = serde_json::from_value::<RefOr<crate::v3_0::schema::Schema>>(json!({
+            "$ref": "#/components/schemas/Foo",
+            "description": "this v3.1 sibling is rejected",
+        }));
+        assert!(
+            r.is_err(),
+            "ref form must fail strictly when 3.1 sibling fields are present, even with permissive ObjectSchema"
+        );
     }
 
     #[test]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -751,7 +751,12 @@ pub struct ArraySchema {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ObjectSchema {
-    #[serde(rename = "type")]
+    /// `type: "object"`. The field is also accepted as **absent** —
+    /// per common practice (Spectral, Stoplight, Redocly), a Schema
+    /// with no declared `type` is treated as an object schema. When
+    /// missing, serde fills in the default value via `MustBe::default()`,
+    /// so the parsed value round-trips with an explicit `type: "object"`.
+    #[serde(rename = "type", default)]
     pub schema_type: MustBe!("object"),
 
     /// A title to explain the purpose of the schema.
@@ -1110,6 +1115,55 @@ mod tests {
                 ..Default::default()
             }))),
         );
+    }
+
+    #[test]
+    fn schema_without_type_parses_as_object() {
+        // A schema with no `type` field is treated as an object schema
+        // (matches Spectral / Stoplight / Redocly tooling behavior). The
+        // deserialized value is `Schema::Single(Object(...))`; presence of
+        // `properties` / `required` round-trips through the object form.
+        let json = serde_json::json!({
+            "title": "Untyped",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"]
+        });
+        let parsed: Schema = serde_json::from_value(json).expect("must parse");
+        match &parsed {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Object(o) => {
+                    assert_eq!(o.title.as_deref(), Some("Untyped"));
+                    assert_eq!(o.required.as_deref(), Some(&["name".to_owned()][..]));
+                    assert!(o.properties.is_some());
+                }
+                other => panic!("expected Object, got {other:?}"),
+            },
+            _ => panic!("expected Schema::Single"),
+        }
+
+        // Bare `{}` also parses (as the default ObjectSchema).
+        let parsed: Schema = serde_json::from_value(serde_json::json!({})).expect("must parse");
+        assert!(matches!(
+            parsed,
+            Schema::Single(ref s) if matches!(s.as_ref(), SingleSchema::Object(_))
+        ));
+    }
+
+    #[test]
+    fn schema_typed_string_still_dispatches_correctly() {
+        // Sanity: making `type` optional on ObjectSchema must NOT route
+        // typed schemas to the object variant.
+        let parsed: Schema =
+            serde_json::from_value(serde_json::json!({"type": "string"})).expect("must parse");
+        match parsed {
+            Schema::Single(s) => match *s {
+                SingleSchema::String(_) => {}
+                other => panic!("expected String, got {other:?}"),
+            },
+            _ => panic!("expected Schema::Single"),
+        }
     }
 
     #[test]

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -724,7 +724,12 @@ pub struct ArraySchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectSchema {
-    #[serde(rename = "type")]
+    /// `type: "object"`. The field is also accepted as **absent** —
+    /// per common practice, a Schema with no declared `type` is
+    /// treated as an object schema. When missing, serde fills in the
+    /// default value, so the parsed value round-trips with an explicit
+    /// `type: "object"`.
+    #[serde(rename = "type", default)]
     pub schema_type: MustBe!("object"),
 
     /// A title to explain the purpose of the schema.
@@ -1256,6 +1261,66 @@ mod tests {
                 title: Some("foo".to_owned()),
                 ..Default::default()
             }))),
+        );
+    }
+
+    #[test]
+    fn schema_without_type_parses_as_object() {
+        // A schema with no `type` field is treated as an object schema in v3.1
+        // (matches Spectral / Stoplight / Redocly tooling). Note: v3.1 has
+        // both `SingleSchema` and `MultiSchema`; missing-type must hit Single
+        // (Object) — not be misidentified as a MultiSchema.
+        let json = serde_json::json!({
+            "title": "Untyped",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"]
+        });
+        let parsed: Schema = serde_json::from_value(json).expect("must parse");
+        match &parsed {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Object(o) => {
+                    assert_eq!(o.title.as_deref(), Some("Untyped"));
+                    assert_eq!(o.required.as_deref(), Some(&["name".to_owned()][..]));
+                    assert!(o.properties.is_some());
+                }
+                other => panic!("expected Object, got {other:?}"),
+            },
+            _ => panic!("expected Schema::Single, got {parsed:?}"),
+        }
+
+        let parsed: Schema = serde_json::from_value(serde_json::json!({})).expect("must parse");
+        assert!(matches!(
+            parsed,
+            Schema::Single(ref s) if matches!(s.as_ref(), SingleSchema::Object(_))
+        ));
+    }
+
+    #[test]
+    fn schema_typed_string_still_dispatches_correctly_v31() {
+        let parsed: Schema =
+            serde_json::from_value(serde_json::json!({"type": "string"})).expect("must parse");
+        match parsed {
+            Schema::Single(s) => match *s {
+                SingleSchema::String(_) => {}
+                other => panic!("expected String, got {other:?}"),
+            },
+            _ => panic!("expected Schema::Single"),
+        }
+    }
+
+    #[test]
+    fn schema_with_type_array_still_routes_to_multi() {
+        // v3.1's MultiSchema (type as array) MUST keep priority over the
+        // missing-type-as-object fallback for a doc that explicitly lists
+        // a type array.
+        let parsed: Schema =
+            serde_json::from_value(serde_json::json!({"type": ["string", "null"]}))
+                .expect("must parse");
+        assert!(
+            matches!(parsed, Schema::Multi(_)),
+            "expected Schema::Multi, got {parsed:?}"
         );
     }
 


### PR DESCRIPTION
A schema with no `type` field is now treated as an `ObjectSchema`, matching the convention used by Spectral, Stoplight, and Redocly tooling. Previously the `MustBe!(<type>)` field on every `SingleSchema` variant required `type` to be present, so a bare `{}` or `{"properties": {...}}` failed to parse.

## Implementation

- `ObjectSchema.schema_type` (v2 / v3_0 / v3_1): added `#[serde(default)]`. `MustBe!("object")` impls `Default`, so a missing field is filled with the unit value and the variant matches. Typed schemas still dispatch correctly because `MustBe` rejects non-matching strings (`{"type": "string"}` fails ObjectSchema and falls through to StringSchema).

- v3_0 `RefOr<T>`: replaced `#[serde(untagged)]` with a custom `Deserialize` that routes by **presence of `$ref`**. If the input object contains `$ref`, it MUST validate as a `Ref` (which still rejects 3.1 sibling fields via `deny_unknown_fields`); otherwise the inline form is tried. This preserves the v3.0 strictness guarantee the existing `schema_ref_rejects_v3_1_sibling_fields` test asserts — without the routing change, a permissive ObjectSchema would silently absorb `{"$ref": "...", "description": "..."}` and drop the `$ref`.

## Tests

- `schema_without_type_parses_as_object` (v2 / v3_0 / v3_1) — `{}` and `{"properties": {...}, "required": [...]}` parse as Object.
- `schema_typed_string_still_dispatches_correctly` — explicit typed schemas still route to the right variant.
- `schema_with_type_array_still_routes_to_multi` (v3_1) — `MultiSchema` keeps priority over the ObjectSchema fallback.
- `schema_with_no_type_parses_as_inline_object` (v3_0) — without `$ref`, a no-type schema parses as `Item`.
- `schema_ref_with_extras_does_not_fall_back_to_inline` (v3_0) — with `$ref`, v3.1 siblings still cause a hard error (no silent fallback).

377 lib tests pass; clippy clean with `-D warnings`.