### PR TITLE
v2: enforce schema gaps surfaced by JSON-schema cross-check

### DIFF
--- a/src/common/formats.rs
+++ b/src/common/formats.rs
@@ -111,6 +111,14 @@ impl Display for CollectionFormat {
     }
 }
 
+impl CollectionFormat {
+    /// Returns `true` if this collection format is `multi`, which the OAS 2.0
+    /// schema allows only on `query` and `formData` parameters.
+    pub fn is_multi(&self) -> bool {
+        matches!(self, CollectionFormat::Multi)
+    }
+}
+
 impl Serialize for StringFormat {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(self.to_string().as_str())

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -247,6 +247,25 @@ pub fn validate_pattern<T>(pattern: &str, ctx: &mut Context<T>, path: String) {
     }
 }
 
+/// Validates that the items in `items` are unique by the key produced by `key`.
+/// Records an error for every duplicate (the *later* occurrence) with the index
+/// in the source slice. The first occurrence is not flagged.
+///
+/// Used to enforce `uniqueItems: true` on lists where the schema requires it
+/// (schemes, MIME type lists, tags by name, scope arrays, etc.).
+pub fn validate_unique_by<T, K, S, F>(items: &[T], ctx: &mut Context<S>, path: String, key: F)
+where
+    K: Eq + std::hash::Hash,
+    F: Fn(&T) -> K,
+{
+    let mut seen: HashSet<K> = HashSet::new();
+    for (i, item) in items.iter().enumerate() {
+        if !seen.insert(key(item)) {
+            ctx.error(format!("{path}[{i}]"), "duplicate value");
+        }
+    }
+}
+
 /// Validates that the given object has not been visited before,
 /// optionally ignoring the check based on the provided option.
 /// If the object has already been visited and the ignore option is not set, an error is recorded.

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
 use crate::v2::items::Items;
 use crate::v2::spec::Spec;
 
@@ -274,6 +274,16 @@ impl ValidateWithContext<Spec> for BooleanHeader {
 
 impl ValidateWithContext<Spec> for ArrayHeader {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // Headers always use the `collectionFormat` enum (csv/ssv/tsv/pipes).
+        // The `multi` variant is reserved for `query` / `formData` parameters.
+        if let Some(fmt) = &self.collection_format
+            && fmt.is_multi()
+        {
+            ctx.error(
+                format!("{path}.collectionFormat"),
+                "`multi` is only allowed on `query` and `formData` parameters",
+            );
+        }
         self.items
             .validate_with_context(ctx, format!("{path}.items"));
     }
@@ -578,6 +588,31 @@ mod tests {
                 "x-extra": "extension",
             }),
             "serialize array",
+        );
+    }
+
+    #[test]
+    fn array_header_rejects_multi_collection_format() {
+        // Headers may not use `collectionFormat: multi`.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        let header = Header::Array(ArrayHeader {
+            description: None,
+            items: Items::String(Box::default()),
+            default: None,
+            collection_format: Some(CollectionFormat::Multi),
+            max_items: None,
+            min_items: None,
+            unique_items: None,
+            extensions: None,
+        });
+        header.validate_with_context(&mut ctx, "h".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("`multi` is only allowed")),
+            "errors: {:?}",
+            ctx.errors
         );
     }
 }

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -1,7 +1,7 @@
 //! Item Object
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, ValidateWithContext, validate_pattern};
+use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
 use crate::v2::spec::Spec;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -288,6 +288,17 @@ impl ValidateWithContext<Spec> for BooleanItem {
 
 impl ValidateWithContext<Spec> for ArrayItem {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        // Per the OAS 2.0 schema, nested `items` use the `collectionFormat`
+        // enum (csv/ssv/tsv/pipes) — `multi` is reserved for top-level
+        // `query` / `formData` array parameters.
+        if let Some(fmt) = &self.collection_format
+            && fmt.is_multi()
+        {
+            ctx.error(
+                format!("{path}.collectionFormat"),
+                "`multi` is only allowed on `query` and `formData` parameters",
+            );
+        }
         self.items
             .validate_with_context(ctx, format!("{path}.items"));
     }
@@ -613,5 +624,44 @@ mod tests {
             }),
             "serialize",
         );
