### PR TITLE
v3_0/v2: regex-validated Version tuple structs

### DIFF
--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -231,8 +231,11 @@ impl serde::Serialize for Version {
 
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(de)?;
-        Version::from_str_inner(&s).map_err(|_| {
+        // Delegate to `TryFrom<String>` so the owned `s` from serde
+        // moves straight into `Version(s)` on success. On failure, the
+        // offending string travels back through `InvalidVersion` and
+        // is borrowed once for the serde error message.
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
             serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&s),
                 &"the literal Swagger version string `2.0`",

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -193,20 +193,52 @@ pub struct Spec {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-/// The Swagger Specification version.
-/// Supports only `2.0` version.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
-pub enum Version {
-    /// `2.0` version
-    #[default]
-    #[serde(rename = "2.0")]
-    V2_0,
+/// The Swagger Specification version. Per the Swagger 2.0 spec the
+/// `swagger` field MUST be the literal string `"2.0"` — no other value
+/// is accepted.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version(String);
+
+impl Default for Version {
+    fn default() -> Self {
+        Self("2.0".to_owned())
+    }
+}
+
+impl Version {
+    /// Convenience constructor for the only valid `2.0` value.
+    #[allow(non_snake_case)]
+    pub fn V2_0() -> Self {
+        Self("2.0".to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::V2_0 => write!(f, "2.0"),
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        if s == "2.0" {
+            Ok(Version(s))
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"the literal Swagger version string `2.0`",
+            ))
         }
     }
 }
@@ -505,7 +537,7 @@ mod tests {
             }))
             .unwrap(),
             Spec {
-                swagger: Version::V2_0,
+                swagger: Version::V2_0(),
                 info: Info {
                     title: String::from("foo"),
                     version: String::from("1"),
@@ -526,7 +558,7 @@ mod tests {
             }))
             .unwrap_err()
             .to_string(),
-            "unknown variant ``, expected `2.0`",
+            "invalid value: string \"\", expected the literal Swagger version string `2.0`",
             "empty swagger version",
         );
         assert_eq!(
@@ -539,7 +571,7 @@ mod tests {
             }))
             .unwrap_err()
             .to_string(),
-            "unknown variant `foo`, expected `2.0`",
+            "invalid value: string \"foo\", expected the literal Swagger version string `2.0`",
             "foo as swagger version",
         );
     }
@@ -604,7 +636,7 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<TestVersion>(
                 serde_json::to_string(&Spec {
-                    swagger: Version::V2_0,
+                    swagger: Version::V2_0(),
                     info: Info {
                         title: String::from("foo"),
                         version: String::from("1"),
@@ -794,7 +826,7 @@ mod tests {
 
     #[test]
     fn version_and_scheme_display() {
-        assert_eq!(format!("{}", Version::V2_0), "2.0");
+        assert_eq!(format!("{}", Version::V2_0()), "2.0");
         for (s, expected) in [
             (Scheme::HTTP, "http"),
             (Scheme::HTTPS, "https"),

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -232,14 +232,49 @@ impl serde::Serialize for Version {
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
         let s = String::deserialize(de)?;
-        if s == "2.0" {
-            Ok(Version(s))
-        } else {
-            Err(serde::de::Error::invalid_value(
+        Version::from_str_inner(&s).map_err(|_| {
+            serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&s),
                 &"the literal Swagger version string `2.0`",
-            ))
+            )
+        })
+    }
+}
+
+/// Returned by `Version::from_str` / `TryFrom<&str>` when the input is
+/// not the literal Swagger version string `2.0`.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("version {0:?} must be the literal Swagger version string `2.0`")]
+pub struct InvalidVersion(pub String);
+
+impl Version {
+    fn from_str_inner(s: &str) -> Result<Self, InvalidVersion> {
+        if s == "2.0" {
+            Ok(Version(s.to_owned()))
+        } else {
+            Err(InvalidVersion(s.to_owned()))
         }
+    }
+}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_str_inner(s)
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::from_str_inner(s)
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str_inner(&s)
     }
 }
 
@@ -667,6 +702,28 @@ mod tests {
             .unwrap()
             .swagger,
             "2.0",
+        );
+    }
+
+    #[test]
+    fn test_swagger_version_parse_programmatically() {
+        use std::str::FromStr;
+        // The literal string round-trips through FromStr / TryFrom.
+        assert_eq!(Version::from_str("2.0").unwrap(), Version::V2_0());
+        assert_eq!(
+            <Version as TryFrom<&str>>::try_from("2.0").unwrap(),
+            Version::V2_0()
+        );
+        assert_eq!(
+            <Version as TryFrom<String>>::try_from("2.0".to_owned()).unwrap(),
+            Version::V2_0()
+        );
+        // Anything else is rejected with a typed error.
+        let err = Version::from_str("3.0.0").unwrap_err();
+        assert_eq!(err, InvalidVersion("3.0.0".to_owned()));
+        assert!(
+            err.to_string().contains("`2.0`"),
+            "error message names the only valid value: {err}"
         );
     }
 

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -229,6 +229,14 @@ impl serde::Serialize for Version {
     }
 }
 
+/// The only valid Swagger version literal. Shared by every parsing
+/// path, serde's `expected` payload, and `InvalidVersion`'s `Display`.
+const SWAGGER_VERSION_LITERAL: &str = "2.0";
+
+/// Human-readable description of the constraint, shared by serde's
+/// `expected` payload and `InvalidVersion`'s `Display`.
+const SWAGGER_VERSION_DESCRIPTION: &str = "the literal Swagger version string `2.0`";
+
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
         // Delegate to `TryFrom<String>` so the owned `s` from serde
@@ -238,7 +246,7 @@ impl<'de> serde::Deserialize<'de> for Version {
         Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
             serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&s),
-                &"the literal Swagger version string `2.0`",
+                &SWAGGER_VERSION_DESCRIPTION,
             )
         })
     }
