### PR TITLE
spec: move Version validation to ValidateWithContext

### DIFF
--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -300,16 +300,10 @@ impl TryFrom<String> for Version {
     }
 }
 
-impl Validate for Version {
-    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
-        // Constructors and parsers all enforce the literal, but
-        // re-checking here keeps `Validate` a self-contained contract.
-        if self.0 == SWAGGER_VERSION_LITERAL {
-            Ok(())
-        } else {
-            Err(Error {
-                errors: vec![format!("#.swagger: must be {SWAGGER_VERSION_DESCRIPTION}")],
-            })
+impl ValidateWithContext<Spec> for Version {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        if self.0 != SWAGGER_VERSION_LITERAL {
+            ctx.error(path, format_args!("must be {SWAGGER_VERSION_DESCRIPTION}"));
         }
     }
 }
@@ -489,12 +483,8 @@ impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
 
-        // Surface any `swagger` literal violations alongside the rest
-        // of the spec's errors instead of bailing out early.
-        if let Err(e) = self.swagger.validate(options) {
-            ctx.errors.extend(e.errors);
-        }
-
+        self.swagger
+            .validate_with_context(&mut ctx, "#.swagger".to_owned());
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
 
@@ -767,28 +757,29 @@ mod tests {
 
     #[test]
     fn test_swagger_version_validate() {
-        assert!(Version::default().validate(Options::new()).is_ok());
-        assert!(Version::V2_0().validate(Options::new()).is_ok());
-        assert!(
-            "2.0"
-                .parse::<Version>()
-                .unwrap()
-                .validate(Options::new())
-                .is_ok()
-        );
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version::default().validate_with_context(&mut ctx, "#.swagger".to_owned());
+        Version::V2_0().validate_with_context(&mut ctx, "#.swagger".to_owned());
+        "2.0"
+            .parse::<Version>()
+            .unwrap()
+            .validate_with_context(&mut ctx, "#.swagger".to_owned());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
 
     #[test]
     fn test_swagger_version_validate_rejects_invalid() {
         // Inner `String` is private to outside callers, so the only
         // way to reach the rejection branch is from inside the module.
-        let invalid = Version("3.0".to_owned());
-        let err = invalid.validate(Options::new()).unwrap_err();
-        assert_eq!(err.errors.len(), 1);
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version("3.0".to_owned()).validate_with_context(&mut ctx, "#.swagger".to_owned());
+        assert_eq!(ctx.errors.len(), 1);
         assert!(
-            err.errors[0].contains("#.swagger") && err.errors[0].contains("`2.0`"),
-            "validate error names the field and the literal: {:?}",
-            err.errors
+            ctx.errors[0].contains("#.swagger") && ctx.errors[0].contains("`2.0`"),
+            "errors: {:?}",
+            ctx.errors
         );
     }
 

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -417,17 +417,10 @@ impl TryFrom<String> for Version {
     }
 }
 
-impl Validate for Version {
-    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
-        // Constructors and parsers all enforce the pattern, but
-        // re-checking here keeps `Validate` a self-contained contract:
-        // any `Version` that survives this call is schema-conformant.
-        if matches_oas_3_0_version(&self.0) {
-            Ok(())
-        } else {
-            Err(Error {
-                errors: vec![format!("#.openapi: must be {VERSION_SCHEMA_DESCRIPTION}")],
-            })
+impl ValidateWithContext<Spec> for Version {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        if !matches_oas_3_0_version(&self.0) {
+            ctx.error(path, format_args!("must be {VERSION_SCHEMA_DESCRIPTION}"));
         }
     }
 }
@@ -701,12 +694,8 @@ impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
 
-        // Surface any `openapi` schema-pattern violations alongside the
-        // rest of the spec's errors instead of bailing out early.
-        if let Err(e) = self.openapi.validate(options) {
-            ctx.errors.extend(e.errors);
-        }
-
+        self.openapi
+            .validate_with_context(&mut ctx, "#.openapi".to_owned());
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
 
@@ -897,16 +886,16 @@ mod tests {
     fn test_version_validate() {
         // Every constructible `Version` is schema-conformant and
         // therefore validates clean.
-        assert!(Version::default().validate(Options::new()).is_ok());
-        assert!(Version::V3_0_0().validate(Options::new()).is_ok());
-        assert!(Version::V3_0_4().validate(Options::new()).is_ok());
-        assert!(
-            "3.0.99"
-                .parse::<Version>()
-                .unwrap()
-                .validate(Options::new())
-                .is_ok()
-        );
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version::default().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        Version::V3_0_0().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        Version::V3_0_4().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        "3.0.99"
+            .parse::<Version>()
+            .unwrap()
+            .validate_with_context(&mut ctx, "#.openapi".to_owned());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
 
     #[test]
@@ -914,13 +903,14 @@ mod tests {
         // The inner `String` is private, so external code can't build
         // a malformed `Version`. Inside the module we can — exercise
         // the rejection branch so the contract is locked in.
-        let invalid = Version("garbage".to_owned());
-        let err = invalid.validate(Options::new()).unwrap_err();
-        assert_eq!(err.errors.len(), 1);
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version("garbage".to_owned()).validate_with_context(&mut ctx, "#.openapi".to_owned());
+        assert_eq!(ctx.errors.len(), 1);
         assert!(
-            err.errors[0].contains("#.openapi") && err.errors[0].contains("3\\.0\\.\\d+(-.+)?$"),
-            "validate error names the field and the schema regex: {:?}",
-            err.errors
+            ctx.errors[0].contains("#.openapi") && ctx.errors[0].contains("3\\.0\\.\\d+(-.+)?$"),
+            "errors: {:?}",
+            ctx.errors
         );
     }
 

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -437,16 +437,10 @@ impl TryFrom<String> for Version {
     }
 }
 
-impl Validate for Version {
-    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
-        // Constructors and parsers all enforce the pattern, but
-        // re-checking here keeps `Validate` a self-contained contract.
-        if matches_oas_3_1_version(&self.0) {
-            Ok(())
-        } else {
-            Err(Error {
-                errors: vec![format!("#.openapi: must be {VERSION_SCHEMA_DESCRIPTION}")],
-            })
+impl ValidateWithContext<Spec> for Version {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        if !matches_oas_3_1_version(&self.0) {
+            ctx.error(path, format_args!("must be {VERSION_SCHEMA_DESCRIPTION}"));
         }
     }
 }
@@ -796,12 +790,8 @@ impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
 
-        // Surface any `openapi` schema-pattern violations alongside the
-        // rest of the spec's errors instead of bailing out early.
-        if let Err(e) = self.openapi.validate(options) {
-            ctx.errors.extend(e.errors);
-        }
-
+        self.openapi
+            .validate_with_context(&mut ctx, "#.openapi".to_owned());
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
 
@@ -1066,27 +1056,28 @@ mod tests {
 
     #[test]
     fn test_version_validate() {
-        assert!(Version::default().validate(Options::new()).is_ok());
-        assert!(Version::V3_1_0().validate(Options::new()).is_ok());
-        assert!(Version::V3_1_2().validate(Options::new()).is_ok());
-        assert!(
-            "3.1.99"
-                .parse::<Version>()
-                .unwrap()
-                .validate(Options::new())
-                .is_ok()
-        );
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version::default().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        Version::V3_1_0().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        Version::V3_1_2().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        "3.1.99"
+            .parse::<Version>()
+            .unwrap()
+            .validate_with_context(&mut ctx, "#.openapi".to_owned());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
 
     #[test]
     fn test_version_validate_rejects_invalid() {
-        let invalid = Version("garbage".to_owned());
-        let err = invalid.validate(Options::new()).unwrap_err();
-        assert_eq!(err.errors.len(), 1);
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version("garbage".to_owned()).validate_with_context(&mut ctx, "#.openapi".to_owned());
+        assert_eq!(ctx.errors.len(), 1);
         assert!(
-            err.errors[0].contains("#.openapi") && err.errors[0].contains("3\\.1\\.\\d+(-.+)?$"),
-            "validate error names the field and the schema regex: {:?}",
-            err.errors
+            ctx.errors[0].contains("#.openapi") && ctx.errors[0].contains("3\\.1\\.\\d+(-.+)?$"),
+            "errors: {:?}",
+            ctx.errors
         );
     }
 

--- a/src/v3_2/spec.rs
+++ b/src/v3_2/spec.rs
@@ -413,16 +413,10 @@ impl TryFrom<String> for Version {
     }
 }
 
-impl Validate for Version {
-    fn validate(&self, _options: EnumSet<Options>) -> Result<(), Error> {
-        // Constructors and parsers all enforce the pattern, but
-        // re-checking here keeps `Validate` a self-contained contract.
-        if matches_oas_3_2_version(&self.0) {
-            Ok(())
-        } else {
-            Err(Error {
-                errors: vec![format!("#.openapi: must be {VERSION_SCHEMA_DESCRIPTION}")],
-            })
+impl ValidateWithContext<Spec> for Version {
+    fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
+        if !matches_oas_3_2_version(&self.0) {
+            ctx.error(path, format_args!("must be {VERSION_SCHEMA_DESCRIPTION}"));
         }
     }
 }
@@ -802,12 +796,8 @@ impl Validate for Spec {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error> {
         let mut ctx = Context::new(self, options);
 
-        // Surface any `openapi` schema-pattern violations alongside the
-        // rest of the spec's errors instead of bailing out early.
-        if let Err(e) = self.openapi.validate(options) {
-            ctx.errors.extend(e.errors);
-        }
-
+        self.openapi
+            .validate_with_context(&mut ctx, "#.openapi".to_owned());
         self.info
             .validate_with_context(&mut ctx, "#.info".to_owned());
 
@@ -1069,26 +1059,27 @@ mod tests {
 
     #[test]
     fn test_version_validate() {
-        assert!(Version::default().validate(Options::new()).is_ok());
-        assert!(Version::V3_2_0().validate(Options::new()).is_ok());
-        assert!(
-            "3.2.99"
-                .parse::<Version>()
-                .unwrap()
-                .validate(Options::new())
-                .is_ok()
-        );
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version::default().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        Version::V3_2_0().validate_with_context(&mut ctx, "#.openapi".to_owned());
+        "3.2.99"
+            .parse::<Version>()
+            .unwrap()
+            .validate_with_context(&mut ctx, "#.openapi".to_owned());
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
 
     #[test]
     fn test_version_validate_rejects_invalid() {
-        let invalid = Version("garbage".to_owned());
-        let err = invalid.validate(Options::new()).unwrap_err();
-        assert_eq!(err.errors.len(), 1);
+        let spec = Spec::default();
+        let mut ctx = Context::new(&spec, Options::new());
+        Version("garbage".to_owned()).validate_with_context(&mut ctx, "#.openapi".to_owned());
+        assert_eq!(ctx.errors.len(), 1);
         assert!(
-            err.errors[0].contains("#.openapi") && err.errors[0].contains("3.2.<patch>"),
-            "validate error names the field and the schema description: {:?}",
-            err.errors
+            ctx.errors[0].contains("#.openapi") && ctx.errors[0].contains("3.2.<patch>"),
+            "errors: {:?}",
+            ctx.errors
         );
     }
 


### PR DESCRIPTION
Each per-version Spec module had an `impl Validate for Version` whose `fn validate` ignored its `options: EnumSet<Options>` parameter — a giveaway that the wrong trait was in use. Validation of `Version` was always invoked from the parent `Spec`'s validation flow with `if let Err(e) = self.openapi.validate(options) { ctx.errors.extend(e.errors); }`, which is exactly what `ValidateWithContext<Spec>` exists to express. Converting the four `Version` impls to `ValidateWithContext<Spec>` removes the unused parameter, drops the `Error::errors.extend` plumbing, and leaves `Validate` implemented only by `Spec` — its natural one-type shape.

Tests that called `Version::validate(Options::new())` directly now construct a small `Context::new(&Spec::default(), Options::new())` and exercise `validate_with_context` instead. Error messages are unchanged: `"#.openapi: must be ..."` / `"#.swagger: must be ..."` are produced via `ctx.error(path, ...)` with the path passed in by the caller.

Net change: -37 lines.