+    }
+
+    #[test]
+    fn array_item_rejects_multi_collection_format() {
+        // `multi` is reserved for top-level query/formData parameters; nested
+        // items must use csv/ssv/tsv/pipes only.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        let item = ArrayItem {
+            items: Items::String(Box::default()),
+            default: None,
+            collection_format: Some(CollectionFormat::Multi),
+            max_items: None,
+            min_items: None,
+            unique_items: None,
+            extensions: None,
+        };
+        item.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("`multi` is only allowed")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // csv stays valid.
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        let item = ArrayItem {
+            items: Items::String(Box::default()),
+            default: None,
+            collection_format: Some(CollectionFormat::CSV),
+            max_items: None,
+            min_items: None,
+            unique_items: None,
+            extensions: None,
+        };
+        item.validate_with_context(&mut ctx, "p".into());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
 }

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -1,6 +1,8 @@
 //! Operation Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::{
+    Context, PushError, ValidateWithContext, validate_required_string, validate_unique_by,
+};
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::parameter::Parameter;
 use crate::v2::reference::RefOr;
@@ -132,6 +134,23 @@ impl ValidateWithContext<Spec> for Operation {
                 path.clone(),
                 format_args!("operationId `{operation_id}` already exists"),
             );
+        }
+        // OAS 2.0 schema marks `tags`, `consumes`, `produces`, `schemes`, and
+        // `security` as `uniqueItems: true`.
+        if let Some(tags) = &self.tags {
+            validate_unique_by(tags, ctx, format!("{path}.tags"), |t| t.clone());
+        }
+        if let Some(consumes) = &self.consumes {
+            validate_unique_by(consumes, ctx, format!("{path}.consumes"), |s| s.clone());
+        }
+        if let Some(produces) = &self.produces {
+            validate_unique_by(produces, ctx, format!("{path}.produces"), |s| s.clone());
+        }
+        if let Some(schemes) = &self.schemes {
+            validate_unique_by(schemes, ctx, format!("{path}.schemes"), |s| s.clone());
+        }
+        if let Some(security) = &self.security {
+            validate_unique_by(security, ctx, format!("{path}.security"), |r| r.clone());
         }
         if let Some(tags) = &self.tags {
             for (i, tag) in tags.iter().enumerate() {
@@ -473,5 +492,44 @@ mod tests {
         let mut ctx = Context::new(&spec, Default::default());
         operation.validate_with_context(&mut ctx, "operation".to_owned());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn unique_items_enforced_on_operation_lists() {
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Default::default());
+        let mut req = BTreeMap::new();
+        req.insert("none".to_owned(), vec![]);
+        let op = Operation {
+            tags: Some(vec!["pet".into(), "pet".into()]),
+            consumes: Some(vec!["application/json".into(), "application/json".into()]),
+            produces: Some(vec!["text/plain".into(), "text/plain".into()]),
+            schemes: Some(vec![Scheme::HTTPS, Scheme::HTTPS]),
+            responses: Responses {
+                default: Some(RefOr::new_item(crate::v2::response::Response {
+                    description: "ok".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            security: Some(vec![req.clone(), req]),
+            ..Default::default()
+        };
+        op.validate_with_context(&mut ctx, "op".to_owned());
+        for field in [
+            "op.tags[1]",
+            "op.consumes[1]",
+            "op.produces[1]",
+            "op.schemes[1]",
+            "op.security[1]",
+        ] {
+            assert!(
+                ctx.errors
+                    .iter()
+                    .any(|e| e.contains(field) && e.contains("duplicate value")),
+                "missing dup error for {field}: {:?}",
+                ctx.errors
+            );
+        }
     }
 }

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -594,6 +594,7 @@ impl ValidateWithContext<Spec> for InPath {
                 must_not_allow_empty_value(&p.allow_empty_value, ctx, path.clone(), p.name.clone());
             }
             InPath::Array(p) => {
+                p.validate_with_context(ctx, path.clone());
                 must_be_required(&p.required, ctx, path.clone(), p.name.clone());
                 must_not_allow_empty_value(&p.allow_empty_value, ctx, path.clone(), p.name.clone());
                 must_not_use_multi_collection_format(&p.collection_format, ctx, path.clone());
@@ -654,6 +655,8 @@ impl ValidateWithContext<Spec> for BooleanParameter {
 impl ValidateWithContext<Spec> for ArrayParameter {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         validate_required_string(&self.name, ctx, format!("{path}.name"));
+        self.items
+            .validate_with_context(ctx, format!("{path}.items"));
     }
 }
 
@@ -704,7 +707,7 @@ fn must_not_use_multi_collection_format(
 mod tests {
     use super::*;
     use crate::common::helpers::Context;
-    use crate::v2::items::Items;
+    use crate::v2::items::{ArrayItem, Items, StringItem};
     use crate::v2::schema::{Schema, StringSchema};
     use crate::validation::Options;
     use serde_json::json;
@@ -1141,5 +1144,53 @@ mod tests {
                 c.errors
             );
         }
+    }
+
+    #[test]
+    fn array_parameter_validates_items() {
+        let p = Parameter::Query(Box::new(InQuery::Array(ArrayParameter {
+            name: "q".into(),
+            items: Items::String(Box::new(StringItem {
+                pattern: Some("[".into()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })));
+
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(
+            c.errors.iter().any(|e| e.contains("p.items.pattern")),
+            "errors: {:?}",
+            c.errors
+        );
+    }
+
+    #[test]
+    fn path_array_parameter_validates_items() {
+        let p = Parameter::Path(Box::new(InPath::Array(ArrayParameter {
+            name: "id".into(),
+            required: Some(true),
+            items: Items::Array(Box::new(ArrayItem {
+                items: Items::String(Box::default()),
+                default: None,
+                collection_format: Some(CollectionFormat::Multi),
+                max_items: None,
+                min_items: None,
+                unique_items: None,
+                extensions: None,
+            })),
+            ..Default::default()
+        })));
+
+        let mut c = ctx();
+        p.validate_with_context(&mut c, "p".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e.contains("p.items.collectionFormat")),
+            "errors: {:?}",
+            c.errors
+        );
     }
 }

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -2,7 +2,7 @@
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
 use crate::common::helpers::{
-    Context, ValidateWithContext, validate_pattern, validate_required_string,
+    Context, PushError, ValidateWithContext, validate_pattern, validate_required_string,
 };
 use crate::v2::items::Items;
 use crate::v2::reference::RefOr;
@@ -546,6 +546,7 @@ impl ValidateWithContext<Spec> for InHeader {
             InHeader::Array(p) => {
                 p.validate_with_context(ctx, path.clone());
                 must_not_allow_empty_value(&p.allow_empty_value, ctx, path.clone(), p.name.clone());
+                must_not_use_multi_collection_format(&p.collection_format, ctx, path.clone());
             }
         }
     }
@@ -595,6 +596,7 @@ impl ValidateWithContext<Spec> for InPath {
             InPath::Array(p) => {
                 must_be_required(&p.required, ctx, path.clone(), p.name.clone());
                 must_not_allow_empty_value(&p.allow_empty_value, ctx, path.clone(), p.name.clone());
+                must_not_use_multi_collection_format(&p.collection_format, ctx, path.clone());
             }
         }
     }
@@ -676,6 +678,25 @@ fn must_not_allow_empty_value(
     if p.is_some_and(|x| x) {
         ctx.errors
             .push(format!("{path}.{name}: must not allow empty value"));
+    }
+}
+
+/// Per the OAS 2.0 schema, `collectionFormat: "multi"` is allowed only on
+/// `query` and `formData` parameters. `header` and `path` parameters must
+/// use the `collectionFormat` enum (csv/ssv/tsv/pipes) — `multi` here is
+/// a spec violation.
+fn must_not_use_multi_collection_format(
+    format: &Option<CollectionFormat>,
+    ctx: &mut Context<Spec>,
+    path: String,
+) {
+    if let Some(fmt) = format
+        && fmt.is_multi()
+    {
+        ctx.error(
+            format!("{path}.collectionFormat"),
+            "`multi` is only allowed on `query` and `formData` parameters",
+        );
     }
 }
 
@@ -1065,5 +1086,60 @@ mod tests {
             _ => panic!("expected query parameter"),
         }
         assert_eq!(serde_json::to_value(&p).unwrap(), query);
+    }
+
+    #[test]
+    fn header_and_path_array_params_reject_multi_collection_format() {
+        // `multi` is allowed only for query/formData; header and path
+        // parameters must use the `collectionFormat` enum without `multi`.
+        for inner in [
+            Parameter::Header(Box::new(InHeader::Array(ArrayParameter {
+                name: "h".into(),
+                items: Items::String(Box::default()),
+                collection_format: Some(CollectionFormat::Multi),
+                ..Default::default()
+            }))),
+            Parameter::Path(Box::new(InPath::Array(ArrayParameter {
+                name: "id".into(),
+                required: Some(true),
+                items: Items::String(Box::default()),
+                collection_format: Some(CollectionFormat::Multi),
+                ..Default::default()
+            }))),
+        ] {
+            let mut c = ctx();
+            inner.validate_with_context(&mut c, "p".into());
+            assert!(
+                c.errors
+                    .iter()
+                    .any(|e| e.contains("`multi` is only allowed")),
+                "errors: {:?}",
+                c.errors
+            );
+        }
+
+        // Query and formData accept `multi`.
+        for inner in [
+            Parameter::Query(Box::new(InQuery::Array(ArrayParameter {
+                name: "q".into(),
+                items: Items::String(Box::default()),
+                collection_format: Some(CollectionFormat::Multi),
+                ..Default::default()
+            }))),
+            Parameter::FormData(Box::new(InFormData::Array(ArrayParameter {
+                name: "f".into(),
+                items: Items::String(Box::default()),
+                collection_format: Some(CollectionFormat::Multi),
+                ..Default::default()
+            }))),
+        ] {
+            let mut c = ctx();
+            inner.validate_with_context(&mut c, "p".into());
+            assert!(
+                c.errors.iter().all(|e| !e.contains("`multi`")),
+                "errors: {:?}",
+                c.errors
+            );
+        }
     }
 }

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -215,6 +215,17 @@ impl ValidateWithContext<Spec> for PathItem {
                 ctx,
                 format!("{path}.$ref"),
             );
+            // OAS 2.0: a Path Item with `$ref` replaces this object; mixing
+            // it with inline operations or parameters has undefined behavior.
+            let has_ops = self.operations.as_ref().is_some_and(|m| !m.is_empty());
+            let has_params = self.parameters.as_ref().is_some_and(|p| !p.is_empty());
+            if has_ops || has_params {
+                crate::common::helpers::PushError::error(
+                    ctx,
+                    format!("{path}.$ref"),
+                    "MUST NOT coexist with inline operations or parameters",
+                );
+            }
         }
 
         if let Some(other) = &self.operations {
@@ -795,6 +806,40 @@ mod tests {
         assert!(item.operations.is_none());
         let v = serde_json::to_value(&item).unwrap();
         assert_eq!(v, raw);
+    }
+
+    #[test]
+    fn path_item_ref_must_not_coexist_with_operations_or_parameters() {
+        let mut ops = BTreeMap::new();
+        ops.insert(
+            "get".to_owned(),
+            crate::v2::operation::Operation {
+                responses: Responses {
+                    default: Some(RefOr::new_item(Response {
+                        description: "ok".into(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let item = PathItem {
+            reference: Some("#/x".to_owned()),
+            operations: Some(ops),
+            parameters: None,
+            extensions: None,
+        };
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        item.validate_with_context(&mut ctx, "p".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("$ref") && e.contains("MUST NOT coexist")),
+            "errors: {:?}",
+            ctx.errors
+        );
     }
 
     #[test]

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -797,8 +797,10 @@ impl ValidateWithContext<Spec> for ArraySchema {
             xml.validate_with_context(ctx, format!("{path}.xml"));
         }
 
-        if let Some(items) = &self.items {
-            items.validate_with_context(ctx, format!("{path}.items"));
+        // Per OAS 2.0: when `type: array`, `items` MUST be present.
+        match &self.items {
+            Some(items) => items.validate_with_context(ctx, format!("{path}.items")),
+            None => ctx.error(path, ".items: is required for `type: array`"),
         }
     }
 }
@@ -831,6 +833,62 @@ impl ValidateWithContext<Spec> for ObjectSchema {
                 schema.validate_with_context(ctx, format!("{path}.allOf[{i}]"));
             }
         }
+
+        // OAS 2.0: when `discriminator` is set, it MUST name a property
+        // defined on this schema, and that property MUST appear in `required`.
+        if let Some(disc) = &self.discriminator {
+            let in_props = self
+                .properties
+                .as_ref()
+                .is_some_and(|p| p.contains_key(disc));
+            if !in_props {
+                ctx.error(
+                    format!("{path}.discriminator"),
+                    format_args!("`{disc}` must be a property defined on this schema"),
+                );
+            }
+            let in_required = self
+                .required
+                .as_ref()
+                .is_some_and(|r| r.iter().any(|n| n == disc));
+            if !in_required {
+                ctx.error(
+                    format!("{path}.discriminator"),
+                    format_args!("`{disc}` must be listed in `required`"),
+                );
+            }
+        }
+
+        // OAS 2.0 prose: properties marked `readOnly: true` SHOULD NOT appear
+        // in `required`. Flag the combination as a warning-level error.
+        if let (Some(props), Some(required)) = (&self.properties, &self.required) {
+            for name in required {
+                if let Some(RefOr::Item(schema)) = props.get(name)
+                    && is_schema_read_only(schema)
+                {
+                    ctx.error(
+                        format!("{path}.required"),
+                        format_args!("`{name}` is marked `readOnly` and SHOULD NOT be required"),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Returns `true` if the schema's `readOnly` flag is set. Used by
+/// `ObjectSchema::validate_with_context` to surface the SHOULD-NOT rule
+/// that read-only properties not appear in `required`.
+fn is_schema_read_only(schema: &Schema) -> bool {
+    match schema {
+        Schema::String(s) => s.read_only == Some(true),
+        Schema::Integer(s) => s.read_only == Some(true),
+        Schema::Number(s) => s.read_only == Some(true),
+        Schema::Boolean(s) => s.read_only == Some(true),
+        Schema::Array(s) => s.read_only == Some(true),
+        Schema::Object(s) => s.read_only == Some(true),
+        Schema::Null(s) => s.read_only == Some(true),
+        Schema::AllOf(_) => false,
     }
 }
 
@@ -1235,6 +1293,139 @@ mod tests {
                     },
                 ],
             }),
+        );
+    }
+
+    #[test]
+    fn array_schema_requires_items() {
+        // Per OAS 2.0: `type: array` MUST be accompanied by `items`.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Array(Box::new(ArraySchema {
+            items: None,
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".items: is required for `type: array`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // With items: valid.
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Array(Box::new(ArraySchema {
+            items: Some(RefOr::new_item(Schema::from(StringSchema::default()))),
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn discriminator_must_be_property_and_required() {
+        let spec = Spec::default();
+
+        // discriminator names a non-existent property.
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Object(Box::new(ObjectSchema {
+            discriminator: Some("kind".into()),
+            properties: Some({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "name".into(),
+                    RefOr::new_item(Schema::from(StringSchema::default())),
+                );
+                m
+            }),
+            required: Some(vec!["name".into()]),
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must be a property defined on this schema")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // discriminator names a property that exists but isn't required.
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Object(Box::new(ObjectSchema {
+            discriminator: Some("kind".into()),
+            properties: Some({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "kind".into(),
+                    RefOr::new_item(Schema::from(StringSchema::default())),
+                );
+                m
+            }),
+            required: None,
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("must be listed in `required`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // discriminator names a property that is both defined and required: ok.
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Object(Box::new(ObjectSchema {
+            discriminator: Some("kind".into()),
+            properties: Some({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "kind".into(),
+                    RefOr::new_item(Schema::from(StringSchema::default())),
+                );
+                m
+            }),
+            required: Some(vec!["kind".into()]),
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("discriminator")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn read_only_property_in_required_warns() {
+        // OAS 2.0 prose: properties marked `readOnly` SHOULD NOT appear in `required`.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Object(Box::new(ObjectSchema {
+            properties: Some({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "id".into(),
+                    RefOr::new_item(Schema::from(StringSchema {
+                        read_only: Some(true),
+                        ..Default::default()
+                    })),
+                );
+                m
+            }),
+            required: Some(vec!["id".into()]),
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("`id`") && e.contains("readOnly") && e.contains("SHOULD NOT")),
+            "errors: {:?}",
+            ctx.errors
         );
     }
 

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -860,10 +860,20 @@ impl ValidateWithContext<Spec> for ObjectSchema {
         }
 
         // OAS 2.0 prose: properties marked `readOnly: true` SHOULD NOT appear
-        // in `required`. Flag the combination as a warning-level error.
+        // in `required`. Surfaced as a validation error (this crate's framework
+        // has no separate warning channel) so SHOULD-violations show up in the
+        // same `errors` Vec. Follow `$ref`s so a referenced schema's
+        // `readOnly` is still caught.
         if let (Some(props), Some(required)) = (&self.properties, &self.required) {
             for name in required {
-                if let Some(RefOr::Item(schema)) = props.get(name)
+                let Some(prop) = props.get(name) else {
+                    continue;
+                };
+                let resolved: Option<&Schema> = match prop {
+                    RefOr::Item(s) => Some(s),
+                    RefOr::Ref(_) => prop.get_item(ctx.spec).ok(),
+                };
+                if let Some(schema) = resolved
                     && is_schema_read_only(schema)
                 {
                     ctx.error(
@@ -1424,6 +1434,63 @@ mod tests {
             ctx.errors
                 .iter()
                 .any(|e| e.contains("`id`") && e.contains("readOnly") && e.contains("SHOULD NOT")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn read_only_property_via_ref_still_flagged() {
+        // The readOnly check follows `$ref` properties through the spec's
+        // `#/definitions/...` pool, so a referenced read-only schema in
+        // `required` is caught the same as an inline one.
+        let mut spec = Spec::default();
+        spec.define_schema(
+            "Id",
+            Schema::from(StringSchema {
+                read_only: Some(true),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Object(Box::new(ObjectSchema {
+            properties: Some({
+                let mut m = BTreeMap::new();
+                m.insert("id".into(), RefOr::new_ref("#/definitions/Id".to_owned()));
+                m
+            }),
+            required: Some(vec!["id".into()]),
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("`id`") && e.contains("readOnly") && e.contains("SHOULD NOT")),
+            "errors: {:?}",
+            ctx.errors
+        );
+
+        // Unresolvable refs are silently skipped here — the bad `$ref` is
+        // flagged by the regular reference walker, not by this rule.
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, crate::validation::Options::new());
+        Schema::Object(Box::new(ObjectSchema {
+            properties: Some({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "id".into(),
+                    RefOr::new_ref("#/definitions/Missing".to_owned()),
+                );
+                m
+            }),
+            required: Some(vec!["id".into()]),
+            ..Default::default()
+        }))
+        .validate_with_context(&mut ctx, "s".into());
+        assert!(
+            ctx.errors.iter().all(|e| !e.contains("SHOULD NOT")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -2,7 +2,7 @@
 
 use crate::common::helpers::{
     Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
-    validate_not_visited, validate_optional_string_matches,
+    validate_not_visited, validate_optional_string_matches, validate_unique_by,
 };
 use crate::common::reference::ResolveReference;
 use crate::v2::external_documentation::ExternalDocumentation;
@@ -315,7 +315,7 @@ impl Validate for Version {
 }
 
 /// The possible values of the transfer protocol of the API
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Default)]
 pub enum Scheme {
     /// `http` protocol
     #[serde(rename = "http")]
@@ -512,6 +512,24 @@ impl Validate for Spec {
                 "#.basePath".to_owned(),
                 format_args!("must start with `/`, found `{base_path}`"),
             );
+        }
+
+        // OAS 2.0 schema marks `schemes`, `consumes`, `produces`, `tags`, and
+        // `security` as `uniqueItems: true`.
+        if let Some(schemes) = &self.schemes {
+            validate_unique_by(schemes, &mut ctx, "#.schemes".to_owned(), |s| s.clone());
+        }
+        if let Some(consumes) = &self.consumes {
+            validate_unique_by(consumes, &mut ctx, "#.consumes".to_owned(), |s| s.clone());
+        }
+        if let Some(produces) = &self.produces {
+            validate_unique_by(produces, &mut ctx, "#.produces".to_owned(), |s| s.clone());
+        }
+        if let Some(tags) = &self.tags {
+            validate_unique_by(tags, &mut ctx, "#.tags".to_owned(), |t| t.name.clone());
+        }
+        if let Some(security) = &self.security {
+            validate_unique_by(security, &mut ctx, "#.security".to_owned(), |r| r.clone());
         }
 
         // Validate paths operations and the new path-template / parameter rules.
@@ -1425,6 +1443,45 @@ mod tests {
             "#/tags/missing",
         );
         assert!(t.is_none());
+    }
+
+    #[test]
+    fn unique_items_enforced_on_top_level_lists() {
+        // schemes, consumes, produces, tags (by name), and security must all
+        // be free of duplicates per the OAS 2.0 schema.
+        let mut spec = spec_with_info();
+        spec.schemes = Some(vec![Scheme::HTTPS, Scheme::HTTPS]);
+        spec.consumes = Some(vec!["application/json".into(), "application/json".into()]);
+        spec.produces = Some(vec!["text/plain".into(), "text/plain".into()]);
+        spec.tags = Some(vec![
+            crate::v2::tag::Tag {
+                name: "pet".into(),
+                ..Default::default()
+            },
+            crate::v2::tag::Tag {
+                name: "pet".into(),
+                ..Default::default()
+            },
+        ]);
+        let mut req = BTreeMap::new();
+        req.insert("none".to_owned(), vec![]);
+        spec.security = Some(vec![req.clone(), req]);
+        let err = spec.validate(Options::new()).unwrap_err();
+        for (field, idx) in [
+            ("#.schemes[1]", "schemes"),
+            ("#.consumes[1]", "consumes"),
+            ("#.produces[1]", "produces"),
+            ("#.tags[1]", "tags"),
+            ("#.security[1]", "security"),
+        ] {
+            assert!(
+                err.errors
+                    .iter()
+                    .any(|e| e.contains(field) && e.contains("duplicate value")),
+                "missing dup error for {idx}: {:?}",
+                err.errors
+            );
+        }
     }
 
     #[test]

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -13,7 +13,7 @@
 use lazy_regex::regex;
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::common::helpers::{Context, PushError};
+use crate::common::helpers::{Context, PushError, validate_unique_by};
 use crate::common::reference::ResolveReference;
 use crate::v2::operation::Operation;
 use crate::v2::parameter::{InFormData, InHeader, InPath, InQuery, Parameter};
@@ -243,6 +243,10 @@ pub fn validate_security_requirements(
     let defs = ctx.spec.security_definitions.as_ref();
     for (i, req) in requirements.iter().enumerate() {
         for (name, scopes) in req {
+            // OAS 2.0 schema: each scope array is `uniqueItems: true`.
+            validate_unique_by(scopes, ctx, format!("{path}[{i}].`{name}`.scopes"), |s| {
+                s.clone()
+            });
             let Some(defs) = defs else {
                 ctx.error(
                     path.to_owned(),
@@ -925,6 +929,36 @@ mod tests {
             ctx.errors
                 .iter()
                 .any(|e| e.contains("path template variable `{id}`")),
+            "errors: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn security_requirement_scope_array_is_unique() {
+        // OAS 2.0: each scope array is `uniqueItems: true`.
+        let mut defs = BTreeMap::new();
+        defs.insert(
+            "o".to_owned(),
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                flow: SecuritySchemeOAuth2Flow::Implicit,
+                authorization_url: Some("https://x.example.com/a".into()),
+                token_url: None,
+                scopes: Scopes::from([("read".to_owned(), "Read".to_owned())]),
+                description: None,
+                extensions: None,
+            }),
+        );
+        let spec = spec_with_security_definitions(defs);
+        let spec: &'static Spec = Box::leak(Box::new(spec));
+        let mut ctx = Context::new(spec, Options::new());
+        let mut req = BTreeMap::new();
+        req.insert("o".to_owned(), vec!["read".to_owned(), "read".to_owned()]);
+        validate_security_requirements(&mut ctx, "#.security", &[req]);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains(".scopes[1]") && e.contains("duplicate value")),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -244,7 +244,7 @@ pub fn validate_security_requirements(
     for (i, req) in requirements.iter().enumerate() {
         for (name, scopes) in req {
             // OAS 2.0 schema: each scope array is `uniqueItems: true`.
-            validate_unique_by(scopes, ctx, format!("{path}[{i}].`{name}`.scopes"), |s| {
+            validate_unique_by(scopes, ctx, format!("{path}: [{i}].`{name}`"), |s| {
                 s.clone()
             });
             let Some(defs) = defs else {
@@ -958,7 +958,7 @@ mod tests {
         assert!(
             ctx.errors
                 .iter()
-                .any(|e| e.contains(".scopes[1]") && e.contains("duplicate value")),
+                .any(|e| e == "#.security: [0].`o`[1]: duplicate value"),
             "errors: {:?}",
             ctx.errors
         );


### PR DESCRIPTION
## Summary

Closes the documented gaps between `src/v2/*` and the OpenAPI 2.0 JSON schema (https://spec.openapis.org/oas/2.0/schema/2017-08-27.html). All existing ReDoc/extension types and the two documented intentional deviations (`Schema::Null`, arbitrary HTTP methods on `PathItem`) are preserved.

- Reject `collectionFormat: multi` on header/path/items — schema reserves it for query/formData.
- Enforce `uniqueItems: true` on `Spec.{schemes, consumes, produces, tags, security}`, `Operation.{tags, consumes, produces, schemes, security}`, and on each security-requirement scope array.
- Require `ArraySchema.items` when `type: array`.
- Require `ObjectSchema.discriminator` to name a property that is both defined on the schema and listed in `required`.
- Flag `readOnly` properties that appear in `required` (spec `SHOULD NOT`).
- Flag `PathItem.$ref` when it coexists with inline operations or parameters.

New helpers: `validate_unique_by` (generic uniqueItems) and `CollectionFormat::is_multi`. `Scheme` gained `Eq + Hash` derives so it can key the dedupe set.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo nextest run --all-features` — 787 / 787 passing, including 10 new tests:
  - `v2::items::tests::array_item_rejects_multi_collection_format`
  - `v2::header::tests::array_header_rejects_multi_collection_format`
  - `v2::parameter::tests::header_and_path_array_params_reject_multi_collection_format`
  - `v2::spec::tests::unique_items_enforced_on_top_level_lists`
  - `v2::operation::tests::unique_items_enforced_on_operation_lists`
  - `v2::validation::tests::security_requirement_scope_array_is_unique`
  - `v2::schema::tests::array_schema_requires_items`
  - `v2::schema::tests::discriminator_must_be_property_and_required`
  - `v2::schema::tests::read_only_property_in_required_warns`
  - `v2::path_item::tests::path_item_ref_must_not_coexist_with_operations_or_parameters`