@@ -246,13 +254,25 @@ impl<'de> serde::Deserialize<'de> for Version {
 
 /// Returned by `Version::from_str` / `TryFrom<&str>` when the input is
 /// not the literal Swagger version string `2.0`.
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("version {0:?} must be the literal Swagger version string `2.0`")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InvalidVersion(pub String);
 
-impl Version {
-    fn from_str_inner(s: &str) -> Result<Self, InvalidVersion> {
-        if s == "2.0" {
+impl fmt::Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "version {:?} must be {SWAGGER_VERSION_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == SWAGGER_VERSION_LITERAL {
             Ok(Version(s.to_owned()))
         } else {
             Err(InvalidVersion(s.to_owned()))
@@ -260,26 +280,19 @@ impl Version {
     }
 }
 
-impl std::str::FromStr for Version {
-    type Err = InvalidVersion;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_str_inner(s)
-    }
-}
-
 impl TryFrom<&str> for Version {
     type Error = InvalidVersion;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Self::from_str_inner(s)
+        s.parse()
     }
 }
 
 impl TryFrom<String> for Version {
     type Error = InvalidVersion;
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        // Move the input directly rather than borrowing into
-        // `from_str_inner` and reallocating.
-        if s == "2.0" {
+        // Move the input directly rather than borrowing and
+        // reallocating.
+        if s == SWAGGER_VERSION_LITERAL {
             Ok(Version(s))
         } else {
             Err(InvalidVersion(s))

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -274,7 +274,13 @@ impl TryFrom<&str> for Version {
 impl TryFrom<String> for Version {
     type Error = InvalidVersion;
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        Self::from_str_inner(&s)
+        // Move the input directly rather than borrowing into
+        // `from_str_inner` and reallocating.
+        if s == "2.0" {
+            Ok(Version(s))
+        } else {
+            Err(InvalidVersion(s))
+        }
     }
 }
 

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -300,6 +300,20 @@ impl TryFrom<String> for Version {
     }
 }
 
+impl Validate for Version {
+    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
+        // Constructors and parsers all enforce the literal, but
+        // re-checking here keeps `Validate` a self-contained contract.
+        if self.0 == SWAGGER_VERSION_LITERAL {
+            Ok(())
+        } else {
+            Err(Error {
+                errors: vec![format!("#.swagger: must be {SWAGGER_VERSION_DESCRIPTION}")],
+            })
+        }
+    }
+}
+
 /// The possible values of the transfer protocol of the API
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub enum Scheme {
@@ -474,6 +488,12 @@ impl ResolveReference<Tag> for Spec {
 impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
+
+        // Surface any `swagger` literal violations alongside the rest
+        // of the spec's errors instead of bailing out early.
+        if let Err(e) = self.swagger.validate(options) {
+            ctx.errors.extend(e.errors);
+        }
 
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
@@ -724,6 +744,19 @@ mod tests {
             .unwrap()
             .swagger,
             "2.0",
+        );
+    }
+
+    #[test]
+    fn test_swagger_version_validate() {
+        assert!(Version::default().validate(Options::new()).is_ok());
+        assert!(Version::V2_0().validate(Options::new()).is_ok());
+        assert!(
+            "2.0"
+                .parse::<Version>()
+                .unwrap()
+                .validate(Options::new())
+                .is_ok()
         );
     }
 

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -761,6 +761,51 @@ mod tests {
     }
 
     #[test]
+    fn test_swagger_version_validate_rejects_invalid() {
+        // Inner `String` is private to outside callers, so the only
+        // way to reach the rejection branch is from inside the module.
+        let invalid = Version("3.0".to_owned());
+        let err = invalid.validate(Options::new()).unwrap_err();
+        assert_eq!(err.errors.len(), 1);
+        assert!(
+            err.errors[0].contains("#.swagger") && err.errors[0].contains("`2.0`"),
+            "validate error names the field and the literal: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_spec_validate_surfaces_invalid_swagger() {
+        let mut spec = Spec {
+            swagger: Version("3.0".to_owned()),
+            info: Info {
+                title: "test".to_owned(),
+                version: "1".to_owned(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        // Cargo `..Default::default()` already sets paths/etc. to defaults.
+        let _ = &mut spec;
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("#.swagger") && e.contains("`2.0`")),
+            "Spec::validate surfaces the swagger error: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_swagger_version_try_from_string_rejects_garbage() {
+        // The owned-input `TryFrom<String>` path moves the offending
+        // string straight into `InvalidVersion`, no clone.
+        let err: InvalidVersion = Version::try_from("nope".to_owned()).unwrap_err();
+        assert_eq!(err.0, "nope");
+    }
+
+    #[test]
     fn test_swagger_version_parse_programmatically() {
         use std::str::FromStr;
         // The literal string round-trips through FromStr / TryFrom.

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -910,6 +910,53 @@ mod tests {
     }
 
     #[test]
+    fn test_version_validate_rejects_invalid() {
+        // The inner `String` is private, so external code can't build
+        // a malformed `Version`. Inside the module we can — exercise
+        // the rejection branch so the contract is locked in.
+        let invalid = Version("garbage".to_owned());
+        let err = invalid.validate(Options::new()).unwrap_err();
+        assert_eq!(err.errors.len(), 1);
+        assert!(
+            err.errors[0].contains("#.openapi") && err.errors[0].contains("3\\.0\\.\\d+(-.+)?$"),
+            "validate error names the field and the schema regex: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_spec_validate_surfaces_invalid_openapi() {
+        let mut spec = Spec {
+            openapi: Version("3.5.0".to_owned()),
+            ..Default::default()
+        };
+        // Make every other field acceptable so the only error is the
+        // openapi-pattern violation we're forcing.
+        spec.info.title = "test".to_owned();
+        spec.info.version = "1".to_owned();
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("#.openapi") && e.contains("3\\.0\\.\\d+(-.+)?$")),
+            "Spec::validate surfaces the openapi error: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_version_try_from_string_normalizes_short_alias() {
+        // The move-friendly `TryFrom<String>` path special-cases the
+        // bare `3.0` alias and yields the canonical `3.0.4` value.
+        let v: Version = "3.0".to_owned().try_into().unwrap();
+        assert_eq!(v, Version::V3_0_4());
+        // And rejects garbage by moving the input into the error
+        // (no extra allocation).
+        let err: InvalidVersion = Version::try_from("nope".to_owned()).unwrap_err();
+        assert_eq!(err.0, "nope");
+    }
+
+    #[test]
     fn test_version_parse_programmatically() {
         use std::str::FromStr;
         // FromStr accepts schema-conformant patch/prerelease values

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -269,39 +269,77 @@ pub struct TagGroup {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-/// The Swagger Specification version.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
-pub enum Version {
-    /// `3.0.0` version
-    #[serde(rename = "3.0.0")]
-    V3_0_0,
+/// The OpenAPI Specification version. Per the OAS 3.0 JSON Schema, the
+/// `openapi` field matches `^3\.0\.\d+(-.+)?$` — any 3.0.x patch version,
+/// optionally with a prerelease suffix. The bare `3.0` short alias is
+/// accepted and normalised to `3.0.4`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version(String);
 
-    /// `3.0.1` version
-    #[serde(rename = "3.0.1")]
-    V3_0_1,
+impl Default for Version {
+    fn default() -> Self {
+        Self("3.0.4".to_owned())
+    }
+}
 
-    /// `3.0.2` version
-    #[serde(rename = "3.0.2")]
-    V3_0_2,
+impl Version {
+    /// Convenience constructor for the `3.0.0` value.
+    #[allow(non_snake_case)]
+    pub fn V3_0_0() -> Self {
+        Self("3.0.0".to_owned())
+    }
+    /// Convenience constructor for the `3.0.1` value.
+    #[allow(non_snake_case)]
+    pub fn V3_0_1() -> Self {
+        Self("3.0.1".to_owned())
+    }
+    /// Convenience constructor for the `3.0.2` value.
+    #[allow(non_snake_case)]
+    pub fn V3_0_2() -> Self {
+        Self("3.0.2".to_owned())
+    }
+    /// Convenience constructor for the `3.0.3` value.
+    #[allow(non_snake_case)]
+    pub fn V3_0_3() -> Self {
+        Self("3.0.3".to_owned())
+    }
+    /// Convenience constructor for the canonical `3.0.4` value.
+    #[allow(non_snake_case)]
+    pub fn V3_0_4() -> Self {
+        Self("3.0.4".to_owned())
+    }
 
-    /// `3.0.3` version
-    #[serde(rename = "3.0.3")]
-    V3_0_3,
-
-    /// `3.0.4` version
-    #[default]
-    #[serde(rename = "3.0.4", alias = "3.0")]
-    V3_0_4,
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::V3_0_0 => write!(f, "3.0.0"),
-            Self::V3_0_1 => write!(f, "3.0.1"),
-            Self::V3_0_2 => write!(f, "3.0.2"),
-            Self::V3_0_3 => write!(f, "3.0.3"),
-            Self::V3_0_4 => write!(f, "3.0.4"),
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        if s == "3.0" {
+            return Ok(Version("3.0.4".to_owned()));
+        }
+        let re = lazy_regex::regex!(r"^3\.0\.\d+(-.+)?$");
+        if re.is_match(&s) {
+            Ok(Version(s))
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`",
+            ))
         }
     }
 }
@@ -667,20 +705,30 @@ mod tests {
     fn test_version_deserialize() {
         assert_eq!(
             serde_json::from_value::<Version>(serde_json::json!("3.0.0")).unwrap(),
-            Version::V3_0_0,
+            Version::V3_0_0(),
             "correct openapi version",
         );
         assert_eq!(
             serde_json::from_value::<Version>(serde_json::json!("3.0")).unwrap(),
-            Version::V3_0_4,
+            Version::V3_0_4(),
             "3.0 openapi version",
         );
         assert_eq!(
             serde_json::from_value::<Version>(serde_json::json!("foo"))
                 .unwrap_err()
                 .to_string(),
-            "unknown variant `foo`, expected one of `3.0.0`, `3.0.1`, `3.0.2`, `3.0.3`, `3.0`, `3.0.4`",
+            "invalid value: string \"foo\", expected a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`",
             "foo as openapi version",
+        );
+        assert_eq!(
+            serde_json::from_value::<Version>(serde_json::json!("3.0.99")).unwrap(),
+            Version("3.0.99".to_owned()),
+            "future patch is accepted by the schema regex",
+        );
+        assert_eq!(
+            serde_json::from_value::<Version>(serde_json::json!("3.0.0-rc1")).unwrap(),
+            Version("3.0.0-rc1".to_owned()),
+            "prerelease suffix is accepted by the schema regex",
         );
         assert_eq!(
             serde_json::from_value::<Spec>(serde_json::json!({
@@ -693,7 +741,7 @@ mod tests {
             }))
             .unwrap()
             .openapi,
-            Version::V3_0_4,
+            Version::V3_0_4(),
             "3.0.4 spec.openapi",
         );
         assert_eq!(
@@ -707,7 +755,7 @@ mod tests {
             }))
             .unwrap()
             .openapi,
-            Version::V3_0_4,
+            Version::V3_0_4(),
             "3.0 spec.openapi",
         );
         assert_eq!(
@@ -721,7 +769,7 @@ mod tests {
             }))
             .unwrap_err()
             .to_string(),
-            "unknown variant ``, expected one of `3.0.0`, `3.0.1`, `3.0.2`, `3.0.3`, `3.0`, `3.0.4`",
+            "invalid value: string \"\", expected a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`",
             "empty spec.openapi",
         );
         assert_eq!(
@@ -742,7 +790,7 @@ mod tests {
     #[test]
     fn test_version_serialize() {
         assert_eq!(
-            serde_json::to_string(&Version::V3_0_0).unwrap(),
+            serde_json::to_string(&Version::V3_0_0()).unwrap(),
             r#""3.0.0""#,
         );
         assert_eq!(
@@ -1137,11 +1185,11 @@ mod tests {
 
     #[test]
     fn version_display_all_variants() {
-        assert_eq!(Version::V3_0_0.to_string(), "3.0.0");
-        assert_eq!(Version::V3_0_1.to_string(), "3.0.1");
-        assert_eq!(Version::V3_0_2.to_string(), "3.0.2");
-        assert_eq!(Version::V3_0_3.to_string(), "3.0.3");
-        assert_eq!(Version::V3_0_4.to_string(), "3.0.4");
+        assert_eq!(Version::V3_0_0().to_string(), "3.0.0");
+        assert_eq!(Version::V3_0_1().to_string(), "3.0.1");
+        assert_eq!(Version::V3_0_2().to_string(), "3.0.2");
+        assert_eq!(Version::V3_0_3().to_string(), "3.0.3");
+        assert_eq!(Version::V3_0_4().to_string(), "3.0.4");
     }
 
     #[test]

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -381,7 +381,19 @@ impl TryFrom<&str> for Version {
 impl TryFrom<String> for Version {
     type Error = InvalidVersion;
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        Self::from_str_inner(&s)
+        // Move the input directly rather than borrowing into
+        // `from_str_inner` and reallocating. The `3.0` short alias
+        // still needs a fresh `3.0.4` string; every other path
+        // consumes `s` in place.
+        if s == "3.0" {
+            return Ok(Version("3.0.4".to_owned()));
+        }
+        let re = lazy_regex::regex!(r"^3\.0\.\d+(-.+)?$");
+        if re.is_match(&s) {
+            Ok(Version(s))
+        } else {
+            Err(InvalidVersion(s))
+        }
     }
 }
 

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -417,6 +417,21 @@ impl TryFrom<String> for Version {
     }
 }
 
+impl Validate for Version {
+    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
+        // Constructors and parsers all enforce the pattern, but
+        // re-checking here keeps `Validate` a self-contained contract:
+        // any `Version` that survives this call is schema-conformant.
+        if matches_oas_3_0_version(&self.0) {
+            Ok(())
+        } else {
+            Err(Error {
+                errors: vec![format!("#.openapi: must be {VERSION_SCHEMA_DESCRIPTION}")],
+            })
+        }
+    }
+}
+
 impl Spec {
     /// Insert a schema under `#/components/schemas/{name}` and return a `$ref` pointing to it.
     /// Replaces any existing entry with the same name.
@@ -686,6 +701,12 @@ impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
 
+        // Surface any `openapi` schema-pattern violations alongside the
+        // rest of the spec's errors instead of bailing out early.
+        if let Err(e) = self.openapi.validate(options) {
+            ctx.errors.extend(e.errors);
+        }
+
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
 
@@ -869,6 +890,22 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Version::default()).unwrap(),
             r#""3.0.4""#,
+        );
+    }
+
+    #[test]
+    fn test_version_validate() {
+        // Every constructible `Version` is schema-conformant and
+        // therefore validates clean.
+        assert!(Version::default().validate(Options::new()).is_ok());
+        assert!(Version::V3_0_0().validate(Options::new()).is_ok());
+        assert!(Version::V3_0_4().validate(Options::new()).is_ok());
+        assert!(
+            "3.0.99"
+                .parse::<Version>()
+                .unwrap()
+                .validate(Options::new())
+                .is_ok()
         );
     }
 

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -334,8 +334,12 @@ impl serde::Serialize for Version {
 
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(de)?;
-        Version::from_str_inner(&s).map_err(|_| {
+        // Delegate to `TryFrom<String>` so the owned `s` from serde
+        // moves straight into `Version(s)` on success (no `to_owned`
+        // round-trip). On failure, the offending string travels back
+        // through `InvalidVersion` and is borrowed once for the serde
+        // error message.
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
             serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&s),
                 &"a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`",

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -332,6 +332,20 @@ impl serde::Serialize for Version {
     }
 }
 
+/// Human-readable description of the OAS 3.0 version pattern, shared
+/// by serde's `expected` payload and `InvalidVersion`'s `Display`.
+/// The literal regex itself lives in [`matches_oas_3_0_version`] —
+/// keep both in sync if either ever changes.
+const VERSION_SCHEMA_DESCRIPTION: &str =
+    "a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`";
+
+/// Single source of truth for the regex check. `lazy_regex::regex!`
+/// requires a string literal so we can't host the pattern in a `const`,
+/// but every parsing path goes through this one function.
+fn matches_oas_3_0_version(s: &str) -> bool {
+    lazy_regex::regex!(r"^3\.0\.\d+(-.+)?$").is_match(s)
+}
+
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
         // Delegate to `TryFrom<String>` so the owned `s` from serde
@@ -342,7 +356,7 @@ impl<'de> serde::Deserialize<'de> for Version {
         Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
             serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&s),
-                &"a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`",
+                &VERSION_SCHEMA_DESCRIPTION,
             )
         })
     }
@@ -350,17 +364,28 @@ impl<'de> serde::Deserialize<'de> for Version {
 
 /// Returned by `Version::from_str` / `TryFrom<&str>` when the input
 /// does not match the OAS 3.0 schema pattern (see [`Version`]).
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("version {0:?} must match the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InvalidVersion(pub String);
 
-impl Version {
-    fn from_str_inner(s: &str) -> Result<Self, InvalidVersion> {
+impl fmt::Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "version {:?} must be {VERSION_SCHEMA_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == "3.0" {
             return Ok(Version("3.0.4".to_owned()));
         }
-        let re = lazy_regex::regex!(r"^3\.0\.\d+(-.+)?$");
-        if re.is_match(s) {
+        if matches_oas_3_0_version(s) {
             Ok(Version(s.to_owned()))
         } else {
             Err(InvalidVersion(s.to_owned()))
@@ -368,32 +393,23 @@ impl Version {
     }
 }
 
-impl std::str::FromStr for Version {
-    type Err = InvalidVersion;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_str_inner(s)
-    }
-}
-
 impl TryFrom<&str> for Version {
     type Error = InvalidVersion;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Self::from_str_inner(s)
+        s.parse()
     }
 }
 
 impl TryFrom<String> for Version {
     type Error = InvalidVersion;
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        // Move the input directly rather than borrowing into
-        // `from_str_inner` and reallocating. The `3.0` short alias
-        // still needs a fresh `3.0.4` string; every other path
-        // consumes `s` in place.
+        // Move the input directly rather than borrowing and
+        // reallocating. The `3.0` short alias still needs a fresh
+        // `3.0.4` string; every other path consumes `s` in place.
         if s == "3.0" {
             return Ok(Version("3.0.4".to_owned()));
         }
-        let re = lazy_regex::regex!(r"^3\.0\.\d+(-.+)?$");
-        if re.is_match(&s) {
+        if matches_oas_3_0_version(&s) {
             Ok(Version(s))
         } else {
             Err(InvalidVersion(s))

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -160,7 +160,13 @@ pub struct Spec {
     /// the OpenAPI document.
     /// This is not related to the API info.version string.
     ///
-    /// The value MUST be one of ["3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4"].
+    /// The value MUST match the OAS 3.0 schema pattern
+    /// `^3\.0\.\d+(-.+)?$`, i.e. any `3.0.x` patch release with an
+    /// optional prerelease suffix.
+    /// The bare `3.0` short alias is also accepted on the wire and
+    /// normalised to `3.0.4`. See [`Version`] for constructors and the
+    /// `FromStr` / `TryFrom<&str>` parsers used to build arbitrary
+    /// schema-conformant values programmatically.
     pub openapi: Version,
 
     /// **Required** Provides metadata about the API.
@@ -329,18 +335,53 @@ impl serde::Serialize for Version {
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
         let s = String::deserialize(de)?;
+        Version::from_str_inner(&s).map_err(|_| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`",
+            )
+        })
+    }
+}
+
+/// Returned by `Version::from_str` / `TryFrom<&str>` when the input
+/// does not match the OAS 3.0 schema pattern (see [`Version`]).
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("version {0:?} must match the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`")]
+pub struct InvalidVersion(pub String);
+
+impl Version {
+    fn from_str_inner(s: &str) -> Result<Self, InvalidVersion> {
         if s == "3.0" {
             return Ok(Version("3.0.4".to_owned()));
         }
         let re = lazy_regex::regex!(r"^3\.0\.\d+(-.+)?$");
-        if re.is_match(&s) {
-            Ok(Version(s))
+        if re.is_match(s) {
+            Ok(Version(s.to_owned()))
         } else {
-            Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Str(&s),
-                &"a version matching the OAS 3.0 schema pattern `^3\\.0\\.\\d+(-.+)?$`",
-            ))
+            Err(InvalidVersion(s.to_owned()))
         }
+    }
+}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_str_inner(s)
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::from_str_inner(s)
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str_inner(&s)
     }
 }
 
@@ -796,6 +837,39 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Version::default()).unwrap(),
             r#""3.0.4""#,
+        );
+    }
+
+    #[test]
+    fn test_version_parse_programmatically() {
+        use std::str::FromStr;
+        // FromStr accepts schema-conformant patch/prerelease values
+        // without going through Serde.
+        assert_eq!(
+            Version::from_str("3.0.99").unwrap(),
+            Version("3.0.99".to_owned())
+        );
+        assert_eq!(
+            Version::from_str("3.0.0-rc1").unwrap(),
+            Version("3.0.0-rc1".to_owned())
+        );
+        // Bare `3.0` short alias normalises to `3.0.4`.
+        assert_eq!(Version::from_str("3.0").unwrap(), Version::V3_0_4());
+        // TryFrom<&str> and TryFrom<String> agree.
+        assert_eq!(
+            <Version as TryFrom<&str>>::try_from("3.0.7").unwrap(),
+            Version("3.0.7".to_owned())
+        );
+        assert_eq!(
+            <Version as TryFrom<String>>::try_from("3.0.7".to_owned()).unwrap(),
+            Version("3.0.7".to_owned())
+        );
+        // Garbage rejects with a typed error carrying the offending input.
+        let err = Version::from_str("foo").unwrap_err();
+        assert_eq!(err, InvalidVersion("foo".to_owned()));
+        assert!(
+            err.to_string().contains("3\\.0\\.\\d+(-.+)?$"),
+            "error message echoes the schema regex: {err}"
         );
     }
 

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -355,20 +355,84 @@ impl serde::Serialize for Version {
     }
 }
 
+/// Human-readable description of the OAS 3.1 version pattern, shared
+/// by serde's `expected` payload and `InvalidVersion`'s `Display`.
+/// The literal regex itself lives in [`matches_oas_3_1_version`] —
+/// keep both in sync if either ever changes.
+const VERSION_SCHEMA_DESCRIPTION: &str =
+    "a version matching the OAS 3.1 schema pattern `^3\\.1\\.\\d+(-.+)?$`";
+
+/// Single source of truth for the regex check. `lazy_regex::regex!`
+/// requires a string literal so we can't host the pattern in a `const`,
+/// but every parsing path goes through this one function.
+fn matches_oas_3_1_version(s: &str) -> bool {
+    lazy_regex::regex!(r"^3\.1\.\d+(-.+)?$").is_match(s)
+}
+
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(de)?;
+        // Delegate to `TryFrom<String>` so the owned `s` from serde
+        // moves straight into `Version(s)` on success (no `to_owned`
+        // round-trip). On failure, the offending string travels back
+        // through `InvalidVersion` and is borrowed once for the serde
+        // error message.
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &VERSION_SCHEMA_DESCRIPTION,
+            )
+        })
+    }
+}
+
+/// Returned by `Version::from_str` / `TryFrom<&str>` when the input
+/// does not match the OAS 3.1 schema pattern (see [`Version`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidVersion(pub String);
+
+impl fmt::Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "version {:?} must be {VERSION_SCHEMA_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == "3.1" {
             return Ok(Version("3.1.2".to_owned()));
         }
-        let re = lazy_regex::regex!(r"^3\.1\.\d+(-.+)?$");
-        if re.is_match(&s) {
+        if matches_oas_3_1_version(s) {
+            Ok(Version(s.to_owned()))
+        } else {
+            Err(InvalidVersion(s.to_owned()))
+        }
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if s == "3.1" {
+            return Ok(Version("3.1.2".to_owned()));
+        }
+        if matches_oas_3_1_version(&s) {
             Ok(Version(s))
         } else {
-            Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Str(&s),
-                &"a version matching the OAS 3.1 schema pattern `^3\\.1\\.\\d+(-.+)?$`",
-            ))
+            Err(InvalidVersion(s))
         }
     }
 }
