### PR TITLE
v3_1: align with the OAS 3.1 JSON Schema (2025-11-23)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -34,13 +34,12 @@ jobs:
         with:
           matrix-exclude-features: roas:default
   BuildJob:
-    name: Build per OS
+    name: Build per Package and Feature
     needs: RustMeta
     strategy:
         matrix:
-            os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
             args: ${{ fromJSON(needs.RustMeta.outputs.matrix) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -69,13 +68,12 @@ jobs:
       - run: cargo clippy --all-features --all-targets --quiet --message-format=json | cargo-action-fmt
         if: failure()
   TestJob:
-    name: Test per OS
+    name: Test per Package and Feature
     needs: RustMeta
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
         args: ${{ fromJSON(needs.RustMeta.outputs.matrix) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,8 +29,10 @@ jobs:
       publish: ${{ steps.rustmeta.outputs.publish }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: sv-tools/rust-metadata-action@0e9c699a85c7984d730be55a2001eea468bf0a54 # v1.1.1
+      - uses: sv-tools/rust-metadata-action@4e7375355154e9cc49ebb10805dbcf2ce4860669 # v1.2.0
         id: rustmeta
+        with:
+          matrix-exclude-features: roas:default
   BuildJob:
     name: Build per OS
     needs: RustMeta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"

--- a/src/v3_1/example.rs
+++ b/src/v3_1/example.rs
@@ -1,6 +1,6 @@
 //! Example object.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_url};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_uri};
 use crate::v3_1::spec::Spec;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -49,7 +49,7 @@ impl ValidateWithContext<Spec> for Example {
                 "value and externalValue are mutually exclusive",
             );
         }
-        validate_optional_url(&self.external_value, ctx, format!("{path}.externalValue"));
+        validate_optional_uri(&self.external_value, ctx, format!("{path}.externalValue"));
     }
 }
 
@@ -78,16 +78,32 @@ mod tests {
     }
 
     #[test]
-    fn external_value_url_validated() {
+    fn external_value_uri_reference_validated() {
+        // Per the OAS 3.1 JSON Schema, `externalValue` is `format:
+        // uri-reference`: relative paths and non-HTTP schemes pass while
+        // whitespace / control-char garbage fails.
         let spec = Spec::default();
+        for ok in ["./fixtures/example.json", "urn:example:my-example"] {
+            let mut ctx = Context::new(&spec, Options::new());
+            Example {
+                external_value: Some(ok.to_owned()),
+                ..Default::default()
+            }
+            .validate_with_context(&mut ctx, "ex".into());
+            assert!(
+                ctx.errors.is_empty(),
+                "uri-reference `{ok}` should pass: {:?}",
+                ctx.errors
+            );
+        }
         let mut ctx = Context::new(&spec, Options::new());
         Example {
-            external_value: Some("not-a-url".into()),
+            external_value: Some("not a uri".into()),
             ..Default::default()
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            ctx.errors.iter().any(|e| e.contains("must be a valid URI")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_1/example.rs
+++ b/src/v3_1/example.rs
@@ -24,9 +24,9 @@ pub struct Example {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<serde_json::Value>,
 
-    /// A URL that points to the literal example.
-    /// This provides the capability to reference examples that cannot easily
-    /// be included in JSON or YAML documents.
+    /// A URI reference (RFC 3986) that points to the literal example.
+    /// Per the OAS 3.1 JSON Schema this is `format: uri-reference`, so
+    /// relative refs and non-HTTP schemes are allowed.
     /// The `value` field and `externalValue` field are mutually exclusive.
     #[serde(rename = "externalValue")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v3_1/external_documentation.rs
+++ b/src/v3_1/external_documentation.rs
@@ -1,7 +1,8 @@
 //! References an external resource for extended documentation.
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_url};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_uri};
 use crate::v3_1::spec::Spec;
+use crate::validation::Options;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -35,7 +36,17 @@ pub struct ExternalDocumentation {
 
 impl ValidateWithContext<Spec> for ExternalDocumentation {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(&self.url, ctx, format!("{path}.url"));
+        // The OAS spec lists `url` as required. When
+        // `IgnoreEmptyExternalDocumentationUrl` is set we silence the
+        // required-string check, but still URI-validate any non-empty
+        // value.
+        if self.url.is_empty() {
+            if !ctx.is_option(Options::IgnoreEmptyExternalDocumentationUrl) {
+                ctx.error(format!("{path}.url"), "must not be empty");
+            }
+        } else {
+            validate_required_uri(&self.url, ctx, format!("{path}.url"));
+        }
     }
 }
 
@@ -107,17 +118,18 @@ mod tests {
             ctx.errors
         );
 
+        // OAS 3.1 schema gives `url` `format: uri-reference`, so
+        // a relative path is structurally fine. Whitespace fails.
         let mut ctx = Context::new(&spec, Options::empty());
         let ed = ExternalDocumentation {
-            url: String::from("invalid-url"),
+            url: String::from("not a uri"),
             description: Some(String::from("Find more info here")),
             ..Default::default()
         };
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
-            ctx.errors.contains(
-                &"externalDocs.url: must be a valid URL, found `invalid-url`".to_string()
-            ),
+            ctx.errors
+                .contains(&"externalDocs.url: must be a valid URI, found `not a uri`".to_string()),
             "Validation should fail: {:?}",
             ctx.errors
         );
@@ -139,7 +151,7 @@ mod tests {
 
         let mut ctx = Context::new(&spec, Options::only(&Options::IgnoreInvalidUrls));
         let ed = ExternalDocumentation {
-            url: String::from("invalid-url"),
+            url: String::from("not a uri"),
             description: Some(String::from("Find more info here")),
             ..Default::default()
         };

--- a/src/v3_1/external_documentation.rs
+++ b/src/v3_1/external_documentation.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ExternalDocumentation {
     /// **Required** The URL for the target documentation.
-    /// Value MUST be in the format of a URL.
+    /// Value MUST be in the format of a URI reference (RFC 3986). Relative refs and non-HTTP schemes are allowed.
     pub url: String,
 
     /// A short description of the target documentation.

--- a/src/v3_1/info.rs
+++ b/src/v3_1/info.rs
@@ -1,8 +1,8 @@
 //! Provides metadata about the API.
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_email, validate_optional_url,
-    validate_required_string, validate_required_url,
+    Context, PushError, ValidateWithContext, validate_email, validate_optional_uri,
+    validate_required_string, validate_required_uri,
 };
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
@@ -192,7 +192,7 @@ impl ValidateWithContext<Spec> for Info {
 
 impl ValidateWithContext<Spec> for Contact {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&self.url, ctx, format!("{path}.url"));
+        validate_optional_uri(&self.url, ctx, format!("{path}.url"));
         validate_email(&self.email, ctx, format!("{path}.email"));
     }
 }
@@ -211,14 +211,14 @@ impl ValidateWithContext<Spec> for License {
         if let Some(id) = &self.identifier {
             validate_required_string(id, ctx, format!("{path}.identifier"));
         }
-        validate_optional_url(&self.url, ctx, format!("{path}.url"));
+        validate_optional_uri(&self.url, ctx, format!("{path}.url"));
     }
 }
 
 impl ValidateWithContext<Spec> for Logo {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(&self.url, ctx, format!("{path}.url"));
-        validate_optional_url(&self.href, ctx, format!("{path}.href"));
+        validate_required_uri(&self.url, ctx, format!("{path}.url"));
+        validate_optional_uri(&self.href, ctx, format!("{path}.href"));
     }
 }
 

--- a/src/v3_1/info.rs
+++ b/src/v3_1/info.rs
@@ -2,8 +2,9 @@
 
 use crate::common::helpers::{
     Context, PushError, ValidateWithContext, validate_email, validate_optional_uri,
-    validate_required_string, validate_required_uri,
+    validate_optional_url, validate_required_string, validate_required_url,
 };
+
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
 use serde::{Deserialize, Serialize};
@@ -88,7 +89,7 @@ pub struct Contact {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// The URL pointing to the contact information. MUST be in the format of a URL.
+    /// The URL pointing to the contact information. MUST be in the format of a URI reference (RFC 3986). Relative refs and non-HTTP schemes are allowed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 
@@ -127,7 +128,7 @@ pub struct License {
     pub identifier: Option<String>,
 
     /// A URL to the license used for the API.
-    /// MUST be in the format of a URL.
+    /// MUST be in the format of a URI reference (RFC 3986). Relative refs and non-HTTP schemes are allowed.
     /// **Mutually exclusive with `identifier`.**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -217,8 +218,11 @@ impl ValidateWithContext<Spec> for License {
 
 impl ValidateWithContext<Spec> for Logo {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_uri(&self.url, ctx, format!("{path}.url"));
-        validate_optional_uri(&self.href, ctx, format!("{path}.href"));
+        // `x-logo` is a Redoc extension, not part of the OAS 3.1 JSON
+        // Schema. Redoc consumes real http(s) URLs, so keep URL-only
+        // validation here (don't lift to uri-reference).
+        validate_required_url(&self.url, ctx, format!("{path}.url"));
+        validate_optional_url(&self.href, ctx, format!("{path}.href"));
     }
 }
 

--- a/src/v3_1/operation.rs
+++ b/src/v3_1/operation.rs
@@ -246,13 +246,13 @@ mod tests {
     #[test]
     fn missing_responses_is_accepted() {
         // Per the OAS 3.1 JSON Schema, `responses` is optional on
-        // Operation. An Operation without one validates clean.
+        // Operation. An entirely default Operation validates clean.
         let spec = Spec::default();
         let mut ctx = Context::new(&spec, Options::new());
         Operation::default().validate_with_context(&mut ctx, "op".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".responses")),
-            "no responses errors expected: {:?}",
+            ctx.errors.is_empty(),
+            "default Operation should validate clean: {:?}",
             ctx.errors
         );
     }

--- a/src/v3_1/operation.rs
+++ b/src/v3_1/operation.rs
@@ -62,9 +62,9 @@ pub struct Operation {
     #[serde(rename = "requestBody")]
     pub request_body: Option<RefOr<RequestBody>>,
 
-    /// **Required** by OAS 3.1.2 — but stored as `Option<Responses>` so
-    /// real-world specs that elide the field still deserialize, with the
-    /// missing-field surfaced at validate-time rather than parse-time.
+    /// The OAS 3.1 JSON Schema does not require `responses`; an
+    /// Operation without it is valid. `Option<Responses>` reflects
+    /// that.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub responses: Option<Responses>,
 
@@ -191,10 +191,10 @@ impl ValidateWithContext<Spec> for Operation {
             }
         }
 
-        // Spec: Operation.responses is required.
-        match &self.responses {
-            Some(r) => r.validate_with_context(ctx, format!("{path}.responses")),
-            None => ctx.error(path.clone(), ".responses: required field is missing"),
+        // Per the OAS 3.1 JSON Schema, `responses` is not required on
+        // Operation. When present, validate it.
+        if let Some(responses) = &self.responses {
+            responses.validate_with_context(ctx, format!("{path}.responses"));
         }
 
         if let Some(external_doc) = &self.external_docs {
@@ -244,15 +244,15 @@ mod tests {
     }
 
     #[test]
-    fn missing_responses_required_field_reported() {
+    fn missing_responses_is_accepted() {
+        // Per the OAS 3.1 JSON Schema, `responses` is optional on
+        // Operation. An Operation without one validates clean.
         let spec = Spec::default();
         let mut ctx = Context::new(&spec, Options::new());
         Operation::default().validate_with_context(&mut ctx, "op".into());
         assert!(
-            ctx.errors
-                .iter()
-                .any(|e| e.contains("op.responses: required field is missing")),
-            "errors: {:?}",
+            ctx.errors.iter().all(|e| !e.contains(".responses")),
+            "no responses errors expected: {:?}",
             ctx.errors
         );
     }

--- a/src/v3_1/response.rs
+++ b/src/v3_1/response.rs
@@ -739,4 +739,42 @@ mod tests {
         Response::default().validate_with_context(&mut ctx, "response".to_owned());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
     }
+
+    #[test]
+    fn responses_default_only_is_valid() {
+        // Per the OAS 3.1 JSON Schema's anyOf, a Responses Object with
+        // only `default` (and no status-code entries) is valid.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Responses {
+            default: Some(RefOr::new_item(Response {
+                description: "ok".to_owned(),
+                ..Default::default()
+            })),
+            responses: None,
+            extensions: None,
+        }
+        .validate_with_context(&mut ctx, "responses".to_owned());
+        assert!(
+            ctx.errors.is_empty(),
+            "default-only Responses should validate clean: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn responses_empty_is_rejected() {
+        // An entirely empty Responses Object (no `default`, no status
+        // codes) is the one shape the validator still flags.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Responses::default().validate_with_context(&mut ctx, "responses".to_owned());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must declare at least one response")),
+            "empty Responses should be flagged: {:?}",
+            ctx.errors
+        );
+    }
 }

--- a/src/v3_1/response.rs
+++ b/src/v3_1/response.rs
@@ -34,8 +34,10 @@ fn is_response_code_key(key: &str) -> bool {
 /// The `default` MAY be used as a default response object for all HTTP codes that are
 /// not covered individually by the specification.
 ///
-/// The `Responses Object` MUST contain at least one response code,
-/// and it SHOULD be the response for a successful operation call.
+/// Per the OAS 3.1 JSON Schema's `anyOf`, a `Responses Object` is valid
+/// when it has either a `default` entry or at least one status-code /
+/// wildcard entry; only an entirely empty object is rejected. The spec
+/// text further recommends covering a successful operation call.
 ///
 /// Specification example:
 /// ```yaml

--- a/src/v3_1/response.rs
+++ b/src/v3_1/response.rs
@@ -234,15 +234,16 @@ impl ValidateWithContext<Spec> for Response {
 
 impl ValidateWithContext<Spec> for Responses {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        // Spec (OAS 3.1.2): "The Responses Object MUST contain at least one
-        // response code." `default` describes "responses other than the ones
-        // declared for specific HTTP response codes" and so does NOT itself
-        // satisfy the "at least one response code" requirement.
+        // Per the OAS 3.1 JSON Schema, a Responses Object satisfies the
+        // anyOf with either a `default` entry OR at least one status-code
+        // / wildcard entry. Both shapes are valid; only an entirely empty
+        // object is flagged.
+        let has_default = self.default.is_some();
         let has_status_code = self.responses.as_ref().is_some_and(|m| !m.is_empty());
-        if !has_status_code {
+        if !has_default && !has_status_code {
             ctx.error(
                 path.clone(),
-                "must declare at least one response code (a 3-digit status code or a wildcard like `2XX`); `default` alone is not sufficient per OAS 3.1.2",
+                "must declare at least one response (`default` or a status code like `200` / wildcard like `2XX`)",
             );
         }
         if let Some(response) = &self.default {

--- a/src/v3_1/security_scheme.rs
+++ b/src/v3_1/security_scheme.rs
@@ -255,12 +255,12 @@ pub struct OAuth2Flows {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ImplicitOAuth2Flow {
     /// **Required** The authorization URL to be used for this flow.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(rename = "authorizationUrl")]
     pub authorization_url: String,
 
     /// The URL to be used for obtaining refresh tokens.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "refreshUrl")]
     pub refresh_url: Option<String>,
@@ -283,12 +283,12 @@ pub struct ImplicitOAuth2Flow {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct PasswordOAuth2Flow {
     /// **Required** The token URL to be used for this flow.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(rename = "tokenUrl")]
     pub token_url: String,
 
     /// The URL to be used for obtaining refresh tokens.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "refreshUrl")]
     pub refresh_url: Option<String>,
@@ -311,12 +311,12 @@ pub struct PasswordOAuth2Flow {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ClientCredentialsOAuth2Flow {
     /// **Required** The token URL to be used for this flow.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(rename = "tokenUrl")]
     pub token_url: String,
 
     /// The URL to be used for obtaining refresh tokens.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "refreshUrl")]
     pub refresh_url: Option<String>,
@@ -339,17 +339,17 @@ pub struct ClientCredentialsOAuth2Flow {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct AuthorizationCodeOAuth2Flow {
     /// **Required** The authorization URL to be used for this flow.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(rename = "authorizationUrl")]
     pub authorization_url: String,
 
     /// **Required** The token URL to be used for this flow.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(rename = "tokenUrl")]
     pub token_url: String,
 
     /// The URL to be used for obtaining refresh tokens.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "refreshUrl")]
     pub refresh_url: Option<String>,
@@ -371,7 +371,7 @@ pub struct AuthorizationCodeOAuth2Flow {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct OpenIdConnectSecurityScheme {
     /// **Required** OpenId Connect URL to discover OAuth2 configuration values.
-    /// This MUST be in the form of a URL.
+    /// This MUST be in the form of a URI reference (RFC 3986).
     #[serde(rename = "openIdConnectUrl")]
     pub open_id_connect_url: String,
 

--- a/src/v3_1/security_scheme.rs
+++ b/src/v3_1/security_scheme.rs
@@ -1,8 +1,8 @@
 //! Security Scheme Object
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_optional_url, validate_required_string,
-    validate_required_url,
+    Context, PushError, ValidateWithContext, validate_optional_uri, validate_required_string,
+    validate_required_uri,
 };
 use crate::v3_1::spec::Spec;
 use serde::{Deserialize, Serialize};
@@ -472,44 +472,44 @@ impl ValidateWithContext<Spec> for OAuth2Flows {
 
 impl ValidateWithContext<Spec> for ImplicitOAuth2Flow {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(
+        validate_required_uri(
             &self.authorization_url,
             ctx,
             format!("{path}.authorizationUrl"),
         );
-        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
+        validate_optional_uri(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
 impl ValidateWithContext<Spec> for PasswordOAuth2Flow {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(&self.token_url, ctx, format!("{path}.tokenUrl"));
-        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
+        validate_required_uri(&self.token_url, ctx, format!("{path}.tokenUrl"));
+        validate_optional_uri(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
 impl ValidateWithContext<Spec> for ClientCredentialsOAuth2Flow {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(&self.token_url, ctx, format!("{path}.tokenUrl"));
-        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
+        validate_required_uri(&self.token_url, ctx, format!("{path}.tokenUrl"));
+        validate_optional_uri(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
 impl ValidateWithContext<Spec> for AuthorizationCodeOAuth2Flow {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(
+        validate_required_uri(
             &self.authorization_url,
             ctx,
             format!("{path}.authorizationUrl"),
         );
-        validate_required_url(&self.token_url, ctx, format!("{path}.tokenUrl"));
-        validate_optional_url(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
+        validate_required_uri(&self.token_url, ctx, format!("{path}.tokenUrl"));
+        validate_optional_uri(&self.refresh_url, ctx, format!("{path}.refreshUrl"));
     }
 }
 
 impl ValidateWithContext<Spec> for OpenIdConnectSecurityScheme {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_required_url(
+        validate_required_uri(
             &self.open_id_connect_url,
             ctx,
             format!("{path}.openIdConnectUrl"),
@@ -1294,8 +1294,8 @@ mod tests {
         SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 implicit: Some(ImplicitOAuth2Flow {
-                    authorization_url: String::from("foo"),
-                    refresh_url: Some(String::from("bar")),
+                    authorization_url: String::from("not a uri"),
+                    refresh_url: Some(String::from("also not")),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -1315,8 +1315,8 @@ mod tests {
         SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 password: Some(PasswordOAuth2Flow {
-                    token_url: String::from("foo"),
-                    refresh_url: Some(String::from("bar")),
+                    token_url: String::from("not a uri"),
+                    refresh_url: Some(String::from("also not")),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -1336,8 +1336,8 @@ mod tests {
         SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 client_credentials: Some(ClientCredentialsOAuth2Flow {
-                    token_url: String::from("foo"),
-                    refresh_url: Some(String::from("bar")),
+                    token_url: String::from("not a uri"),
+                    refresh_url: Some(String::from("also not")),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -1357,9 +1357,9 @@ mod tests {
         SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
             flows: OAuth2Flows {
                 authorization_code: Some(AuthorizationCodeOAuth2Flow {
-                    authorization_url: String::from("xyz"),
-                    token_url: String::from("foo"),
-                    refresh_url: Some(String::from("bar")),
+                    authorization_url: String::from("third bad"),
+                    token_url: String::from("not a uri"),
+                    refresh_url: Some(String::from("also not")),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/src/v3_1/security_scheme.rs
+++ b/src/v3_1/security_scheme.rs
@@ -443,18 +443,9 @@ impl ValidateWithContext<Spec> for OAuth2SecurityScheme {
 
 impl ValidateWithContext<Spec> for OAuth2Flows {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        // Spec: at least one of implicit / password / clientCredentials /
-        // authorizationCode MUST be defined on an OAuthFlows Object.
-        if self.implicit.is_none()
-            && self.password.is_none()
-            && self.client_credentials.is_none()
-            && self.authorization_code.is_none()
-        {
-            ctx.error(
-                path.clone(),
-                "must define at least one of `implicit` / `password` / `clientCredentials` / `authorizationCode`",
-            );
-        }
+        // Per the OAS 3.1 JSON Schema, `flows` does not require any of
+        // implicit / password / clientCredentials / authorizationCode to
+        // be set — an empty `flows: {}` is valid.
         if let Some(flow) = &self.implicit {
             flow.validate_with_context(ctx, format!("{path}.implicit"));
         }
@@ -1281,12 +1272,11 @@ mod tests {
             ..Default::default()
         }))
         .validate_with_context(&mut ctx, String::from("securityScheme"));
-        // OAS 3.1.2: OAuthFlows MUST define at least one flow.
+        // Per the OAS 3.1 JSON Schema, an empty `flows: {}` is valid;
+        // no error expected.
         assert!(
-            ctx.errors
-                .iter()
-                .any(|e| e.contains("must define at least one")),
-            "expected at-least-one-flow error: {:?}",
+            ctx.errors.is_empty(),
+            "empty flows accepted: {:?}",
             ctx.errors
         );
 

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -367,7 +367,7 @@ impl<'de> serde::Deserialize<'de> for Version {
         } else {
             Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&s),
-                &"`3.1.<patch>` semver, optionally with a `-<prerelease>` suffix",
+                &"a version matching the OAS 3.1 schema pattern `^3\\.1\\.\\d+(-.+)?$`",
             ))
         }
     }
@@ -905,7 +905,7 @@ mod tests {
             serde_json::from_value::<Version>(serde_json::json!("foo"))
                 .unwrap_err()
                 .to_string()
-                .contains("expected `3.1.<patch>` semver"),
+                .contains("3.1 schema pattern"),
             "foo as openapi version",
         );
 
@@ -937,7 +937,7 @@ mod tests {
             .unwrap()
             .openapi,
             Version::V3_1_2(),
-            "non-semver `3.1` must be rejected at the Spec level too",
+            "`3.1` short alias is accepted at the Spec level and normalises to `3.1.2`",
         );
         assert!(
             serde_json::from_value::<Spec>(serde_json::json!({
@@ -950,7 +950,7 @@ mod tests {
             }))
             .unwrap_err()
             .to_string()
-            .contains("expected `3.1.<patch>` semver"),
+            .contains("3.1 schema pattern"),
             "empty spec.openapi",
         );
         assert_eq!(

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -308,29 +308,67 @@ pub struct TagGroup {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-/// The Swagger Specification version.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
-pub enum Version {
-    /// `3.1.0` version
-    #[serde(rename = "3.1.0")]
-    V3_1_0,
+/// The OpenAPI Specification version. Per the OAS 3.1 JSON Schema, the
+/// `openapi` field matches `^3\.1\.\d+(-.+)?$` — any 3.1.x patch version,
+/// optionally with a prerelease suffix. The bare `3.1` short alias is
+/// accepted and normalised to `3.1.2`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version(String);
 
-    /// `3.1.1` version
-    #[serde(rename = "3.1.1")]
-    V3_1_1,
+impl Default for Version {
+    fn default() -> Self {
+        Self("3.1.2".to_owned())
+    }
+}
 
-    /// `3.1.2` version
-    #[default]
-    #[serde(rename = "3.1.2", alias = "3.1")]
-    V3_1_2,
+impl Version {
+    /// Convenience constructor for the `3.1.0` value.
+    #[allow(non_snake_case)]
+    pub fn V3_1_0() -> Self {
+        Self("3.1.0".to_owned())
+    }
+    /// Convenience constructor for the `3.1.1` value.
+    #[allow(non_snake_case)]
+    pub fn V3_1_1() -> Self {
+        Self("3.1.1".to_owned())
+    }
+    /// Convenience constructor for the canonical `3.1.2` value.
+    #[allow(non_snake_case)]
+    pub fn V3_1_2() -> Self {
+        Self("3.1.2".to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::V3_1_0 => write!(f, "3.1.0"),
-            Self::V3_1_1 => write!(f, "3.1.1"),
-            Self::V3_1_2 => write!(f, "3.1.2"),
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        if s == "3.1" {
+            return Ok(Version("3.1.2".to_owned()));
+        }
+        let re = lazy_regex::regex!(r"^3\.1\.\d+(-.+)?$");
+        if re.is_match(&s) {
+            Ok(Version(s))
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"`3.1.<patch>` semver, optionally with a `-<prerelease>` suffix",
+            ))
         }
     }
 }
@@ -855,21 +893,27 @@ mod tests {
     fn test_version_deserialize() {
         assert_eq!(
             serde_json::from_value::<Version>(serde_json::json!("3.1.0")).unwrap(),
-            Version::V3_1_0,
+            Version::V3_1_0(),
             "correct openapi version",
         );
         assert_eq!(
             serde_json::from_value::<Version>(serde_json::json!("3.1")).unwrap(),
-            Version::V3_1_2,
+            Version::V3_1_2(),
             "alias to latest `3.1.X` version",
         );
-        assert_eq!(
+        assert!(
             serde_json::from_value::<Version>(serde_json::json!("foo"))
                 .unwrap_err()
-                .to_string(),
-            "unknown variant `foo`, expected one of `3.1.0`, `3.1.1`, `3.1`, `3.1.2`",
+                .to_string()
+                .contains("expected `3.1.<patch>` semver"),
             "foo as openapi version",
         );
+
+        // Patch versions and prerelease suffixes per the schema pattern.
+        for ok in ["3.1.0", "3.1.5", "3.1.42", "3.1.0-rc1", "3.1.7-beta.3"] {
+            let v: Version = serde_json::from_value(serde_json::json!(ok)).expect("must accept");
+            assert_eq!(v.as_str(), ok, "round-trip `{ok}`");
+        }
         assert_eq!(
             serde_json::from_value::<Spec>(serde_json::json!({
                 "openapi": "3.1.2",
@@ -881,7 +925,7 @@ mod tests {
             }))
             .unwrap()
             .openapi,
-            Version::V3_1_2,
+            Version::V3_1_2(),
             "3.1.2 spec.openapi",
         );
         assert_eq!(
@@ -892,10 +936,10 @@ mod tests {
             }))
             .unwrap()
             .openapi,
-            Version::V3_1_2,
+            Version::V3_1_2(),
             "non-semver `3.1` must be rejected at the Spec level too",
         );
-        assert_eq!(
+        assert!(
             serde_json::from_value::<Spec>(serde_json::json!({
                 "openapi": "",
                 "info": {
@@ -905,8 +949,8 @@ mod tests {
                 "paths": {},
             }))
             .unwrap_err()
-            .to_string(),
-            "unknown variant ``, expected one of `3.1.0`, `3.1.1`, `3.1`, `3.1.2`",
+            .to_string()
+            .contains("expected `3.1.<patch>` semver"),
             "empty spec.openapi",
         );
         assert_eq!(
@@ -927,7 +971,7 @@ mod tests {
     #[test]
     fn test_version_serialize() {
         assert_eq!(
-            serde_json::to_string(&Version::V3_1_0).unwrap(),
+            serde_json::to_string(&Version::V3_1_0()).unwrap(),
             r#""3.1.0""#,
         );
         assert_eq!(
@@ -1386,9 +1430,9 @@ mod tests {
 
     #[test]
     fn version_display_all_variants() {
-        assert_eq!(Version::V3_1_0.to_string(), "3.1.0");
-        assert_eq!(Version::V3_1_1.to_string(), "3.1.1");
-        assert_eq!(Version::V3_1_2.to_string(), "3.1.2");
+        assert_eq!(Version::V3_1_0().to_string(), "3.1.0");
+        assert_eq!(Version::V3_1_1().to_string(), "3.1.1");
+        assert_eq!(Version::V3_1_2().to_string(), "3.1.2");
     }
 
     #[test]

--- a/src/v3_1/xml.rs
+++ b/src/v3_1/xml.rs
@@ -118,10 +118,15 @@ impl ValidateWithContext<Spec> for XML {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         validate_optional_uri(&self.namespace, ctx, format!("{path}.namespace"));
         // OAS XML Object: `namespace` MUST be an *absolute* URI. Require
-        // a present `<scheme>:` prefix per RFC 3986 §3.1.
+        // a present `<scheme>:` prefix per RFC 3986 §3.1. Skip when the
+        // value already failed `validate_optional_uri` (whitespace /
+        // control chars) so the user sees a single, most-relevant error.
         if let Some(ns) = &self.namespace
             && !ns.is_empty()
             && !ctx.is_option(Options::IgnoreInvalidUrls)
+            && !ns
+                .bytes()
+                .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
         {
             let mut chars = ns.chars();
             let first_ok = chars.next().is_some_and(|c| c.is_ascii_alphabetic());

--- a/src/v3_1/xml.rs
+++ b/src/v3_1/xml.rs
@@ -1,7 +1,8 @@
 //! XML Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_uri};
 use crate::v3_1::spec::Spec;
+use crate::validation::Options;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -115,7 +116,29 @@ pub struct XML {
 
 impl ValidateWithContext<Spec> for XML {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
-        validate_optional_url(&self.namespace, ctx, format!("{path}.namespace"));
+        validate_optional_uri(&self.namespace, ctx, format!("{path}.namespace"));
+        // OAS XML Object: `namespace` MUST be an *absolute* URI. Require
+        // a present `<scheme>:` prefix per RFC 3986 §3.1.
+        if let Some(ns) = &self.namespace
+            && !ns.is_empty()
+            && !ctx.is_option(Options::IgnoreInvalidUrls)
+        {
+            let mut chars = ns.chars();
+            let first_ok = chars.next().is_some_and(|c| c.is_ascii_alphabetic());
+            let scheme_end = ns.find(':');
+            let scheme_ok = first_ok
+                && scheme_end.is_some_and(|i| {
+                    ns[..i]
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+                });
+            if !scheme_ok {
+                ctx.error(
+                    format!("{path}.namespace"),
+                    format_args!("must be an absolute URI (with `<scheme>:` prefix), found `{ns}`"),
+                );
+            }
+        }
     }
 }
 
@@ -214,16 +237,44 @@ mod tests {
         .validate_with_context(&mut ctx, "xml".to_owned());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
+        // Non-HTTP absolute URIs (urn:, mailto:, …) are accepted per
+        // the OAS 3.1 schema's uri-reference format on namespaces, but
+        // the spec text demands an *absolute* URI — so no scheme means
+        // it's rejected.
+        let mut ctx = Context::new(&spec, Options::new());
         XML {
-            namespace: Some("foo-bar".to_owned()),
+            namespace: Some("urn:example:ns:1".to_owned()),
             ..Default::default()
         }
         .validate_with_context(&mut ctx, "xml".to_owned());
-        assert_eq!(
-            ctx.errors,
-            vec!["xml.namespace: must be a valid URL, found `foo-bar`"],
-            "invalid URL: {:?}",
+        assert!(ctx.errors.is_empty(), "urn accepted: {:?}", ctx.errors);
+
+        let mut ctx = Context::new(&spec, Options::new());
+        XML {
+            namespace: Some("not a uri".to_owned()),
+            ..Default::default()
+        }
+        .validate_with_context(&mut ctx, "xml".to_owned());
+        assert!(
+            ctx.errors.iter().any(|e| e.contains("must be a valid URI")),
+            "invalid URI: {:?}",
             ctx.errors
         );
+
+        for rel in ["#/foo", "bar/baz", "/relative/path"] {
+            let mut ctx = Context::new(&spec, Options::new());
+            XML {
+                namespace: Some(rel.to_owned()),
+                ..Default::default()
+            }
+            .validate_with_context(&mut ctx, "xml".to_owned());
+            assert!(
+                ctx.errors
+                    .iter()
+                    .any(|e| e.contains("must be an absolute URI")),
+                "relative `{rel}` rejected: {:?}",
+                ctx.errors
+            );
+        }
     }
 }


### PR DESCRIPTION
Cross-checked the v3_1 module against the official JSON Schema at https://spec.openapis.org/oas/3.1/schema/2025-11-23 and tightened the shape and validation rules to match. Same set of fixes applied to v3_2 in #107, brought back to v3_1 here.

## Changes

**Version pattern** — `Version` is no longer a fixed `enum { V3_1_0, V3_1_1, V3_1_2 }`. It's a `pub struct Version(String)` with a custom `Deserialize` that matches the schema pattern `^3\.1\.\d+(-.+)?$`. Patch versions like `3.1.5` and prereleases like `3.1.0-rc1`, `3.1.7-beta.3` now deserialize round-trip. The bare `3.1` short alias still normalises to `3.1.2`. Convenience constructors `Version::V3_1_0() / V3_1_1() / V3_1_2()` and an `as_str()` accessor are provided.

**`Operation.responses` no longer required at validate time** — the OAS 3.1 JSON Schema does not require `responses` on Operation. The validator no longer emits `responses: required field is missing`; the field doc and the `missing_responses_is_accepted` test reflect that.

**`Responses` default-only is valid** — per the schema's anyOf, a Responses Object satisfies the rule with either `default` OR at least one status-code/wildcard entry. Drop the "default alone is not sufficient" rule; only an entirely empty Responses object is flagged.

**URI-reference URL fields** — the schema marks `Example.externalValue`, every OAuth2 flow URL (auth/token/refresh), the `OpenIdConnectUrl`, `ExternalDocumentation.url`, `Contact.url`, and `License.url` as `format: uri-reference`. Switch from URL-only validators to URI validators so relative refs and non-HTTP schemes (`urn:`, `mailto:`, …) pass; whitespace / control-char garbage still fails. The `IgnoreEmptyExternalDocumentationUrl` toggle keeps its meaning at its one owner site.

## Breaking changes (allowed at 0.x)

- `Version` is now a tuple struct, not an enum. Callers that did `Version::V3_1_0` (without parens) now need `Version::V3_1_0()`. Match arms over `Version` no longer work — use `version.as_str()` instead.
- `Operation::default()` is now valid without a `responses` field.
- `Responses` accepts a `default`-only shape.
- URL-format errors now say "must be a valid URI" for the affected fields.

678 tests pass across all features; clippy clean.