### PR TITLE
v3_1/v3_2: add Schema::Empty for the literal {} schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 description = "Rust OpenAPI Specification"

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -28,7 +28,49 @@ pub enum Schema {
     OneOf(Box<OneOfSchema>),
     Not(Box<NotSchema>),
     Multi(Box<MultiSchema>),
+    /// The literal empty schema `{}`. Per JSON Schema 2020-12 this is
+    /// semantically equivalent to `true` ("matches anything") but
+    /// preserves the `{}` JSON representation.
+    ///
+    /// Must come before [`Schema::Single`]: `SingleSchema::Object`
+    /// uses `MustBe!("object")` with a `default`, so the typed
+    /// variant happily matches a bare `{}`. Putting `Empty` first
+    /// captures the empty-object idiom while leaving anything with at
+    /// least one field (even just `description`) to fall through to
+    /// `Single::Object`.
+    Empty(EmptySchema),
     Single(Box<SingleSchema>), // must be last
+}
+
+/// Marker for the empty schema `{}`. Round-trips to `{}` and rejects
+/// any non-empty object on deserialization, so a schema with even one
+/// field stays a typed `Single` / composition variant.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct EmptySchema;
+
+impl Serialize for EmptySchema {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        let map: BTreeMap<String, ()> = BTreeMap::new();
+        map.serialize(ser)
+    }
+}
+
+impl<'de> Deserialize<'de> for EmptySchema {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let map: BTreeMap<String, serde::de::IgnoredAny> = BTreeMap::deserialize(de)?;
+        if !map.is_empty() {
+            return Err(serde::de::Error::custom(
+                "expected empty schema object `{}`",
+            ));
+        }
+        Ok(EmptySchema)
+    }
+}
+
+impl From<EmptySchema> for Schema {
+    fn from(s: EmptySchema) -> Self {
+        Schema::Empty(s)
+    }
 }
 
 impl From<bool> for Schema {
@@ -1103,6 +1145,8 @@ impl ValidateWithContext<Spec> for Schema {
         match self {
             // A boolean schema (true / false) has no fields to validate.
             Schema::Bool(_) => {}
+            // The empty schema `{}` is the unconstrained schema — nothing to validate.
+            Schema::Empty(_) => {}
             Schema::Single(s) => s.validate_with_context(ctx, path),
             Schema::Multi(s) => s.validate_with_context(ctx, path),
             Schema::AllOf(s) => {
@@ -1542,11 +1586,13 @@ mod tests {
             _ => panic!("expected Schema::Single, got {parsed:?}"),
         }
 
+        // A literal `{}` now matches `Schema::Empty` — see the
+        // `empty_schema_*` tests below for full coverage. Anything
+        // with at least one field (even without `type`) still
+        // dispatches to `Single::Object` because that variant has a
+        // default `schema_type`.
         let parsed: Schema = serde_json::from_value(serde_json::json!({})).expect("must parse");
-        assert!(matches!(
-            parsed,
-            Schema::Single(ref s) if matches!(s.as_ref(), SingleSchema::Object(_))
-        ));
+        assert_eq!(parsed, Schema::Empty(EmptySchema));
     }
 
     #[test]
@@ -2399,5 +2445,69 @@ mod tests {
             "enum descriptions length: {:?}",
             ctx.errors
         );
+    }
+
+    #[test]
+    fn empty_schema_round_trips_as_literal_empty_object() {
+        let json = serde_json::json!({});
+        let schema: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(schema, Schema::Empty(EmptySchema));
+        assert_eq!(serde_json::to_value(&schema).unwrap(), json);
+    }
+
+    #[test]
+    fn schema_with_only_description_remains_object() {
+        // Anything beyond a literal `{}` (even a `description` with no
+        // `type`) falls through to the typed `Single::Object` variant
+        // — `{type: "object"}` is the canonical re-serialised form.
+        let json = serde_json::json!({"description": "just metadata"});
+        let schema: Schema = serde_json::from_value(json).unwrap();
+        match &schema {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Object(o) => {
+                    assert_eq!(o.description.as_deref(), Some("just metadata"));
+                }
+                other => panic!("expected ObjectSchema, got {other}"),
+            },
+            other => panic!("expected Single, got {other:?}"),
+        }
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value["type"], "object");
+        assert_eq!(value["description"], "just metadata");
+    }
+
+    #[test]
+    fn explicit_object_schema_still_picks_object_variant() {
+        let json = serde_json::json!({"type": "object", "title": "T"});
+        let schema: Schema = serde_json::from_value(json.clone()).unwrap();
+        let Schema::Single(s) = &schema else {
+            panic!("expected Single, got {schema:?}");
+        };
+        let SingleSchema::Object(_) = s.as_ref() else {
+            panic!("expected ObjectSchema, got {s}");
+        };
+        assert_eq!(serde_json::to_value(&schema).unwrap(), json);
+    }
+
+    #[test]
+    fn empty_schema_validates_clean() {
+        let schema = Schema::Empty(EmptySchema);
+        let spec = crate::v3_1::spec::Spec::default();
+        let mut ctx =
+            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        schema.validate_with_context(&mut ctx, "s".into());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn empty_schema_distinct_from_bool_true() {
+        // Both are semantically "matches anything" but the JSON
+        // representation is what users author, so they round-trip
+        // distinctly.
+        let bool_schema: Schema = serde_json::from_value(serde_json::json!(true)).unwrap();
+        let empty_schema: Schema = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(bool_schema, Schema::Bool(true));
+        assert_eq!(empty_schema, Schema::Empty(EmptySchema));
+        assert_ne!(bool_schema, empty_schema);
     }
 }

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -57,13 +57,30 @@ impl Serialize for EmptySchema {
 
 impl<'de> Deserialize<'de> for EmptySchema {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let map: BTreeMap<String, serde::de::IgnoredAny> = BTreeMap::deserialize(de)?;
-        if !map.is_empty() {
-            return Err(serde::de::Error::custom(
-                "expected empty schema object `{}`",
-            ));
+        // Use a `MapAccess` visitor that peeks the first key instead
+        // of buffering the whole object into a `BTreeMap` only to
+        // check `is_empty()` — same constraint, zero allocation.
+        struct EmptyVisitor;
+        impl<'de> serde::de::Visitor<'de> for EmptyVisitor {
+            type Value = EmptySchema;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("empty schema object `{}`")
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> Result<EmptySchema, M::Error> {
+                if map.next_key::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "expected empty schema object `{}`",
+                    ));
+                }
+                Ok(EmptySchema)
+            }
         }