@@ -977,6 +1041,34 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Version::default()).unwrap(),
             r#""3.1.2""#,
+        );
+    }
+
+    #[test]
+    fn test_version_parse_programmatically() {
+        use std::str::FromStr;
+        assert_eq!(
+            Version::from_str("3.1.99").unwrap(),
+            Version("3.1.99".to_owned())
+        );
+        assert_eq!(
+            Version::from_str("3.1.0-rc1").unwrap(),
+            Version("3.1.0-rc1".to_owned())
+        );
+        assert_eq!(Version::from_str("3.1").unwrap(), Version::V3_1_2());
+        assert_eq!(
+            <Version as TryFrom<&str>>::try_from("3.1.7").unwrap(),
+            Version("3.1.7".to_owned())
+        );
+        assert_eq!(
+            <Version as TryFrom<String>>::try_from("3.1.7".to_owned()).unwrap(),
+            Version("3.1.7".to_owned())
+        );
+        let err = Version::from_str("foo").unwrap_err();
+        assert_eq!(err, InvalidVersion("foo".to_owned()));
+        assert!(
+            err.to_string().contains("3\\.1\\.\\d+(-.+)?$"),
+            "error message echoes the schema regex: {err}"
         );
     }
 

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -1079,6 +1079,44 @@ mod tests {
     }
 
     #[test]
