### PR TITLE
v3_2 XML.namespace: short-circuit absolute-URI check on URI-validation failure

### DIFF
--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -156,15 +156,20 @@ pub fn validate_optional_uri<T>(uri: &Option<String>, ctx: &mut Context<T>, path
         ctx.error(path, "must be a valid URI, found ``");
         return;
     }
-    // Reject obviously broken forms: any ASCII whitespace or control
-    // character (C0 0x00..0x1F or DEL 0x7F). The full RFC 3986 grammar
-    // is wide enough that everything else is best left to a parser.
-    if uri
-        .bytes()
-        .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
-    {
+    if has_uri_unsafe_bytes(uri) {
         ctx.error(path, format_args!("must be a valid URI, found `{uri}`"));
     }
+}
+
+/// Returns `true` if `s` contains any byte that an RFC 3986 URI cannot
+/// hold — ASCII whitespace or a C0/DEL control char. This is the shared
+/// "obviously broken" predicate used by `validate_optional_uri` /
+/// `validate_required_uri` and by callers (e.g. XML namespace
+/// validators) that want to skip a follow-up scheme check when the URI
+/// validator has already flagged the value.
+pub fn has_uri_unsafe_bytes(s: &str) -> bool {
+    s.bytes()
+        .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
 }
 
 /// Required-URI validator: errors if the value is empty and otherwise
@@ -180,10 +185,7 @@ pub fn validate_required_uri<T>(uri: &String, ctx: &mut Context<T>, path: String
     if uri.is_empty() || ctx.is_option(Options::IgnoreInvalidUrls) {
         return;
     }
-    if uri
-        .bytes()
-        .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
-    {
+    if has_uri_unsafe_bytes(uri) {
         ctx.error(path, format_args!("must be a valid URI, found `{uri}`"));
     }
 }

--- a/src/v3_1/xml.rs
+++ b/src/v3_1/xml.rs
@@ -1,6 +1,8 @@
 //! XML Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_uri};
+use crate::common::helpers::{
+    Context, PushError, ValidateWithContext, has_uri_unsafe_bytes, validate_optional_uri,
+};
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
 use serde::{Deserialize, Serialize};
@@ -124,9 +126,7 @@ impl ValidateWithContext<Spec> for XML {
         if let Some(ns) = &self.namespace
             && !ns.is_empty()
             && !ctx.is_option(Options::IgnoreInvalidUrls)
-            && !ns
-                .bytes()
-                .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
+            && !has_uri_unsafe_bytes(ns)
         {
             let mut chars = ns.chars();
             let first_ok = chars.next().is_some_and(|c| c.is_ascii_alphabetic());

--- a/src/v3_2/xml.rs
+++ b/src/v3_2/xml.rs
@@ -129,9 +129,15 @@ impl ValidateWithContext<Spec> for XML {
         // URI: a relative reference like `#/foo` or `bar/baz` is not
         // valid. Enforce a present `scheme:` prefix per RFC 3986
         // §3.1: `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`.
+        // Skip when the value already failed `validate_optional_uri`
+        // (whitespace / control chars) so users see a single,
+        // most-relevant error.
         if let Some(ns) = &self.namespace
             && !ns.is_empty()
             && !ctx.is_option(Options::IgnoreInvalidUrls)
+            && !ns
+                .bytes()
+                .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
         {
             let mut chars = ns.chars();
             let first_ok = chars.next().is_some_and(|c| c.is_ascii_alphabetic());

--- a/src/v3_2/xml.rs
+++ b/src/v3_2/xml.rs
@@ -1,6 +1,8 @@
 //! XML Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_uri};
+use crate::common::helpers::{
+    Context, PushError, ValidateWithContext, has_uri_unsafe_bytes, validate_optional_uri,
+};
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
 use serde::{Deserialize, Serialize};
@@ -135,9 +137,7 @@ impl ValidateWithContext<Spec> for XML {
         if let Some(ns) = &self.namespace
             && !ns.is_empty()
             && !ctx.is_option(Options::IgnoreInvalidUrls)
-            && !ns
-                .bytes()
-                .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
+            && !has_uri_unsafe_bytes(ns)
         {
             let mut chars = ns.chars();
             let first_ok = chars.next().is_some_and(|c| c.is_ascii_alphabetic());
@@ -291,18 +291,38 @@ mod tests {
         .validate_with_context(&mut ctx, "xml".to_owned());
         assert!(ctx.errors.is_empty(), "urn accepted: {:?}", ctx.errors);
 
-        // Whitespace / control chars are rejected.
-        let mut ctx = Context::new(&spec, Options::new());
-        XML {
-            namespace: Some("not a uri".to_owned()),
-            ..Default::default()
+        // Whitespace / control chars are rejected — and the absolute-URI
+        // scheme check short-circuits, so the user sees a single
+        // "must be a valid URI" error rather than two errors at the same
+        // path.
+        for ns in ["not a uri", "tab\there", "ctrl\x01char"] {
+            let mut ctx = Context::new(&spec, Options::new());
+            XML {
+                namespace: Some(ns.to_owned()),
+                ..Default::default()
+            }
+            .validate_with_context(&mut ctx, "xml".to_owned());
+            let valid_uri_errs = ctx
+                .errors
+                .iter()
+                .filter(|e| e.contains("must be a valid URI"))
+                .count();
+            let absolute_uri_errs = ctx
+                .errors
+                .iter()
+                .filter(|e| e.contains("must be an absolute URI"))
+                .count();
+            assert_eq!(
+                valid_uri_errs, 1,
+                "exactly one 'must be a valid URI' for `{ns}`: {:?}",
+                ctx.errors
+            );
+            assert_eq!(
+                absolute_uri_errs, 0,
+                "no redundant 'must be an absolute URI' for `{ns}`: {:?}",
+                ctx.errors
+            );
         }
-        .validate_with_context(&mut ctx, "xml".to_owned());
-        assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URI")),
-            "invalid URI: {:?}",
-            ctx.errors
-        );
 
         // Relative refs (no scheme) are rejected: namespace MUST be an
         // absolute URI per the OAS XML Object spec.


### PR DESCRIPTION
A namespace value like \`\"not a uri\"\` was producing two errors at the same path:

1. \`xml.namespace: must be a valid URI, found \`not a uri\`\` (from \`validate_optional_uri\`)
2. \`xml.namespace: must be an absolute URI (with \`<scheme>:\` prefix), found \`not a uri\`\` (from the scheme check that follows)

Skip the absolute-URI scheme check when the value already contains whitespace or control chars (i.e. when \`validate_optional_uri\` has already complained), so users see a single, most-relevant error per bad value.

Mirrors the same fix applied to v3_1 in #111 (commit \`5559266\`). 678 tests pass; clippy clean.