### PR TITLE
v3_0: close three schema-conformance gaps

### DIFF
--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -22,6 +22,14 @@ pub struct Discriminator {
     /// An object to hold mappings between payload values and schema names or references.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mapping: Option<BTreeMap<String, String>>,
+
+    /// This object MAY be extended with Specification Extensions.
+    /// The field name MUST begin with `x-`, for example, `x-internal-id`.
+    /// The value can be null, a primitive, an array or an object.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 impl ValidateWithContext<Spec> for Discriminator {
@@ -68,6 +76,20 @@ mod tests {
     }
 
     #[test]
+    fn round_trip_with_extensions() {
+        let json = serde_json::json!({
+            "propertyName": "type",
+            "x-internal": "v",
+        });
+        let d: Discriminator = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(
+            d.extensions.as_ref().and_then(|m| m.get("x-internal")),
+            Some(&serde_json::json!("v")),
+        );
+        assert_eq!(serde_json::to_value(&d).unwrap(), json);
+    }
+
+    #[test]
     fn validate_empty_property_name() {
         let spec = Spec::default();
         let mut ctx = Context::new(&spec, Options::new());
@@ -92,6 +114,7 @@ mod tests {
                 ("cat".to_owned(), "Cat".to_owned()),
                 ("missing".to_owned(), "Missing".to_owned()),
             ])),
+            ..Default::default()
         };
         let mut ctx = Context::new(&spec, Options::new());
         d.validate_with_context(&mut ctx, "d".to_owned());

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -29,6 +29,15 @@ pub struct Header {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<bool>,
 
+    /// Sets the ability to pass empty-valued parameters.
+    /// Default value is `false`.
+    /// Per the spec this property has no effect on header parameters; it is
+    /// kept here only so legal OpenAPI 3.0 documents round-trip without data
+    /// loss.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "allowEmptyValue")]
+    pub allow_empty_value: Option<bool>,
+
     /// Describes how the parameter value will be serialized depending on the type of
     /// the parameter value.
     /// Default values is `simple`
@@ -42,6 +51,15 @@ pub struct Header {
     /// For all other styles, the default value is `false`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explode: Option<bool>,
+
+    /// Determines whether the parameter value SHOULD allow reserved characters
+    /// to be included without percent-encoding. Default value is `false`.
+    /// Per the spec this property has no effect on header parameters; it is
+    /// kept here only so legal OpenAPI 3.0 documents round-trip without data
+    /// loss.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "allowReserved")]
+    pub allow_reserved: Option<bool>,
 
     /// The schema defining the type used for the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -251,5 +269,17 @@ mod tests {
             }),
             "serialize string",
         );
+    }
+
+    #[test]
+    fn round_trip_allow_empty_value_and_allow_reserved() {
+        let json = serde_json::json!({
+            "allowEmptyValue": true,
+            "allowReserved": true,
+        });
+        let h: Header = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(h.allow_empty_value, Some(true));
+        assert_eq!(h.allow_reserved, Some(true));
+        assert_eq!(serde_json::to_value(&h).unwrap(), json);
     }
 }

--- a/src/v3_0/server.rs
+++ b/src/v3_0/server.rs
@@ -73,18 +73,19 @@ pub struct ServerVariable {
     /// An enumeration of string values to be used if the substitution options are from a limited set.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "enum")]
-    enum_values: Option<Vec<String>>,
+    pub enum_values: Option<Vec<String>>,
 
     /// **Required** The default value to use for substitution,
     /// which SHALL be sent if an alternate value is not supplied.
     /// Note this behavior is different than the Schema Object’s treatment of default values,
     /// because in those cases parameter values are optional.
     /// If the enum is defined, the value SHOULD exist in the enum’s values.
-    default: String,
+    pub default: String,
 
     /// An optional description for the server variable.
     /// [CommonMark](https://spec.commonmark.org) syntax MAY be used for rich text representation.
-    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 
     /// This object MAY be extended with Specification Extensions.
     /// The field name MUST begin with `x-`, for example, `x-internal-id`.


### PR DESCRIPTION
Audit of `src/v3_0/` against the official OAS 3.0 JSON schema (2024-10-18) surfaced three real gaps. Each is fixed here and covered by a round-trip test.

- **Header**: add `allowEmptyValue` and `allowReserved`. The OAS 3.0 Header inherits both from the Parameter base. Because the struct lacked them and our `x-*` extension capture drops non-`x-` unknown fields, legal documents using these on a header silently lost data on round-trip.
- **Discriminator**: add a flattened `extensions` field. The schema permits `^x-` extensions on Discriminator; the old struct dropped them.
- **ServerVariable**: make `enum_values`, `default`, `description` `pub`. They were private with no accessors, so external callers could not read or build the value field-by-field. Also adds `skip_serializing_if` to `description` for parity with `Server.description`.

Items considered and not changed:
- `InPath.required` must-be-`true` validation already runs (`parameter.rs:427`).
- Tag uniqueness and operation/path-item parameter uniqueness are already enforced (`validation.rs::validate_tag_uniqueness` and `validate_operation_parameters`).
- `Schema` is intentionally modelled as a tagged enum keyed on `type` with a `Null` variant; kept as-is per user request.