+    fn test_version_validate_rejects_invalid() {
+        let invalid = Version("garbage".to_owned());
+        let err = invalid.validate(Options::new()).unwrap_err();
+        assert_eq!(err.errors.len(), 1);
+        assert!(
+            err.errors[0].contains("#.openapi") && err.errors[0].contains("3\\.1\\.\\d+(-.+)?$"),
+            "validate error names the field and the schema regex: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_spec_validate_surfaces_invalid_openapi() {
+        let mut spec = Spec {
+            openapi: Version("3.5.0".to_owned()),
+            ..Default::default()
+        };
+        spec.info.title = "test".to_owned();
+        spec.info.version = "1".to_owned();
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("#.openapi") && e.contains("3\\.1\\.\\d+(-.+)?$")),
+            "Spec::validate surfaces the openapi error: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_version_try_from_string_normalizes_short_alias() {
+        let v: Version = "3.1".to_owned().try_into().unwrap();
+        assert_eq!(v, Version::V3_1_2());
+        let err: InvalidVersion = Version::try_from("nope".to_owned()).unwrap_err();
+        assert_eq!(err.0, "nope");
+    }
+
+    #[test]
     fn test_version_parse_programmatically() {
         use std::str::FromStr;
         assert_eq!(

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -437,6 +437,20 @@ impl TryFrom<String> for Version {
     }
 }
 
+impl Validate for Version {
+    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
+        // Constructors and parsers all enforce the pattern, but
+        // re-checking here keeps `Validate` a self-contained contract.
+        if matches_oas_3_1_version(&self.0) {
+            Ok(())
+        } else {
+            Err(Error {
+                errors: vec![format!("#.openapi: must be {VERSION_SCHEMA_DESCRIPTION}")],
+            })
+        }
+    }
+}
+
 impl Spec {
     /// Insert a schema under `#/components/schemas/{name}` and return a `$ref` pointing to it.
     /// Replaces any existing entry with the same name.
@@ -782,6 +796,12 @@ impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
 
+        // Surface any `openapi` schema-pattern violations alongside the
+        // rest of the spec's errors instead of bailing out early.
+        if let Err(e) = self.openapi.validate(options) {
+            ctx.errors.extend(e.errors);
+        }
+
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
 
@@ -1041,6 +1061,20 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Version::default()).unwrap(),
             r#""3.1.2""#,
