### PR TITLE
validation: move Context / ValidateWithContext to crate::validation; hide helpers

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -3,5 +3,5 @@
 pub mod bool_or;
 pub mod extensions;
 pub mod formats;
-pub mod helpers;
+pub(crate) mod helpers;
 pub mod reference;

--- a/src/common/bool_or.rs
+++ b/src/common/bool_or.rs
@@ -1,5 +1,5 @@
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::common::reference::{RefOr, ResolveReference};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -1,118 +1,13 @@
-use enumset::EnumSet;
-use lazy_regex::regex;
+//! Internal validation utility functions shared across the per-version
+//! validators. The user-facing types (`Context`, `ValidateWithContext`,
+//! `PushError`, `InvalidComponentName`, `check_component_name`) live in
+//! [`crate::validation`]; this module is `pub(crate)` and holds only
+//! crate-internal helpers.
+
 use regex::Regex;
 use std::collections::HashSet;
-use std::fmt;
-use thiserror::Error;
 
-use crate::validation::{Error, Options};
-
-/// Allowed character set for OpenAPI component / definition map keys.
-/// Mirrors the pattern enforced by `v3_0::Components` / `v3_1::Components`
-/// validators. Used by `Spec::define_*` helpers to surface invalid keys
-/// at insertion time rather than during a later `validate()` pass.
-pub const COMPONENT_NAME_PATTERN: &str = r"^[a-zA-Z0-9.\-_]+$";
-
-/// Returned by `Spec::define_*` helpers when a component name does not
-/// match [`COMPONENT_NAME_PATTERN`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
-#[error("component name {name:?} must match pattern `{COMPONENT_NAME_PATTERN}`")]
-pub struct InvalidComponentName {
-    pub name: String,
-}
-
-/// Returns `Ok(())` if `name` matches [`COMPONENT_NAME_PATTERN`],
-/// otherwise an [`InvalidComponentName`] error.
-pub fn check_component_name(name: &str) -> Result<(), InvalidComponentName> {
-    if regex!(r"^[a-zA-Z0-9.\-_]+$").is_match(name) {
-        Ok(())
-    } else {
-        Err(InvalidComponentName {
-            name: name.to_owned(),
-        })
-    }
-}
-
-/// ValidateWithContext is a trait for validating an object with a context.
-/// It allows the object to be validated with additional context information,
-/// such as the specification and validation options.
-pub trait ValidateWithContext<T> {
-    fn validate_with_context(&self, ctx: &mut Context<T>, path: String);
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Context<'a, T> {
-    pub spec: &'a T,
-    pub visited: HashSet<String>,
-    pub errors: Vec<String>,
-    pub options: EnumSet<Options>,
-}
-
-pub trait PushError<T> {
-    fn error(&mut self, path: String, args: T);
-}
-
-impl<T> PushError<&str> for Context<'_, T> {
-    fn error(&mut self, path: String, msg: &str) {
-        if msg.starts_with('.') {
-            self.errors.push(format!("{path}{msg}"));
-        } else {
-            self.errors.push(format!("{path}: {msg}"));
-        }
-    }
-}
-
-impl<T> PushError<String> for Context<'_, T> {
-    fn error(&mut self, path: String, msg: String) {
-        self.error(path, msg.as_str());
-    }
-}
-
-impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
-    fn error(&mut self, path: String, args: fmt::Arguments<'_>) {
-        self.error(path, args.to_string().as_str());
-    }
-}
-
-impl<T> Context<'_, T> {
-    pub fn reset(&mut self) {
-        self.visited.clear();
-        self.errors.clear();
-    }
-
-    pub fn visit(&mut self, path: String) -> bool {
-        self.visited.insert(path)
-    }
-
-    pub fn is_visited(&self, path: &str) -> bool {
-        self.visited.contains(path)
-    }
-
-    pub fn is_option(&self, option: Options) -> bool {
-        self.options.contains(option)
-    }
-}
-
-impl Context<'_, ()> {
-    pub fn new<T>(spec: &T, options: EnumSet<Options>) -> Context<'_, T> {
-        Context {
-            spec,
-            visited: HashSet::new(),
-            errors: Vec::new(),
-            options,
-        }
-    }
-}
-
-impl<'a, T> From<Context<'a, T>> for Result<(), Error> {
-    fn from(val: Context<'a, T>) -> Self {
-        if val.errors.is_empty() {
-            Ok(())
-        } else {
-            Err(Error { errors: val.errors })
-        }
-    }
-}
+use crate::validation::{Context, Options, PushError, ValidateWithContext};
 
 /// Validates that the given optional email string contains an '@' character.
 /// If the email is present and invalid, records an error in the context.

--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -5,6 +5,7 @@
 //! crate-internal helpers.
 
 use regex::Regex;
+#[cfg(feature = "v2")]
 use std::collections::HashSet;
 
 use crate::validation::{Context, Options, PushError, ValidateWithContext};
@@ -22,12 +23,15 @@ pub fn validate_email<T>(email: &Option<String>, ctx: &mut Context<T>, path: Str
     }
 }
 
+#[cfg(any(feature = "v2", feature = "v3_0", feature = "v3_1"))]
 const HTTP: &str = "http://";
+#[cfg(any(feature = "v2", feature = "v3_0", feature = "v3_1"))]
 const HTTPS: &str = "https://";
 
 /// Validates an optional URL string.
 /// If the URL is present, it checks if it is valid using `validate_required_url`.
 /// Records an error in the context if the URL is invalid.