-        Ok(EmptySchema)
+        de.deserialize_map(EmptyVisitor)
     }
 }
 

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -2533,6 +2533,23 @@ mod tests {
     }
 
     #[test]
+    fn schema_from_empty_schema_dispatches_to_empty_variant() {
+        // `impl From<EmptySchema> for Schema` is the constructor
+        // path used when callers want to build `Schema::Empty`
+        // without naming the variant directly. Make sure the impl
+        // exists and produces the right variant.
+        let schema: Schema = EmptySchema.into();
+        assert_eq!(schema, Schema::Empty(EmptySchema));
+        let schema: Schema = Schema::from(EmptySchema);
+        assert_eq!(schema, Schema::Empty(EmptySchema));
+        // Round-trips back to `{}` through `Schema`'s untagged enum.
+        assert_eq!(
+            serde_json::to_value(&schema).unwrap(),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
     fn empty_schema_round_trip_via_string_is_stable() {
         let original = EmptySchema;
         let encoded = serde_json::to_string(&original).unwrap();

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -2448,6 +2448,84 @@ mod tests {
     }
 
     #[test]
+    fn empty_schema_default_is_unit_value() {
+        // `EmptySchema` is a unit-like marker; `default()` must
+        // produce the same singular value every time. Use the trait
+        // path so the test still exercises the `Default` impl
+        // (clippy flags `EmptySchema::default()` as redundant on a
+        // unit struct, but we want to pin down the impl exists).
+        assert_eq!(EmptySchema, <EmptySchema as Default>::default());
+    }
+
+    #[test]
+    fn empty_schema_serializes_as_empty_object() {
+        // The on-the-wire form is the literal JSON `{}`. Use a string
+        // round-trip so we observe exactly what serde writes (rather
+        // than going through `Value` which loses ordering / duplicate
+        // info).
+        let s = serde_json::to_string(&EmptySchema).unwrap();
+        assert_eq!(s, "{}");
+        // `to_value` agrees and produces an empty object (not null,
+        // not array).
+        let v = serde_json::to_value(EmptySchema).unwrap();
+        assert!(v.is_object());
+        assert!(v.as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_schema_deserializes_from_empty_object() {
+        let from_str: EmptySchema = serde_json::from_str("{}").unwrap();
+        assert_eq!(from_str, EmptySchema);
+        let from_value: EmptySchema = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(from_value, EmptySchema);
+    }
+
+    #[test]
+    fn empty_schema_rejects_populated_object() {
+        // Any populated object is rejected — that's the whole point.
+        // The error message names the expected shape.
+        let err = serde_json::from_value::<EmptySchema>(serde_json::json!({"k": 1}))
+            .expect_err("populated object must reject");
+        assert!(
+            err.to_string().contains("expected empty schema object"),
+            "error must explain the constraint: {err}"
+        );
+        // Even a single key with a null value still counts as
+        // populated.
+        let err = serde_json::from_value::<EmptySchema>(serde_json::json!({"x": null}))
+            .expect_err("single null entry must reject");
+        assert!(err.to_string().contains("expected empty schema object"));
+    }
+
+    #[test]
+    fn empty_schema_rejects_non_object_shapes() {
+        // Anything other than a JSON object is a hard parse error.
+        for value in [
+            serde_json::json!(null),
+            serde_json::json!(true),
+            serde_json::json!(false),
+            serde_json::json!(0),
+            serde_json::json!("{}"),
+            serde_json::json!([]),
+        ] {
+            assert!(
+                serde_json::from_value::<EmptySchema>(value.clone()).is_err(),
+                "{value} must not deserialize as EmptySchema",
+            );
+        }
+    }
+
+    #[test]
+    fn empty_schema_round_trip_via_string_is_stable() {
+        let original = EmptySchema;
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: EmptySchema = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(original, decoded);
+        // Re-encoding produces the same bytes.
+        assert_eq!(serde_json::to_string(&decoded).unwrap(), encoded);
+    }
+
+    #[test]
     fn empty_schema_round_trips_as_literal_empty_object() {
         let json = serde_json::json!({});
         let schema: Schema = serde_json::from_value(json.clone()).unwrap();

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -50,8 +50,8 @@ pub struct EmptySchema;
 
 impl Serialize for EmptySchema {
     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        let map: BTreeMap<String, ()> = BTreeMap::new();
-        map.serialize(ser)
+        use serde::ser::SerializeMap;
+        ser.serialize_map(Some(0))?.end()
     }
 }
 

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -26,7 +26,49 @@ pub enum Schema {
     OneOf(Box<OneOfSchema>),
     Not(Box<NotSchema>),
     Multi(Box<MultiSchema>),
+    /// The literal empty schema `{}`. Per JSON Schema 2020-12 this is
+    /// semantically equivalent to `true` ("matches anything") but
+    /// preserves the `{}` JSON representation.
+    ///
+    /// Must come before [`Schema::Single`]: `SingleSchema::Object`
+    /// uses `MustBe!("object")` with a `default`, so the typed
+    /// variant happily matches a bare `{}`. Putting `Empty` first
+    /// captures the empty-object idiom while leaving anything with at
+    /// least one field (even just `description`) to fall through to
+    /// `Single::Object`.
+    Empty(EmptySchema),
     Single(Box<SingleSchema>), // must be last
+}
+
+/// Marker for the empty schema `{}`. Round-trips to `{}` and rejects
+/// any non-empty object on deserialization, so a schema with even one
+/// field stays a typed `Single` / composition variant.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct EmptySchema;
+
+impl Serialize for EmptySchema {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        let map: BTreeMap<String, ()> = BTreeMap::new();
+        map.serialize(ser)
+    }
+}
+
+impl<'de> Deserialize<'de> for EmptySchema {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let map: BTreeMap<String, serde::de::IgnoredAny> = BTreeMap::deserialize(de)?;
+        if !map.is_empty() {
+            return Err(serde::de::Error::custom(
+                "expected empty schema object `{}`",
+            ));
+        }
+        Ok(EmptySchema)
+    }
+}
+
+impl From<EmptySchema> for Schema {
+    fn from(s: EmptySchema) -> Self {
+        Schema::Empty(s)
+    }
 }
 
 impl From<bool> for Schema {
@@ -1076,6 +1118,8 @@ impl ValidateWithContext<Spec> for Schema {
         match self {
             // A boolean schema (true / false) has no fields to validate.
             Schema::Bool(_) => {}
+            // The empty schema `{}` is the unconstrained schema — nothing to validate.
+            Schema::Empty(_) => {}
             Schema::Single(s) => s.validate_with_context(ctx, path),
             Schema::Multi(s) => s.validate_with_context(ctx, path),
             Schema::AllOf(s) => {
@@ -1466,11 +1510,13 @@ mod tests {
             _ => panic!("expected Schema::Single, got {parsed:?}"),
         }
 
+        // A literal `{}` now matches `Schema::Empty` — see the
+        // `empty_schema_*` tests below for full coverage. Anything
+        // with at least one field (even without `type`) still
+        // dispatches to `Single::Object` because that variant has a
+        // default `schema_type`.
         let parsed: Schema = serde_json::from_value(serde_json::json!({})).expect("must parse");
-        assert!(matches!(
-            parsed,
-            Schema::Single(ref s) if matches!(s.as_ref(), SingleSchema::Object(_))
-        ));
+        assert_eq!(parsed, Schema::Empty(EmptySchema));
     }
 
     #[test]
@@ -2310,5 +2356,63 @@ mod tests {
             crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn empty_schema_round_trips_as_literal_empty_object() {
+        let json = serde_json::json!({});
+        let schema: Schema = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(schema, Schema::Empty(EmptySchema));
+        assert_eq!(serde_json::to_value(&schema).unwrap(), json);
+    }
+
+    #[test]
+    fn schema_with_only_description_remains_object() {
+        let json = serde_json::json!({"description": "just metadata"});
+        let schema: Schema = serde_json::from_value(json).unwrap();
+        match &schema {
+            Schema::Single(s) => match s.as_ref() {
+                SingleSchema::Object(o) => {
+                    assert_eq!(o.description.as_deref(), Some("just metadata"));
+                }
+                other => panic!("expected ObjectSchema, got {other}"),
+            },
+            other => panic!("expected Single, got {other:?}"),
+        }
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value["type"], "object");
+        assert_eq!(value["description"], "just metadata");
+    }
+
+    #[test]
+    fn explicit_object_schema_still_picks_object_variant() {
+        let json = serde_json::json!({"type": "object", "title": "T"});
+        let schema: Schema = serde_json::from_value(json.clone()).unwrap();
+        let Schema::Single(s) = &schema else {
+            panic!("expected Single, got {schema:?}");
+        };
+        let SingleSchema::Object(_) = s.as_ref() else {
+            panic!("expected ObjectSchema, got {s}");
+        };
+        assert_eq!(serde_json::to_value(&schema).unwrap(), json);
+    }
+
+    #[test]
+    fn empty_schema_validates_clean() {
+        let schema = Schema::Empty(EmptySchema);
+        let spec = crate::v3_2::spec::Spec::default();
+        let mut ctx =
+            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        schema.validate_with_context(&mut ctx, "s".into());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn empty_schema_distinct_from_bool_true() {
+        let bool_schema: Schema = serde_json::from_value(serde_json::json!(true)).unwrap();
+        let empty_schema: Schema = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(bool_schema, Schema::Bool(true));
+        assert_eq!(empty_schema, Schema::Empty(EmptySchema));
+        assert_ne!(bool_schema, empty_schema);
     }
 }

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -55,13 +55,30 @@ impl Serialize for EmptySchema {
 
 impl<'de> Deserialize<'de> for EmptySchema {
     fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let map: BTreeMap<String, serde::de::IgnoredAny> = BTreeMap::deserialize(de)?;
-        if !map.is_empty() {
-            return Err(serde::de::Error::custom(
-                "expected empty schema object `{}`",
-            ));
+        // Use a `MapAccess` visitor that peeks the first key instead
+        // of buffering the whole object into a `BTreeMap` only to
+        // check `is_empty()` — same constraint, zero allocation.
+        struct EmptyVisitor;
+        impl<'de> serde::de::Visitor<'de> for EmptyVisitor {
+            type Value = EmptySchema;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("empty schema object `{}`")
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> Result<EmptySchema, M::Error> {
+                if map.next_key::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "expected empty schema object `{}`",
+                    ));
+                }
+                Ok(EmptySchema)
+            }
         }
-        Ok(EmptySchema)
+        de.deserialize_map(EmptyVisitor)
     }
 }
 

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -2359,6 +2359,70 @@ mod tests {
     }
 
     #[test]
+    fn empty_schema_default_is_unit_value() {
+        // Trait-path call so clippy doesn't flag the redundant
+        // `::default()` on a unit struct while we still exercise the
+        // `Default` impl.
+        assert_eq!(EmptySchema, <EmptySchema as Default>::default());
+    }
+
+    #[test]
+    fn empty_schema_serializes_as_empty_object() {
+        let s = serde_json::to_string(&EmptySchema).unwrap();
+        assert_eq!(s, "{}");
+        let v = serde_json::to_value(EmptySchema).unwrap();
+        assert!(v.is_object());
+        assert!(v.as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_schema_deserializes_from_empty_object() {
+        let from_str: EmptySchema = serde_json::from_str("{}").unwrap();
+        assert_eq!(from_str, EmptySchema);
+        let from_value: EmptySchema = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(from_value, EmptySchema);
+    }
+
+    #[test]
+    fn empty_schema_rejects_populated_object() {
+        let err = serde_json::from_value::<EmptySchema>(serde_json::json!({"k": 1}))
+            .expect_err("populated object must reject");
+        assert!(
+            err.to_string().contains("expected empty schema object"),
+            "error must explain the constraint: {err}"
+        );
+        let err = serde_json::from_value::<EmptySchema>(serde_json::json!({"x": null}))
+            .expect_err("single null entry must reject");
+        assert!(err.to_string().contains("expected empty schema object"));
+    }
+
+    #[test]
+    fn empty_schema_rejects_non_object_shapes() {
+        for value in [
+            serde_json::json!(null),
+            serde_json::json!(true),
+            serde_json::json!(false),
+            serde_json::json!(0),
+            serde_json::json!("{}"),
+            serde_json::json!([]),
+        ] {
+            assert!(
+                serde_json::from_value::<EmptySchema>(value.clone()).is_err(),
+                "{value} must not deserialize as EmptySchema",
+            );
+        }
+    }
+
+    #[test]
+    fn empty_schema_round_trip_via_string_is_stable() {
+        let original = EmptySchema;
+        let encoded = serde_json::to_string(&original).unwrap();
+        let decoded: EmptySchema = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(original, decoded);
+        assert_eq!(serde_json::to_string(&decoded).unwrap(), encoded);
+    }
+
+    #[test]
     fn empty_schema_round_trips_as_literal_empty_object() {
         let json = serde_json::json!({});
         let schema: Schema = serde_json::from_value(json.clone()).unwrap();

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -2431,6 +2431,18 @@ mod tests {
     }
 
     #[test]
+    fn schema_from_empty_schema_dispatches_to_empty_variant() {
+        let schema: Schema = EmptySchema.into();
+        assert_eq!(schema, Schema::Empty(EmptySchema));
+        let schema: Schema = Schema::from(EmptySchema);
+        assert_eq!(schema, Schema::Empty(EmptySchema));
+        assert_eq!(
+            serde_json::to_value(&schema).unwrap(),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
     fn empty_schema_round_trip_via_string_is_stable() {
         let original = EmptySchema;
         let encoded = serde_json::to_string(&original).unwrap();

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -48,8 +48,8 @@ pub struct EmptySchema;
 
 impl Serialize for EmptySchema {
     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        let map: BTreeMap<String, ()> = BTreeMap::new();
-        map.serialize(ser)
+        use serde::ser::SerializeMap;
+        ser.serialize_map(Some(0))?.end()
     }
 }
 


### PR DESCRIPTION
## Summary
Add a new `EmptySchema` marker plus a `Schema::Empty(EmptySchema)` variant to both `v3_1::schema::Schema` and `v3_2::schema::Schema`. The variant slots in just before `Single` in the untagged enum, so:

- A literal `{}` now matches `Empty` first (instead of being normalised to `{type: "object"}` via `ObjectSchema::default()`). Round-trips byte-for-byte.
- Anything with at least one field still falls through. A schema with only `description` and no `type` continues to deserialise as `Single::Object` because that variant's `schema_type: MustBe!("object")` has a `default`. Re-serialising re-adds the explicit `type: object`, matching prior behaviour.
- `{}` is now distinct from `Schema::Bool(true)`. Both are semantically "matches anything" but users author one or the other, so they round-trip distinctly.

`EmptySchema`'s custom `Deserialize` requires a literal empty object and rejects any populated map, so the variant ordering can't be wrong. `Validate` for `Schema::Empty` is a no-op (an unconstrained schema has nothing to check).

This unblocks the `from_v3_0` octet-stream rewrite to emit `{}` (the form the official upgrade guide recommends) instead of `Schema::Bool(true)`. That follow-up will land on PR #116 once this PR is merged.

API impact: this is a breaking change to the public `Schema` enum surface (new variant added). Bump 0.9.0 → 0.10.0. The pre-existing `schema_without_type_parses_as_object` test that previously asserted `Single::Object` for `{}` now asserts `Empty` — the test name and intent (anything with at least one field stays `Object`) are preserved.

Six new tests per module pin down the new dispatch: empty round-trip, description-only stays `Object`, explicit `Object` stays `Object`, `Empty` validates clean, and `Empty` distinct from `Bool(true)`. 733 tests pass.