+        );
+    }
+
+    #[test]
+    fn test_version_validate() {
+        assert!(Version::default().validate(Options::new()).is_ok());
+        assert!(Version::V3_1_0().validate(Options::new()).is_ok());
+        assert!(Version::V3_1_2().validate(Options::new()).is_ok());
+        assert!(
+            "3.1.99"
+                .parse::<Version>()
+                .unwrap()
+                .validate(Options::new())
+                .is_ok()
         );
     }
 

--- a/src/v3_2/spec.rs
+++ b/src/v3_2/spec.rs
@@ -413,6 +413,20 @@ impl TryFrom<String> for Version {
     }
 }
 
+impl Validate for Version {
+    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
+        // Constructors and parsers all enforce the pattern, but
+        // re-checking here keeps `Validate` a self-contained contract.
+        if matches_oas_3_2_version(&self.0) {
+            Ok(())
+        } else {
+            Err(Error {
+                errors: vec![format!("#.openapi: must be {VERSION_SCHEMA_DESCRIPTION}")],
+            })
+        }
+    }
+}
+
 impl Spec {
     /// Insert a schema under `#/components/schemas/{name}` and return a `$ref` pointing to it.
     /// Replaces any existing entry with the same name.
@@ -788,6 +802,12 @@ impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
 
+        // Surface any `openapi` schema-pattern violations alongside the
+        // rest of the spec's errors instead of bailing out early.
+        if let Err(e) = self.openapi.validate(options) {
+            ctx.errors.extend(e.errors);
+        }
+
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
 
@@ -1044,6 +1064,19 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Version::default()).unwrap(),
             r#""3.2.0""#,