+#[cfg(any(feature = "v2", feature = "v3_0", feature = "v3_1"))]
 pub fn validate_optional_url<T>(url: &Option<String>, ctx: &mut Context<T>, path: String) {
     if let Some(url) = url {
         validate_required_url(url, ctx, path);
@@ -87,6 +91,7 @@ pub fn validate_required_uri<T>(uri: &String, ctx: &mut Context<T>, path: String
 
 /// Validates that the given URL string starts with "http://" or "https://".
 /// If the URL is invalid, records an error in the context.
+#[cfg(any(feature = "v2", feature = "v3_0", feature = "v3_1"))]
 pub fn validate_required_url<T>(url: &String, ctx: &mut Context<T>, path: String) {
     if !ctx.is_option(Options::IgnoreEmptyExternalDocumentationUrl) {
         validate_required_string(url, ctx, path.clone());
@@ -122,6 +127,7 @@ pub fn validate_string_matches<T>(s: &str, pattern: &Regex, ctx: &mut Context<T>
 }
 
 // Validates an optional string against a regex pattern if present.
+#[cfg(feature = "v2")]
 pub fn validate_optional_string_matches<T>(
     s: &Option<String>,
     pattern: &Regex,
@@ -148,6 +154,7 @@ pub fn validate_pattern<T>(pattern: &str, ctx: &mut Context<T>, path: String) {
 ///
 /// Used to enforce `uniqueItems: true` on lists where the schema requires it
 /// (schemes, MIME type lists, tags by name, scope arrays, etc.).
+#[cfg(feature = "v2")]
 pub fn validate_unique_by<T, K, S, F>(items: &[T], ctx: &mut Context<S>, path: String, key: F)
 where
     K: Eq + std::hash::Hash,
@@ -185,6 +192,7 @@ pub fn validate_not_visited<T, D>(
 mod tests {
     use super::*;
 
+    #[cfg(any(feature = "v2", feature = "v3_0", feature = "v3_1"))]
     #[test]
     fn test_validate_url() {
         let mut ctx = Context::new(&(), Options::new());

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 
 /// ResolveReference is a trait for resolving references.
 pub trait ResolveReference<D> {

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -1,7 +1,8 @@
 //! External Documentation Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_url};
+use crate::common::helpers::validate_required_url;
 use crate::v2::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v2/header.rs
+++ b/src/v2/header.rs
@@ -4,9 +4,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
+use crate::common::helpers::validate_pattern;
 use crate::v2::items::Items;
 use crate::v2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]

--- a/src/v2/info.rs
+++ b/src/v2/info.rs
@@ -1,10 +1,9 @@
 //! Metadata about the API.
 
-use crate::common::helpers::{
-    Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
-};
+use crate::common::helpers::{validate_email, validate_optional_url, validate_required_string};
 use crate::v2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v2/items.rs
+++ b/src/v2/items.rs
@@ -1,8 +1,9 @@
 //! Item Object
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
+use crate::common::helpers::validate_pattern;
 use crate::v2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v2/operation.rs
+++ b/src/v2/operation.rs
@@ -1,8 +1,6 @@
 //! Operation Object
 
-use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_required_string, validate_unique_by,
-};
+use crate::common::helpers::{validate_required_string, validate_unique_by};
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::parameter::Parameter;
 use crate::v2::reference::RefOr;
@@ -10,6 +8,7 @@ use crate::v2::response::Responses;
 use crate::v2::spec::{Scheme, Spec};
 use crate::v2::tag::Tag;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -1,13 +1,12 @@
 //! Parameter Object
 
 use crate::common::formats::{CollectionFormat, IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_pattern, validate_required_string,
-};
+use crate::common::helpers::{validate_pattern, validate_required_string};
 use crate::v2::items::Items;
 use crate::v2::reference::RefOr;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -706,9 +705,9 @@ fn must_not_use_multi_collection_format(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v2::items::{ArrayItem, Items, StringItem};
     use crate::v2::schema::{Schema, StringSchema};
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -1,10 +1,10 @@
 //! Path Items
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v2::operation::Operation;
 use crate::v2::parameter::Parameter;
 use crate::v2::reference::RefOr;
 use crate::v2::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -220,7 +220,7 @@ impl ValidateWithContext<Spec> for PathItem {
             let has_ops = self.operations.as_ref().is_some_and(|m| !m.is_empty());
             let has_params = self.parameters.as_ref().is_some_and(|p| !p.is_empty());
             if has_ops || has_params {
-                crate::common::helpers::PushError::error(
+                crate::validation::PushError::error(
                     ctx,
                     format!("{path}.$ref"),
                     "MUST NOT coexist with inline operations or parameters",
@@ -882,10 +882,10 @@ mod tests {
 
     #[test]
     fn path_item_validate_runs_operations_and_parameters() {
-        use crate::common::helpers::Context;
         use crate::v2::operation::Operation;
         use crate::v2::response::Responses;
         use crate::v2::spec::Spec;
+        use crate::validation::Context;
         use crate::validation::Options;
         let spec = Spec::default();
 

--- a/src/v2/reference.rs
+++ b/src/v2/reference.rs
@@ -7,9 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::{ResolveError, ResolveReference};
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 
 /// v2 Reference Object — exactly `{ "$ref": "..." }`.
 ///
@@ -168,9 +168,9 @@ mod tests {
         );
     }
 
-    use crate::common::helpers::Context;
     use crate::v2::schema::{Schema, StringSchema};
     use crate::v2::spec::Spec;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -1,11 +1,12 @@
 //! Response Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v2::header::Header;
 use crate::v2::reference::RefOr;
 use crate::v2::schema::Schema;
 use crate::v2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -213,9 +214,9 @@ impl ValidateWithContext<Spec> for Responses {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v2::header::{IntegerHeader, StringHeader};
     use crate::v2::reference::RefOr;
+    use crate::validation::Context;
     use crate::validation::Options;
     use std::collections::BTreeMap;
 

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -2,11 +2,12 @@
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
+use crate::common::helpers::validate_pattern;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::reference::RefOr;
 use crate::v2::spec::Spec;
 use crate::v2::xml::XML;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use monostate::MustBe;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -1,9 +1,8 @@
 //! Security Scheme Object
 
-use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_required_string, validate_required_url,
-};
+use crate::common::helpers::{validate_required_string, validate_required_url};
 use crate::v2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::de::{Error as DeError, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -577,7 +576,7 @@ mod tests {
 
     #[test]
     fn oauth2_validate_empty_scopes_and_url_branches() {
-        use crate::common::helpers::Context;
+        use crate::validation::Context;
         use crate::validation::Options;
         let spec = Spec::default();
 
@@ -787,7 +786,7 @@ mod tests {
 
     #[test]
     fn apikey_validate_required_name() {
-        use crate::common::helpers::Context;
+        use crate::validation::Context;
         use crate::validation::Options;
         let spec = Spec::default();
         let s = ApiKeySecurityScheme {

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -1,7 +1,6 @@
 //! The root document object of the OpenAPI v2.0 specification.
 
 use crate::common::helpers::{
-    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
     validate_not_visited, validate_optional_string_matches, validate_unique_by,
 };
 use crate::common::reference::ResolveReference;
@@ -14,6 +13,9 @@ use crate::v2::response::Response;
 use crate::v2::schema::{ObjectSchema, Schema};
 use crate::v2::security_scheme::SecurityScheme;
 use crate::v2::tag::Tag;
+use crate::validation::{
+    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
+};
 use crate::validation::{Error, Options, Validate};
 use enumset::EnumSet;
 use lazy_regex::regex;

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -1,8 +1,9 @@
 //! Tag Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v2::external_documentation::ExternalDocumentation;
 use crate::v2::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -13,7 +13,7 @@
 use lazy_regex::regex;
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::common::helpers::{Context, PushError, validate_unique_by};
+use crate::common::helpers::validate_unique_by;
 use crate::common::reference::ResolveReference;
 use crate::v2::operation::Operation;
 use crate::v2::parameter::{InFormData, InHeader, InPath, InQuery, Parameter};
@@ -22,6 +22,7 @@ use crate::v2::reference::RefOr;
 use crate::v2::security_scheme::{SecurityScheme, SecuritySchemeOAuth2Flow};
 use crate::v2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError};
 
 /// Resolve a `RefOr<Parameter>` against the spec's `#/parameters/...` pool.
 fn resolve_parameter<'a>(spec: &'a Spec, p: &'a RefOr<Parameter>) -> Option<&'a Parameter> {
@@ -356,7 +357,7 @@ pub fn validate_security_definitions(ctx: &mut Context<Spec>) {
         else {
             continue;
         };
-        crate::common::helpers::ValidateWithContext::validate_with_context(&scheme, ctx, p.clone());
+        crate::validation::ValidateWithContext::validate_with_context(&scheme, ctx, p.clone());
         if !ctx.is_visited(&p) && !ctx.is_option(Options::IgnoreUnusedSecuritySchemes) {
             ctx.error(p, "unused");
         }
@@ -391,7 +392,6 @@ fn validate_operation_security(ctx: &mut Context<Spec>, op_path: &str, op: &Oper
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v2::parameter::{InBody, InFormData, InPath, InQuery, Parameter, StringParameter};
     use crate::v2::path_item::PathItem;
     use crate::v2::reference::RefOr;
@@ -402,6 +402,7 @@ mod tests {
         SecuritySchemeApiKeyLocation, SecuritySchemeOAuth2Flow,
     };
     use crate::v2::spec::Spec;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     fn body_param(name: &str) -> RefOr<Parameter> {

--- a/src/v2/xml.rs
+++ b/src/v2/xml.rs
@@ -1,9 +1,8 @@
 //! XML Object
 
-use crate::common::helpers::{
-    Context, ValidateWithContext, validate_optional_url, validate_required_string,
-};
+use crate::common::helpers::{validate_optional_url, validate_required_string};
 use crate::v2::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_0/callback.rs
+++ b/src/v3_0/callback.rs
@@ -1,6 +1,6 @@
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v3_0::path_item::PathItem;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -141,7 +141,7 @@ impl ValidateWithContext<Spec> for Callback {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -1,6 +1,6 @@
 //! Holds a set of reusable objects for different aspects of the OAS.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_string_matches};
+use crate::common::helpers::validate_string_matches;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::example::Example;
 use crate::v3_0::header::Header;
@@ -13,6 +13,7 @@ use crate::v3_0::schema::Schema;
 use crate::v3_0::security_scheme::SecurityScheme;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -201,7 +202,6 @@ impl ValidateWithContext<Spec> for Components {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_0::callback::Callback;
     use crate::v3_0::example::Example;
     use crate::v3_0::header::Header;
@@ -214,6 +214,7 @@ mod tests {
         AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, ImplicitOAuth2Flow, OAuth2Flows,
         OAuth2SecurityScheme, PasswordOAuth2Flow, SecurityScheme,
     };
+    use crate::validation::Context;
     use serde_json::json;
 
     fn map_with<T>(name: &str, t: T) -> BTreeMap<String, RefOr<T>> {

--- a/src/v3_0/discriminator.rs
+++ b/src/v3_0/discriminator.rs
@@ -1,9 +1,10 @@
 //! Discriminator Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -48,8 +49,8 @@ impl ValidateWithContext<Spec> for Discriminator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_0::schema::{ObjectSchema, SingleSchema};
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_0/example.rs
+++ b/src/v3_0/example.rs
@@ -1,7 +1,8 @@
 //! Example object.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_url};
+use crate::common::helpers::validate_optional_url;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -56,7 +57,7 @@ impl ValidateWithContext<Spec> for Example {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_0/external_documentation.rs
+++ b/src/v3_0/external_documentation.rs
@@ -1,7 +1,8 @@
 //! References an external resource for extended documentation.
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_url};
+use crate::common::helpers::validate_required_url;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_0/header.rs
+++ b/src/v3_0/header.rs
@@ -1,12 +1,12 @@
 //! Header Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::parameter::InHeaderStyle;
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -1,11 +1,11 @@
 //! Provides metadata about the API.
 
 use crate::common::helpers::{
-    Context, ValidateWithContext, validate_email, validate_optional_url, validate_required_string,
-    validate_required_url,
+    validate_email, validate_optional_url, validate_required_string, validate_required_url,
 };
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -1,9 +1,9 @@
 //! Represents a possible design-time link for a response
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -255,7 +255,7 @@ impl ValidateWithContext<Spec> for Link {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -1,12 +1,12 @@
 //! Provides schema and examples for the media type
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_0::example::Example;
 use crate::v3_0::header::Header;
 use crate::v3_0::parameter::InQueryStyle;
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -207,9 +207,9 @@ impl ValidateWithContext<Spec> for Encoding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_0::header::Header;
     use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -1,6 +1,6 @@
 //! Operation Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::parameter::Parameter;
@@ -11,6 +11,7 @@ use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
 use crate::v3_0::tag::Tag;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -252,7 +253,7 @@ impl ValidateWithContext<Spec> for Badge {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -1,11 +1,12 @@
 //! Describes a single operation parameter.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_0::example::Example;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::schema::Schema;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -501,8 +502,8 @@ fn either_schema_or_content(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_0/path_item.rs
+++ b/src/v3_0/path_item.rs
@@ -1,11 +1,11 @@
 //! Path Items
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_0::operation::Operation;
 use crate::v3_0::parameter::Parameter;
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::server::Server;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/v3_0/reference.rs
+++ b/src/v3_0/reference.rs
@@ -7,9 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::{ResolveError, ResolveReference};
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use std::collections::BTreeSet;
 
 /// v3.0 Reference Object — exactly `{ "$ref": "..." }`.

--- a/src/v3_0/request_body.rs
+++ b/src/v3_0/request_body.rs
@@ -1,8 +1,8 @@
 //! Request Body Object
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -76,7 +76,7 @@ impl ValidateWithContext<Spec> for RequestBody {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -1,12 +1,13 @@
 //! Response Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_0::header::Header;
 use crate::v3_0::link::Link;
 use crate::v3_0::media_type::MediaType;
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -8,12 +8,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
+use crate::common::helpers::validate_pattern;
 use crate::v3_0::discriminator::Discriminator;
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::reference::RefOr;
 use crate::v3_0::spec::Spec;
 use crate::v3_0::xml::XML;
+use crate::validation::{Context, PushError, ValidateWithContext};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]

--- a/src/v3_0/security_scheme.rs
+++ b/src/v3_0/security_scheme.rs
@@ -1,10 +1,10 @@
 //! Security Scheme Object
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_optional_url, validate_required_string,
-    validate_required_url,
+    validate_optional_url, validate_required_string, validate_required_url,
 };
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};

--- a/src/v3_0/server.rs
+++ b/src/v3_0/server.rs
@@ -1,8 +1,9 @@
 //! Representing a Server.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_0::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -1,9 +1,6 @@
 //! The root document object of the OpenAPI v3.0.X specification.
 
-use crate::common::helpers::{
-    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
-    validate_not_visited, validate_required_string,
-};
+use crate::common::helpers::{validate_not_visited, validate_required_string};
 use crate::common::reference::ResolveReference;
 use crate::v3_0::callback::Callback;
 use crate::v3_0::components::Components;
@@ -24,6 +21,9 @@ use crate::v3_0::tag::Tag;
 use crate::v3_0::validation::{
     validate_path_item, validate_path_template_uniqueness, validate_security_requirements,
     validate_tag_uniqueness,
+};
+use crate::validation::{
+    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
 };
 use crate::validation::{Error, Options, Validate};
 use enumset::EnumSet;
@@ -1325,8 +1325,8 @@ mod tests {
 
     #[test]
     fn component_reference_alias_cycle_does_not_recurse_forever() {
-        use crate::common::helpers::Context;
         use crate::v3_0::components::Components;
+        use crate::validation::Context;
 
         let mut schemas = BTreeMap::new();
         schemas.insert(

--- a/src/v3_0/tag.rs
+++ b/src/v3_0/tag.rs
@@ -1,8 +1,9 @@
 //! Tag Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_0::external_documentation::ExternalDocumentation;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -15,7 +15,6 @@
 use lazy_regex::regex;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use crate::common::helpers::{Context, PushError};
 use crate::common::reference::ResolveReference;
 use crate::v3_0::parameter::{InCookie, InHeader, InPath, InQuery, Parameter};
 use crate::v3_0::path_item::PathItem;
@@ -24,6 +23,7 @@ use crate::v3_0::security_scheme::SecurityScheme;
 use crate::v3_0::spec::Spec;
 use crate::v3_0::tag::Tag;
 use crate::validation::Options;
+use crate::validation::{Context, PushError};
 
 /// Result of attempting to resolve a `RefOr<Parameter>` for cross-cutting
 /// validation purposes. The distinction between an unresolved *internal* ref
@@ -402,7 +402,6 @@ pub fn validate_path_item(ctx: &mut Context<Spec>, template: &str, path: &str, i
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_0::components::Components;
     use crate::v3_0::parameter::{InCookie, InHeader, InPath, InQuery};
     use crate::v3_0::reference::RefOr;
@@ -411,6 +410,7 @@ mod tests {
         OAuth2Flows, OAuth2SecurityScheme, OpenIdConnectSecurityScheme, SecurityScheme,
     };
     use crate::v3_0::spec::Spec;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     fn path_param(name: &str) -> RefOr<Parameter> {

--- a/src/v3_0/xml.rs
+++ b/src/v3_0/xml.rs
@@ -1,7 +1,8 @@
 //! XML Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_optional_url};
+use crate::common::helpers::validate_optional_url;
 use crate::v3_0::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_1/callback.rs
+++ b/src/v3_1/callback.rs
@@ -1,6 +1,6 @@
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v3_1::path_item::PathItem;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/v3_1/components.rs
+++ b/src/v3_1/components.rs
@@ -1,6 +1,6 @@
 //! Holds a set of reusable objects for different aspects of the OAS.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_string_matches};
+use crate::common::helpers::validate_string_matches;
 use crate::common::reference::RefOr;
 use crate::v3_1::callback::Callback;
 use crate::v3_1::example::Example;
@@ -14,6 +14,7 @@ use crate::v3_1::schema::Schema;
 use crate::v3_1::security_scheme::SecurityScheme;
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -219,7 +220,6 @@ impl ValidateWithContext<Spec> for Components {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_1::operation::Operation;
     use crate::v3_1::parameter::{InQuery, Parameter};
     use crate::v3_1::response::{Response, Responses};
@@ -228,6 +228,7 @@ mod tests {
         AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, ImplicitOAuth2Flow, OAuth2Flows,
         OAuth2SecurityScheme, PasswordOAuth2Flow,
     };
+    use crate::validation::Context;
     use serde_json::json;
 
     fn map_with<T>(name: &str, t: T) -> BTreeMap<String, RefOr<T>> {

--- a/src/v3_1/discriminator.rs
+++ b/src/v3_1/discriminator.rs
@@ -1,9 +1,10 @@
 //! Discriminator Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::common::reference::RefOr;
 use crate::v3_1::schema::Schema;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -55,8 +56,8 @@ impl ValidateWithContext<Spec> for Discriminator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_1::schema::{ObjectSchema, SingleSchema};
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_1/example.rs
+++ b/src/v3_1/example.rs
@@ -1,7 +1,8 @@
 //! Example object.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_uri};
+use crate::common::helpers::validate_optional_uri;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -56,7 +57,7 @@ impl ValidateWithContext<Spec> for Example {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_1/external_documentation.rs
+++ b/src/v3_1/external_documentation.rs
@@ -1,8 +1,9 @@
 //! References an external resource for extended documentation.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_uri};
+use crate::common::helpers::validate_required_uri;
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_1/header.rs
+++ b/src/v3_1/header.rs
@@ -1,12 +1,12 @@
 //! Header Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_1::example::Example;
 use crate::v3_1::media_type::MediaType;
 use crate::v3_1::parameter::InHeaderStyle;
 use crate::v3_1::schema::Schema;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_1/info.rs
+++ b/src/v3_1/info.rs
@@ -1,9 +1,10 @@
 //! Provides metadata about the API.
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_email, validate_optional_uri,
-    validate_optional_url, validate_required_string, validate_required_url,
+    validate_email, validate_optional_uri, validate_optional_url, validate_required_string,
+    validate_required_url,
 };
+use crate::validation::{Context, PushError, ValidateWithContext};
 
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;

--- a/src/v3_1/link.rs
+++ b/src/v3_1/link.rs
@@ -1,9 +1,9 @@
 //! Represents a possible design-time link for a response
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_1::server::Server;
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -517,11 +517,11 @@ impl ValidateWithContext<Spec> for Link {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::common::reference::RefOr;
     use crate::v3_1::operation::Operation;
     use crate::v3_1::path_item::{PathItem, Paths};
     use crate::v3_1::response::{Response, Responses};
+    use crate::validation::Context;
     use serde_json::json;
 
     fn spec_with_pets_get() -> Spec {

--- a/src/v3_1/media_type.rs
+++ b/src/v3_1/media_type.rs
@@ -4,13 +4,13 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_1::example::Example;
 use crate::v3_1::header::Header;
 use crate::v3_1::parameter::InQueryStyle;
 use crate::v3_1::schema::Schema;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 
 /// Each Media Type Object provides schema and examples for the media type identified by its key.
 ///
@@ -209,7 +209,7 @@ impl ValidateWithContext<Spec> for Encoding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_1/operation.rs
+++ b/src/v3_1/operation.rs
@@ -1,6 +1,6 @@
 //! Operation Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::common::reference::RefOr;
 use crate::v3_1::callback::Callback;
 use crate::v3_1::external_documentation::ExternalDocumentation;
@@ -11,6 +11,7 @@ use crate::v3_1::server::Server;
 use crate::v3_1::spec::Spec;
 use crate::v3_1::tag::Tag;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -226,9 +227,9 @@ impl ValidateWithContext<Spec> for CodeSample {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_1::response::{Response, Responses};
     use crate::v3_1::tag::Tag;
+    use crate::validation::Context;
 
     fn ok_responses() -> Responses {
         Responses {

--- a/src/v3_1/parameter.rs
+++ b/src/v3_1/parameter.rs
@@ -1,11 +1,12 @@
 //! Describes a single operation parameter.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::common::reference::RefOr;
 use crate::v3_1::example::Example;
 use crate::v3_1::media_type::MediaType;
 use crate::v3_1::schema::Schema;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -527,7 +528,7 @@ fn either_schema_or_content(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_1/path_item.rs
+++ b/src/v3_1/path_item.rs
@@ -1,12 +1,12 @@
 //! Path Items
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_1::operation::Operation;
 use crate::v3_1::parameter::Parameter;
 use crate::v3_1::server::Server;
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/v3_1/request_body.rs
+++ b/src/v3_1/request_body.rs
@@ -1,8 +1,8 @@
 //! Request Body Object
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v3_1::media_type::MediaType;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_1/response.rs
+++ b/src/v3_1/response.rs
@@ -1,12 +1,13 @@
 //! Response Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::common::reference::RefOr;
 use crate::v3_1::header::Header;
 use crate::v3_1::link::Link;
 use crate::v3_1::media_type::MediaType;
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -2,14 +2,13 @@
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_pattern, validate_required_string,
-};
+use crate::common::helpers::{validate_pattern, validate_required_string};
 use crate::common::reference::RefOr;
 use crate::v3_1::discriminator::Discriminator;
 use crate::v3_1::external_documentation::ExternalDocumentation;
 use crate::v3_1::spec::Spec;
 use crate::v3_1::xml::XML;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use monostate::MustBe;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
@@ -2146,8 +2145,7 @@ mod tests {
 
         // Validate is a no-op on Bool.
         let spec = crate::v3_1::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         Schema::Bool(true).validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
@@ -2244,8 +2242,7 @@ mod tests {
                 ..Default::default()
             })),
         ] {
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors
@@ -2278,8 +2275,7 @@ mod tests {
                 ..Default::default()
             }))),
         ] {
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors.iter().any(|e| e.contains("externalDocs.url")),
@@ -2339,8 +2335,7 @@ mod tests {
             ),
         ];
         for (label, schema, needle) in cases {
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             schema.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors.iter().any(|e| e.contains(needle)),
@@ -2362,8 +2357,7 @@ mod tests {
         });
         let s: Schema = serde_json::from_value(json).unwrap();
         let spec = crate::v3_1::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         s.validate_with_context(&mut ctx, "s".into());
         assert!(
             ctx.errors
@@ -2383,8 +2377,7 @@ mod tests {
             (serde_json::json!({"oneOf": []}), "oneOf"),
         ] {
             let s: Schema = serde_json::from_value(json).unwrap();
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors
@@ -2401,8 +2394,7 @@ mod tests {
         // Build via the struct: `serde_json::from_value` on `{"type": []}`
         // would not route to `MultiSchema`.
         let spec = crate::v3_1::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         let m = MultiSchema {
             schema_types: vec![],
             ..Default::default()
@@ -2429,8 +2421,7 @@ mod tests {
         assert_eq!(serde_json::to_value(&schema).unwrap(), enum_json);
 
         let spec = crate::v3_1::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
@@ -2442,8 +2433,7 @@ mod tests {
         let schema: Schema = serde_json::from_value(object_json.clone()).unwrap();
         assert_eq!(serde_json::to_value(&schema).unwrap(), object_json);
 
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
@@ -2452,8 +2442,7 @@ mod tests {
             x_enum_descriptions: Some(vec!["Open state".to_owned()]),
             ..Default::default()
         })));
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(
             ctx.errors
@@ -2605,8 +2594,7 @@ mod tests {
     fn empty_schema_validates_clean() {
         let schema = Schema::Empty(EmptySchema);
         let spec = crate::v3_1::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }

--- a/src/v3_1/security_scheme.rs
+++ b/src/v3_1/security_scheme.rs
@@ -1,10 +1,10 @@
 //! Security Scheme Object
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_optional_uri, validate_required_string,
-    validate_required_uri,
+    validate_optional_uri, validate_required_string, validate_required_uri,
 };
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};

--- a/src/v3_1/server.rs
+++ b/src/v3_1/server.rs
@@ -1,8 +1,9 @@
 //! Representing a Server.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};

--- a/src/v3_1/spec.rs
+++ b/src/v3_1/spec.rs
@@ -2,10 +2,7 @@
 //!
 //! https://spec.openapis.org/oas/v3.1.2
 
-use crate::common::helpers::{
-    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
-    validate_not_visited, validate_required_string,
-};
+use crate::common::helpers::{validate_not_visited, validate_required_string};
 use crate::common::reference::{RefOr, ResolveReference, resolve_in_map};
 use crate::v3_1::callback::Callback;
 use crate::v3_1::components::Components;
@@ -26,6 +23,9 @@ use crate::v3_1::tag::Tag;
 use crate::v3_1::validation::{
     validate_path_item, validate_path_template_uniqueness, validate_security_requirements,
     validate_tag_uniqueness,
+};
+use crate::validation::{
+    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
 };
 use crate::validation::{Error, Options, Validate};
 use enumset::EnumSet;

--- a/src/v3_1/tag.rs
+++ b/src/v3_1/tag.rs
@@ -1,8 +1,9 @@
 //! Tag Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_1::external_documentation::ExternalDocumentation;
 use crate::v3_1::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_1/validation.rs
+++ b/src/v3_1/validation.rs
@@ -20,7 +20,6 @@
 use lazy_regex::regex;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use crate::common::helpers::{Context, PushError};
 use crate::common::reference::{RefOr, ResolveReference};
 use crate::v3_1::parameter::{InCookie, InHeader, InPath, InQuery, Parameter};
 use crate::v3_1::path_item::PathItem;
@@ -28,6 +27,7 @@ use crate::v3_1::security_scheme::SecurityScheme;
 use crate::v3_1::spec::Spec;
 use crate::v3_1::tag::Tag;
 use crate::validation::Options;
+use crate::validation::{Context, PushError};
 
 /// Result of attempting to resolve a `RefOr<Parameter>` for cross-cutting
 /// validation. The internal/external distinction matters: when
@@ -462,7 +462,6 @@ fn find_path_item_by_ref<'a>(spec: &'a Spec, reference: &str) -> Option<&'a Path
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_1::components::Components;
     use crate::v3_1::parameter::{InCookie, InHeader, InPath, InQuery};
     use crate::v3_1::security_scheme::{
@@ -470,6 +469,7 @@ mod tests {
         OpenIdConnectSecurityScheme, SecurityScheme,
     };
     use crate::v3_1::spec::Spec;
+    use crate::validation::Context;
 
     fn path_param(name: &str) -> RefOr<Parameter> {
         RefOr::new_item(Parameter::Path(InPath {

--- a/src/v3_1/xml.rs
+++ b/src/v3_1/xml.rs
@@ -1,10 +1,9 @@
 //! XML Object
 
-use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, has_uri_unsafe_bytes, validate_optional_uri,
-};
+use crate::common::helpers::{has_uri_unsafe_bytes, validate_optional_uri};
 use crate::v3_1::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_2/callback.rs
+++ b/src/v3_2/callback.rs
@@ -1,6 +1,6 @@
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::v3_2::path_item::PathItem;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/v3_2/components.rs
+++ b/src/v3_2/components.rs
@@ -1,6 +1,6 @@
 //! Holds a set of reusable objects for different aspects of the OAS.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_string_matches};
+use crate::common::helpers::validate_string_matches;
 use crate::common::reference::RefOr;
 use crate::v3_2::callback::Callback;
 use crate::v3_2::example::Example;
@@ -14,6 +14,7 @@ use crate::v3_2::schema::Schema;
 use crate::v3_2::security_scheme::SecurityScheme;
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -237,7 +238,6 @@ impl ValidateWithContext<Spec> for Components {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_2::operation::Operation;
     use crate::v3_2::parameter::{InQuery, Parameter};
     use crate::v3_2::response::{Response, Responses};
@@ -246,6 +246,7 @@ mod tests {
         AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow, ImplicitOAuth2Flow, OAuth2Flows,
         OAuth2SecurityScheme, PasswordOAuth2Flow,
     };
+    use crate::validation::Context;
     use serde_json::json;
 
     fn map_with<T>(name: &str, t: T) -> BTreeMap<String, RefOr<T>> {

--- a/src/v3_2/discriminator.rs
+++ b/src/v3_2/discriminator.rs
@@ -1,9 +1,10 @@
 //! Discriminator Object
 
-use crate::common::helpers::{Context, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::common::reference::RefOr;
 use crate::v3_2::schema::Schema;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -65,8 +66,8 @@ impl ValidateWithContext<Spec> for Discriminator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_2::schema::{ObjectSchema, SingleSchema};
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_2/example.rs
+++ b/src/v3_2/example.rs
@@ -1,7 +1,8 @@
 //! Example object.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_optional_uri};
+use crate::common::helpers::validate_optional_uri;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -106,7 +107,7 @@ impl ValidateWithContext<Spec> for Example {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
     use serde_json::json;
 

--- a/src/v3_2/external_documentation.rs
+++ b/src/v3_2/external_documentation.rs
@@ -1,8 +1,9 @@
 //! References an external resource for extended documentation.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_uri};
+use crate::common::helpers::validate_required_uri;
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_2/header.rs
+++ b/src/v3_2/header.rs
@@ -1,12 +1,12 @@
 //! Header Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_2::example::Example;
 use crate::v3_2::media_type::MediaType;
 use crate::v3_2::parameter::InHeaderStyle;
 use crate::v3_2::schema::Schema;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_2/info.rs
+++ b/src/v3_2/info.rs
@@ -1,11 +1,9 @@
 //! Provides metadata about the API.
 
-use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_email, validate_optional_uri,
-    validate_required_string,
-};
+use crate::common::helpers::{validate_email, validate_optional_uri, validate_required_string};
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_2/link.rs
+++ b/src/v3_2/link.rs
@@ -1,9 +1,9 @@
 //! Represents a possible design-time link for a response
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::v3_2::server::Server;
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -517,11 +517,11 @@ impl ValidateWithContext<Spec> for Link {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::common::reference::RefOr;
     use crate::v3_2::operation::Operation;
     use crate::v3_2::path_item::{PathItem, Paths};
     use crate::v3_2::response::{Response, Responses};
+    use crate::validation::Context;
     use serde_json::json;
 
     fn spec_with_pets_get() -> Spec {

--- a/src/v3_2/media_type.rs
+++ b/src/v3_2/media_type.rs
@@ -4,13 +4,13 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_2::example::Example;
 use crate::v3_2::header::Header;
 use crate::v3_2::parameter::InQueryStyle;
 use crate::v3_2::schema::Schema;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 
 /// Each Media Type Object provides schema and examples for the media type identified by its key.
 ///
@@ -302,7 +302,7 @@ impl ValidateWithContext<Spec> for Encoding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_2/operation.rs
+++ b/src/v3_2/operation.rs
@@ -1,6 +1,6 @@
 //! Operation Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::common::reference::RefOr;
 use crate::v3_2::callback::Callback;
 use crate::v3_2::external_documentation::ExternalDocumentation;
@@ -11,6 +11,7 @@ use crate::v3_2::server::Server;
 use crate::v3_2::spec::Spec;
 use crate::v3_2::tag::Tag;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -177,9 +178,9 @@ impl ValidateWithContext<Spec> for Operation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_2::response::{Response, Responses};
     use crate::v3_2::tag::Tag;
+    use crate::validation::Context;
 
     fn ok_responses() -> Responses {
         Responses {

--- a/src/v3_2/parameter.rs
+++ b/src/v3_2/parameter.rs
@@ -1,11 +1,12 @@
 //! Describes a single operation parameter.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::common::reference::RefOr;
 use crate::v3_2::example::Example;
 use crate::v3_2::media_type::MediaType;
 use crate::v3_2::schema::Schema;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -608,7 +609,7 @@ fn either_schema_or_content(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
+    use crate::validation::Context;
     use crate::validation::Options;
 
     #[test]

--- a/src/v3_2/path_item.rs
+++ b/src/v3_2/path_item.rs
@@ -1,12 +1,12 @@
 //! Path Items
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_2::operation::Operation;
 use crate::v3_2::parameter::Parameter;
 use crate::v3_2::server::Server;
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/src/v3_2/request_body.rs
+++ b/src/v3_2/request_body.rs
@@ -1,9 +1,9 @@
 //! Request Body Object
 
-use crate::common::helpers::{Context, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_2::media_type::MediaType;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_2/response.rs
+++ b/src/v3_2/response.rs
@@ -1,12 +1,12 @@
 //! Response Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext};
 use crate::common::reference::RefOr;
 use crate::v3_2::header::Header;
 use crate::v3_2::link::Link;
 use crate::v3_2::media_type::MediaType;
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -2,12 +2,13 @@
 
 use crate::common::bool_or::BoolOr;
 use crate::common::formats::{IntegerFormat, NumberFormat, StringFormat};
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_pattern};
+use crate::common::helpers::validate_pattern;
 use crate::common::reference::RefOr;
 use crate::v3_2::discriminator::Discriminator;
 use crate::v3_2::external_documentation::ExternalDocumentation;
 use crate::v3_2::spec::Spec;
 use crate::v3_2::xml::XML;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use monostate::MustBe;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
@@ -2070,8 +2071,7 @@ mod tests {
 
         // Validate is a no-op on Bool.
         let spec = crate::v3_2::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         Schema::Bool(true).validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
@@ -2168,8 +2168,7 @@ mod tests {
                 ..Default::default()
             })),
         ] {
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors
@@ -2202,8 +2201,7 @@ mod tests {
                 ..Default::default()
             }))),
         ] {
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors.iter().any(|e| e.contains("externalDocs.url")),
@@ -2263,8 +2261,7 @@ mod tests {
             ),
         ];
         for (label, schema, needle) in cases {
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             schema.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors.iter().any(|e| e.contains(needle)),
@@ -2286,8 +2283,7 @@ mod tests {
         });
         let s: Schema = serde_json::from_value(json).unwrap();
         let spec = crate::v3_2::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         s.validate_with_context(&mut ctx, "s".into());
         assert!(
             ctx.errors
@@ -2307,8 +2303,7 @@ mod tests {
             (serde_json::json!({"oneOf": []}), "oneOf"),
         ] {
             let s: Schema = serde_json::from_value(json).unwrap();
-            let mut ctx =
-                crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+            let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
                 ctx.errors
@@ -2325,8 +2320,7 @@ mod tests {
         // Build via the struct: `serde_json::from_value` on `{"type": []}`
         // would not route to `MultiSchema`.
         let spec = crate::v3_2::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         let m = MultiSchema {
             schema_types: vec![],
             ..Default::default()
@@ -2356,8 +2350,7 @@ mod tests {
         assert_eq!(serde_json::to_value(&schema).unwrap(), enum_json);
 
         let spec = crate::v3_2::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
 
@@ -2369,8 +2362,7 @@ mod tests {
         let schema: Schema = serde_json::from_value(object_json.clone()).unwrap();
         assert_eq!(serde_json::to_value(&schema).unwrap(), object_json);
 
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "no errors: {:?}", ctx.errors);
     }
@@ -2494,8 +2486,7 @@ mod tests {
     fn empty_schema_validates_clean() {
         let schema = Schema::Empty(EmptySchema);
         let spec = crate::v3_2::spec::Spec::default();
-        let mut ctx =
-            crate::common::helpers::Context::new(&spec, crate::validation::Options::new());
+        let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
         schema.validate_with_context(&mut ctx, "s".into());
         assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }

--- a/src/v3_2/security_scheme.rs
+++ b/src/v3_2/security_scheme.rs
@@ -1,10 +1,10 @@
 //! Security Scheme Object
 
 use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, validate_optional_uri, validate_required_string,
-    validate_required_uri,
+    validate_optional_uri, validate_required_string, validate_required_uri,
 };
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};

--- a/src/v3_2/server.rs
+++ b/src/v3_2/server.rs
@@ -1,8 +1,9 @@
 //! Representing a Server.
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use lazy_regex::regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};

--- a/src/v3_2/spec.rs
+++ b/src/v3_2/spec.rs
@@ -2,10 +2,7 @@
 //!
 //! https://spec.openapis.org/oas/v3.2.0
 
-use crate::common::helpers::{
-    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
-    validate_not_visited,
-};
+use crate::common::helpers::validate_not_visited;
 use crate::common::reference::{RefOr, ResolveReference, resolve_in_map};
 use crate::v3_2::callback::Callback;
 use crate::v3_2::components::Components;
@@ -26,6 +23,9 @@ use crate::v3_2::tag::Tag;
 use crate::v3_2::validation::{
     validate_path_item, validate_path_template_uniqueness, validate_security_requirements,
     validate_tag_uniqueness,
+};
+use crate::validation::{
+    Context, InvalidComponentName, PushError, ValidateWithContext, check_component_name,
 };
 use crate::validation::{Error, Options, Validate};
 use enumset::EnumSet;

--- a/src/v3_2/tag.rs
+++ b/src/v3_2/tag.rs
@@ -1,8 +1,9 @@
 //! Tag Object
 
-use crate::common::helpers::{Context, PushError, ValidateWithContext, validate_required_string};
+use crate::common::helpers::validate_required_string;
 use crate::v3_2::external_documentation::ExternalDocumentation;
 use crate::v3_2::spec::Spec;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/v3_2/validation.rs
+++ b/src/v3_2/validation.rs
@@ -20,7 +20,6 @@
 use lazy_regex::regex;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use crate::common::helpers::{Context, PushError};
 use crate::common::reference::{RefOr, ResolveReference};
 use crate::v3_2::parameter::{InCookie, InHeader, InPath, InQuery, Parameter};
 use crate::v3_2::path_item::PathItem;
@@ -28,6 +27,7 @@ use crate::v3_2::security_scheme::SecurityScheme;
 use crate::v3_2::spec::Spec;
 use crate::v3_2::tag::Tag;
 use crate::validation::Options;
+use crate::validation::{Context, PushError};
 
 /// Result of attempting to resolve a `RefOr<Parameter>` for cross-cutting
 /// validation. The internal/external distinction matters: when
@@ -498,7 +498,6 @@ fn find_path_item_by_ref<'a>(spec: &'a Spec, reference: &str) -> Option<&'a Path
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::helpers::Context;
     use crate::v3_2::components::Components;
     use crate::v3_2::parameter::{InCookie, InHeader, InPath, InQuery};
     use crate::v3_2::security_scheme::{
@@ -506,6 +505,7 @@ mod tests {
         OpenIdConnectSecurityScheme, SecurityScheme,
     };
     use crate::v3_2::spec::Spec;
+    use crate::validation::Context;
 
     fn path_param(name: &str) -> RefOr<Parameter> {
         RefOr::new_item(Parameter::Path(InPath {

--- a/src/v3_2/xml.rs
+++ b/src/v3_2/xml.rs
@@ -1,10 +1,9 @@
 //! XML Object
 
-use crate::common::helpers::{
-    Context, PushError, ValidateWithContext, has_uri_unsafe_bytes, validate_optional_uri,
-};
+use crate::common::helpers::{has_uri_unsafe_bytes, validate_optional_uri};
 use crate::v3_2::spec::Spec;
 use crate::validation::Options;
+use crate::validation::{Context, PushError, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,8 +1,7 @@
 use enumset::{EnumSet, EnumSetType, enum_set};
-use regex::Regex;
+use lazy_regex::{Lazy, Regex};
 use std::collections::HashSet;
 use std::fmt::{self, Display};
-use std::sync::LazyLock;
 use thiserror::Error as ThisError;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -171,7 +170,7 @@ pub struct InvalidComponentName {
 /// Compiled form of [`COMPONENT_NAME_PATTERN`]. Single source of truth
 /// for both [`check_component_name`] and the error display on
 /// [`InvalidComponentName`].
-static COMPONENT_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+static COMPONENT_NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(COMPONENT_NAME_PATTERN).expect("COMPONENT_NAME_PATTERN must be a valid regex")
 });
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,5 +1,5 @@
 use enumset::{EnumSet, EnumSetType, enum_set};
-use lazy_regex::{Lazy, Regex};
+use lazy_regex::regex;
 use std::collections::HashSet;
 use std::fmt::{self, Display};
 use thiserror::Error as ThisError;
@@ -153,31 +153,19 @@ pub trait Validate {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error>;
 }
 
-/// Allowed character set for OpenAPI component / definition map keys.
-/// Mirrors the pattern enforced by `v3_0::Components` / `v3_1::Components`
-/// validators. Used by `Spec::define_*` helpers to surface invalid keys
-/// at insertion time rather than during a later `validate()` pass.
-pub const COMPONENT_NAME_PATTERN: &str = r"^[a-zA-Z0-9.\-_]+$";
-
 /// Returned by `Spec::define_*` helpers when a component name does not
-/// match [`COMPONENT_NAME_PATTERN`].
+/// match `^[a-zA-Z0-9.\-_]+$`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ThisError)]
-#[error("component name {name:?} must match pattern `{COMPONENT_NAME_PATTERN}`")]
+#[error("component name {name:?} must match pattern `^[a-zA-Z0-9.\\-_]+$`")]
 pub struct InvalidComponentName {
     pub name: String,
 }
 
-/// Compiled form of [`COMPONENT_NAME_PATTERN`]. Single source of truth
-/// for both [`check_component_name`] and the error display on
-/// [`InvalidComponentName`].
-static COMPONENT_NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(COMPONENT_NAME_PATTERN).expect("COMPONENT_NAME_PATTERN must be a valid regex")
-});
-
-/// Returns `Ok(())` if `name` matches [`COMPONENT_NAME_PATTERN`],
-/// otherwise an [`InvalidComponentName`] error.
+/// Returns `Ok(())` if `name` matches `^[a-zA-Z0-9.\-_]+$`, otherwise
+/// an [`InvalidComponentName`] error.
 pub fn check_component_name(name: &str) -> Result<(), InvalidComponentName> {
-    if COMPONENT_NAME_REGEX.is_match(name) {
+    let r = regex!(r"^[a-zA-Z0-9.\-_]+$");
+    if r.is_match(name) {
         Ok(())
     } else {
         Err(InvalidComponentName {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,7 +1,8 @@
 use enumset::{EnumSet, EnumSetType, enum_set};
-use lazy_regex::regex;
+use regex::Regex;
 use std::collections::HashSet;
 use std::fmt::{self, Display};
+use std::sync::LazyLock;
 use thiserror::Error as ThisError;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -167,10 +168,17 @@ pub struct InvalidComponentName {
     pub name: String,
 }
 
+/// Compiled form of [`COMPONENT_NAME_PATTERN`]. Single source of truth
+/// for both [`check_component_name`] and the error display on
+/// [`InvalidComponentName`].
+static COMPONENT_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(COMPONENT_NAME_PATTERN).expect("COMPONENT_NAME_PATTERN must be a valid regex")
+});
+
 /// Returns `Ok(())` if `name` matches [`COMPONENT_NAME_PATTERN`],
 /// otherwise an [`InvalidComponentName`] error.
 pub fn check_component_name(name: &str) -> Result<(), InvalidComponentName> {
-    if regex!(r"^[a-zA-Z0-9.\-_]+$").is_match(name) {
+    if COMPONENT_NAME_REGEX.is_match(name) {
         Ok(())
     } else {
         Err(InvalidComponentName {
@@ -250,7 +258,7 @@ impl<T> Context<'_, T> {
 }
 
 impl Context<'_, ()> {
-    pub fn new<T>(spec: &T, options: EnumSet<Options>) -> Context<'_, T> {
+    pub fn new<'a, T>(spec: &'a T, options: EnumSet<Options>) -> Context<'a, T> {
         Context {
             spec,
             visited: HashSet::new(),

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,5 +1,8 @@
 use enumset::{EnumSet, EnumSetType, enum_set};
-use std::fmt::Display;
+use lazy_regex::regex;
+use std::collections::HashSet;
+use std::fmt::{self, Display};
+use thiserror::Error as ThisError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {
@@ -148,4 +151,121 @@ impl Options {
 /// Validates the OpenAPI specification.
 pub trait Validate {
     fn validate(&self, options: EnumSet<Options>) -> Result<(), Error>;
+}
+
+/// Allowed character set for OpenAPI component / definition map keys.
+/// Mirrors the pattern enforced by `v3_0::Components` / `v3_1::Components`
+/// validators. Used by `Spec::define_*` helpers to surface invalid keys
+/// at insertion time rather than during a later `validate()` pass.
+pub const COMPONENT_NAME_PATTERN: &str = r"^[a-zA-Z0-9.\-_]+$";
+
+/// Returned by `Spec::define_*` helpers when a component name does not
+/// match [`COMPONENT_NAME_PATTERN`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ThisError)]
+#[error("component name {name:?} must match pattern `{COMPONENT_NAME_PATTERN}`")]
+pub struct InvalidComponentName {
+    pub name: String,
+}
+
+/// Returns `Ok(())` if `name` matches [`COMPONENT_NAME_PATTERN`],
+/// otherwise an [`InvalidComponentName`] error.
+pub fn check_component_name(name: &str) -> Result<(), InvalidComponentName> {
+    if regex!(r"^[a-zA-Z0-9.\-_]+$").is_match(name) {
+        Ok(())
+    } else {
+        Err(InvalidComponentName {
+            name: name.to_owned(),
+        })
+    }
+}
+
+/// Trait for validating an object with a [`Context`].
+///
+/// Implemented by every component type that participates in spec
+/// validation. Implementors push errors into the context via
+/// [`PushError::error`] and recurse into sub-objects by calling each
+/// child's `validate_with_context`.
+pub trait ValidateWithContext<T> {
+    fn validate_with_context(&self, ctx: &mut Context<T>, path: String);
+}
+
+/// Validation context — carries the spec being validated, accumulated
+/// errors, the per-call options, and a `visited` set used for unused
+/// detection and cycle handling.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Context<'a, T> {
+    pub spec: &'a T,
+    pub visited: HashSet<String>,
+    pub errors: Vec<String>,
+    pub options: EnumSet<Options>,
+}
+
+/// Generic "push an error message into a [`Context`]" trait. The blanket
+/// impls accept `&str`, `String`, and `fmt::Arguments`, so callers can
+/// `ctx.error(path, "literal")`, `ctx.error(path, format!(...))`, or
+/// `ctx.error(path, format_args!(...))` interchangeably.
+pub trait PushError<T> {
+    fn error(&mut self, path: String, args: T);
+}
+
+impl<T> PushError<&str> for Context<'_, T> {
+    fn error(&mut self, path: String, msg: &str) {
+        if msg.starts_with('.') {
+            self.errors.push(format!("{path}{msg}"));
+        } else {
+            self.errors.push(format!("{path}: {msg}"));
+        }
+    }
+}
+
+impl<T> PushError<String> for Context<'_, T> {
+    fn error(&mut self, path: String, msg: String) {
+        self.error(path, msg.as_str());
+    }
+}
+
+impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
+    fn error(&mut self, path: String, args: fmt::Arguments<'_>) {
+        self.error(path, args.to_string().as_str());
+    }
+}
+
+impl<T> Context<'_, T> {
+    pub fn reset(&mut self) {
+        self.visited.clear();
+        self.errors.clear();
+    }
+
+    pub fn visit(&mut self, path: String) -> bool {
+        self.visited.insert(path)
+    }
+
+    pub fn is_visited(&self, path: &str) -> bool {
+        self.visited.contains(path)
+    }
+
+    pub fn is_option(&self, option: Options) -> bool {
+        self.options.contains(option)
+    }
+}
+
+impl Context<'_, ()> {
+    pub fn new<T>(spec: &T, options: EnumSet<Options>) -> Context<'_, T> {
+        Context {
+            spec,
+            visited: HashSet::new(),
+            errors: Vec::new(),
+            options,
+        }
+    }
+}
+
+impl<'a, T> From<Context<'a, T>> for Result<(), Error> {
+    fn from(val: Context<'a, T>) -> Self {
+        if val.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(Error { errors: val.errors })
+        }
+    }
 }


### PR DESCRIPTION
The user-facing parts of the validation framework now live in `crate::validation` next to `Options`, `Validate`, `Error`, and the `IGNORE_*` constants:

- `Context<'a, T>`
- `ValidateWithContext<T>` trait
- `PushError<T>` trait (with blanket `&str` / `String` / `fmt::Arguments` impls)
- `InvalidComponentName` + `check_component_name` (return type of `Spec::define_*`)
- `COMPONENT_NAME_PATTERN`

`crate::common::helpers` is demoted to `pub(crate)` and keeps only the crate-internal validator utility functions (`validate_email`, `validate_optional_url`, `validate_required_url`, `validate_optional_uri`, `validate_required_uri`, `validate_required_string`, `validate_string_matches`, `validate_optional_string_matches`, `validate_pattern`, `validate_unique_by`, `validate_not_visited`, `has_uri_unsafe_bytes`). Those were leaking through `pub mod helpers` despite being internal plumbing.

All in-crate `use crate::common::helpers::{Context, ...}` imports are rewritten to `use crate::validation::{...}`, with mixed imports split into two `use` lines. One fully-qualified `crate::common::helpers::PushError::error(...)` call in `v2::path_item` was repointed at `crate::validation::PushError`.

Externally: anyone implementing `ValidateWithContext<Spec>` for their own extension type (the documented extension path for `RefOr<T>`) now imports from `roas::validation::*` — a more discoverable location than the previous `roas::common::helpers::*`.