+        );
+    }
+
+    #[test]
+    fn test_version_validate() {
+        assert!(Version::default().validate(Options::new()).is_ok());
+        assert!(Version::V3_2_0().validate(Options::new()).is_ok());
+        assert!(
+            "3.2.99"
+                .parse::<Version>()
+                .unwrap()
+                .validate(Options::new())
+                .is_ok()
         );
     }
 

--- a/src/v3_2/spec.rs
+++ b/src/v3_2/spec.rs
@@ -1081,6 +1081,44 @@ mod tests {
     }
 
     #[test]
+    fn test_version_validate_rejects_invalid() {
+        let invalid = Version("garbage".to_owned());
+        let err = invalid.validate(Options::new()).unwrap_err();
+        assert_eq!(err.errors.len(), 1);
+        assert!(
+            err.errors[0].contains("#.openapi") && err.errors[0].contains("3.2.<patch>"),
+            "validate error names the field and the schema description: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_spec_validate_surfaces_invalid_openapi() {
+        let mut spec = Spec {
+            openapi: Version("3.5.0".to_owned()),
+            ..Default::default()
+        };
+        spec.info.title = "test".to_owned();
+        spec.info.version = "1".to_owned();
+        let err = spec.validate(Options::new()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("#.openapi") && e.contains("3.2.<patch>")),
+            "Spec::validate surfaces the openapi error: {:?}",
+            err.errors
+        );
+    }
+
+    #[test]
+    fn test_version_try_from_string_normalizes_short_alias() {
+        let v: Version = "3.2".to_owned().try_into().unwrap();
+        assert_eq!(v, Version::V3_2_0());
+        let err: InvalidVersion = Version::try_from("nope".to_owned()).unwrap_err();
+        assert_eq!(err.0, "nope");
+    }
+
+    #[test]
     fn test_version_parse_programmatically() {
         use std::str::FromStr;
         assert_eq!(

--- a/src/v3_2/spec.rs
+++ b/src/v3_2/spec.rs
@@ -331,22 +331,84 @@ impl serde::Serialize for Version {
     }
 }
 
+/// Human-readable description of the OAS 3.2 version pattern, shared
+/// by serde's `expected` payload and `InvalidVersion`'s `Display`.
+/// The literal regex itself lives in [`matches_oas_3_2_version`] —
+/// keep both in sync if either ever changes.
+const VERSION_SCHEMA_DESCRIPTION: &str =
+    "`3.2.<patch>` semver, optionally with a `-<prerelease>` suffix";
+
+/// Single source of truth for the regex check. `lazy_regex::regex!`
+/// requires a string literal so we can't host the pattern in a `const`,
+/// but every parsing path goes through this one function.
+fn matches_oas_3_2_version(s: &str) -> bool {
+    lazy_regex::regex!(r"^3\.2\.\d+(-.+)?$").is_match(s)
+}
+
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(de)?;
-        // Per the spec pattern: `3.2.<digits>` optionally followed by
-        // `-<anything>` for prerelease. Also accept the short alias `3.2`.
+        // Delegate to `TryFrom<String>` so the owned `s` from serde
+        // moves straight into `Version(s)` on success (no `to_owned`
+        // round-trip). On failure, the offending string travels back
+        // through `InvalidVersion` and is borrowed once for the serde
+        // error message.
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &VERSION_SCHEMA_DESCRIPTION,
+            )
+        })
+    }
+}
+
+/// Returned by `Version::from_str` / `TryFrom<&str>` when the input
+/// does not match the OAS 3.2 schema pattern (see [`Version`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidVersion(pub String);
+
+impl fmt::Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "version {:?} must be {VERSION_SCHEMA_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == "3.2" {
             return Ok(Version("3.2.0".to_owned()));
         }
-        let re = lazy_regex::regex!(r"^3\.2\.\d+(-.+)?$");
-        if re.is_match(&s) {
+        if matches_oas_3_2_version(s) {
+            Ok(Version(s.to_owned()))
+        } else {
+            Err(InvalidVersion(s.to_owned()))
+        }
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if s == "3.2" {
+            return Ok(Version("3.2.0".to_owned()));
+        }
+        if matches_oas_3_2_version(&s) {
             Ok(Version(s))
         } else {
-            Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Str(&s),
-                &"`3.2.<patch>` semver, optionally with a `-<prerelease>` suffix",
-            ))
+            Err(InvalidVersion(s))
         }
     }
 }
@@ -982,6 +1044,34 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Version::default()).unwrap(),
             r#""3.2.0""#,
+        );
+    }
+
+    #[test]
+    fn test_version_parse_programmatically() {
+        use std::str::FromStr;
+        assert_eq!(
+            Version::from_str("3.2.99").unwrap(),
+            Version("3.2.99".to_owned())
+        );
+        assert_eq!(
+            Version::from_str("3.2.0-rc1").unwrap(),
+            Version("3.2.0-rc1".to_owned())
+        );
+        assert_eq!(Version::from_str("3.2").unwrap(), Version::V3_2_0());
+        assert_eq!(
+            <Version as TryFrom<&str>>::try_from("3.2.7").unwrap(),
+            Version("3.2.7".to_owned())
+        );
+        assert_eq!(
+            <Version as TryFrom<String>>::try_from("3.2.7".to_owned()).unwrap(),
+            Version("3.2.7".to_owned())
+        );
+        let err = Version::from_str("foo").unwrap_err();
+        assert_eq!(err, InvalidVersion("foo".to_owned()));
+        assert!(
+            err.to_string().contains("3.2.<patch>"),
+            "error message describes the schema: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary
- `v3_0::Version` now mirrors `v3_1::Version`: a tuple struct with custom `Deserialize` matching `^3\.0\.\d+(-.+)?

. The bare `3.0` short alias is preserved (normalised to `3.0.4`). Constructors `V3_0_0()` … `V3_0_4()` replace the old enum variants.
- `v2::Version` is also a tuple struct, but its custom `Deserialize` only accepts the literal `"2.0"` per the Swagger 2.0 spec ("The value MUST be \"2.0\""). One constructor: `V2_0()`.
- API impact: call sites that named enum variants (`Version::V3_0_4`, `Version::V2_0`) need to call them as constructors (`Version::V3_0_4()`, `Version::V2_0()`).