### PR TITLE
validation: structured ValidationError replaces Vec<String>

### DIFF
--- a/src/common/helpers.rs
+++ b/src/common/helpers.rs
@@ -191,6 +191,7 @@ pub fn validate_not_visited<T, D>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
 
     #[cfg(any(feature = "v2", feature = "v3_0", feature = "v3_1"))]
     #[test]
@@ -215,7 +216,7 @@ mod tests {
         validate_required_url(&String::from("foo-bar"), &mut ctx, String::from("test_url"));
         assert!(
             ctx.errors
-                .contains(&"test_url: must be a valid URL, found `foo-bar`".to_string()),
+                .has_exact("test_url: must be a valid URL, found `foo-bar`"),
             "expected error: {:?}",
             ctx.errors
         );
@@ -252,7 +253,7 @@ mod tests {
         );
         assert!(
             ctx.errors
-                .contains(&"test_url: must be a valid URL, found `foo-bar`".to_string()),
+                .has_exact("test_url: must be a valid URL, found `foo-bar`"),
             "expected error: {:?}",
             ctx.errors
         );
@@ -273,7 +274,7 @@ mod tests {
             let mut ctx = Context::new(&(), Options::new());
             validate_optional_uri(&Some(s.to_owned()), &mut ctx, "u".to_owned());
             assert!(
-                ctx.errors.iter().any(|e| e.contains("must be a valid URI")),
+                ctx.errors.mentions("must be a valid URI"),
                 "expected error for `{s:?}`: {:?}",
                 ctx.errors
             );

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -613,8 +613,8 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         r.validate_with_context(&mut ctx, "#.x".into());
         assert!(
-            ctx.errors.mentions("not supported")
-                && ctx.errors.mentions("https://example.test/foo.json"),
+            ctx.errors
+                .mentions_all(&["not supported", "https://example.test/foo.json"]),
             "expected `not supported` error, got: {:?}",
             ctx.errors,
         );

--- a/src/common/reference.rs
+++ b/src/common/reference.rs
@@ -373,6 +373,7 @@ where
 mod tests {
     use super::*;
     use crate::loader::{JsonFileFetcher, ResourceFetcher};
+    use crate::validation::ValidationErrorsExt;
     use serde_json::Value;
     use std::fs;
     use url::Url;
@@ -612,8 +613,8 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         r.validate_with_context(&mut ctx, "#.x".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("not supported")
-                && e.contains("https://example.test/foo.json")),
+            ctx.errors.mentions("not supported")
+                && ctx.errors.mentions("https://example.test/foo.json"),
             "expected `not supported` error, got: {:?}",
             ctx.errors,
         );
@@ -639,7 +640,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         r.validate_with_context(&mut ctx, "#.x".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("not found")),
+            ctx.errors.mentions("not found"),
             "expected `not found` error, got: {:?}",
             ctx.errors,
         );
@@ -657,7 +658,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         r.validate_with_context(&mut ctx, "#.x".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            ctx.errors.mentions("must not be empty"),
             "expected recursive `must not be empty` error, got: {:?}",
             ctx.errors,
         );
@@ -670,7 +671,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         r.validate_with_context(&mut ctx, "#.x".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            ctx.errors.mentions("must not be empty"),
             "inline item validation must propagate, got: {:?}",
             ctx.errors,
         );
@@ -702,7 +703,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         Ref::validate_with_context::<FooSpec, Foo>(&r, &mut ctx, "#.x".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            ctx.errors.mentions("must not be empty"),
             "empty `$ref` must error: {:?}",
             ctx.errors,
         );

--- a/src/v2/external_documentation.rs
+++ b/src/v2/external_documentation.rs
@@ -43,6 +43,7 @@ impl ValidateWithContext<Spec> for ExternalDocumentation {
 mod tests {
     use super::*;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_external_documentation_deserialize() {
@@ -101,8 +102,7 @@ mod tests {
         };
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
-            ctx.errors
-                .contains(&"externalDocs.url: must not be empty".to_string()),
+            ctx.errors.has_exact("externalDocs.url: must not be empty"),
             "Validation should fail: {:?}",
             ctx.errors
         );
@@ -115,9 +115,8 @@ mod tests {
         };
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
-            ctx.errors.contains(
-                &"externalDocs.url: must be a valid URL, found `invalid-url`".to_string()
-            ),
+            ctx.errors
+                .has_exact("externalDocs.url: must be a valid URL, found `invalid-url`"),
             "Validation should fail: {:?}",
             ctx.errors
         );

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -667,7 +667,7 @@ impl ValidateWithContext<Spec> for FileParameter {
 
 fn must_be_required(p: &Option<bool>, ctx: &mut Context<Spec>, path: String, name: String) {
     if !p.is_some_and(|x| x) {
-        ctx.errors.push(format!("{path}.{name}: must be required"));
+        ctx.error(format!("{path}.{name}"), "must be required");
     }
 }
 
@@ -678,8 +678,7 @@ fn must_not_allow_empty_value(
     name: String,
 ) {
     if p.is_some_and(|x| x) {
-        ctx.errors
-            .push(format!("{path}.{name}: must not allow empty value"));
+        ctx.error(format!("{path}.{name}"), "must not allow empty value");
     }
 }
 
@@ -709,6 +708,7 @@ mod tests {
     use crate::v2::schema::{Schema, StringSchema};
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     fn ctx() -> Context<'static, Spec> {
@@ -756,7 +756,7 @@ mod tests {
         let mut c = ctx();
         bad.validate_with_context(&mut c, "p".into());
         assert!(
-            c.errors.iter().any(|e| e.contains("must not be empty")),
+            c.errors.mentions("must not be empty"),
             "errors: {:?}",
             c.errors
         );
@@ -830,11 +830,7 @@ mod tests {
         })));
         let mut c = ctx();
         p.validate_with_context(&mut c, "p".into());
-        assert!(
-            c.errors.iter().any(|e| e.contains("pattern")),
-            "errors: {:?}",
-            c.errors
-        );
+        assert!(c.errors.mentions("pattern"), "errors: {:?}", c.errors);
 
         // Each non-string variant — exercise allow-empty-value on each.
         for variant in [
@@ -903,7 +899,7 @@ mod tests {
             let mut c = ctx();
             p.validate_with_context(&mut c, "p".into());
             assert!(
-                c.errors.iter().any(|e| e.contains("must not be empty")),
+                c.errors.mentions("must not be empty"),
                 "errors: {:?}",
                 c.errors
             );
@@ -959,7 +955,7 @@ mod tests {
         let mut c = ctx();
         p.validate_with_context(&mut c, "p".into());
         assert!(
-            c.errors.iter().any(|e| e.contains("must be required")),
+            c.errors.mentions("must be required"),
             "errors: {:?}",
             c.errors
         );
@@ -995,7 +991,7 @@ mod tests {
             let mut c = ctx();
             p.validate_with_context(&mut c, "p".into());
             assert!(
-                c.errors.iter().any(|e| e.contains("must be required")),
+                c.errors.mentions("must be required"),
                 "errors: {:?}",
                 c.errors
             );
@@ -1035,7 +1031,7 @@ mod tests {
             let mut c = ctx();
             p.validate_with_context(&mut c, "p".into());
             assert!(
-                c.errors.iter().any(|e| e.contains("must not be empty")),
+                c.errors.mentions("must not be empty"),
                 "errors: {:?}",
                 c.errors
             );
@@ -1159,7 +1155,7 @@ mod tests {
         let mut c = ctx();
         p.validate_with_context(&mut c, "p".into());
         assert!(
-            c.errors.iter().any(|e| e.contains("p.items.pattern")),
+            c.errors.mentions("p.items.pattern"),
             "errors: {:?}",
             c.errors
         );

--- a/src/v2/parameter.rs
+++ b/src/v2/parameter.rs
@@ -1133,11 +1133,7 @@ mod tests {
         ] {
             let mut c = ctx();
             inner.validate_with_context(&mut c, "p".into());
-            assert!(
-                c.errors.iter().all(|e| !e.contains("`multi`")),
-                "errors: {:?}",
-                c.errors
-            );
+            assert!(!c.errors.mentions("`multi`"), "errors: {:?}", c.errors);
         }
     }
 

--- a/src/v2/path_item.rs
+++ b/src/v2/path_item.rs
@@ -360,6 +360,7 @@ mod tests {
     use crate::v2::items::{Items, StringItem};
     use crate::v2::parameter::{ArrayParameter, InPath};
     use crate::v2::response::{Response, Responses};
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_path_item_deserialize() {
@@ -853,7 +854,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         item.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            ctx.errors.mentions("must not be empty"),
             "errors: {:?}",
             ctx.errors
         );
@@ -921,7 +922,7 @@ mod tests {
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be required")),
+            ctx.errors.mentions("must be required"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v2/response.rs
+++ b/src/v2/response.rs
@@ -217,6 +217,7 @@ mod tests {
     use crate::v2::header::{IntegerHeader, StringHeader};
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use std::collections::BTreeMap;
 
     #[test]
@@ -759,7 +760,7 @@ mod tests {
         Response::default().validate_with_context(&mut ctx, "response".to_owned());
         assert!(
             ctx.errors
-                .contains(&"response.description: must not be empty".to_string()),
+                .has_exact("response.description: must not be empty"),
             "expected error: {:?}",
             ctx.errors
         );

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -917,6 +917,7 @@ impl ValidateWithContext<Spec> for NullSchema {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_single_deserialize() {
@@ -1106,11 +1107,7 @@ mod tests {
         }));
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         s.validate_with_context(&mut ctx, "p".into());
-        assert!(
-            ctx.errors.iter().any(|e| e.contains("pattern")),
-            "errors: {:?}",
-            ctx.errors
-        );
+        assert!(ctx.errors.mentions("pattern"), "errors: {:?}", ctx.errors);
 
         // External docs validation paths
         let ed = crate::v2::external_documentation::ExternalDocumentation {
@@ -1124,7 +1121,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         s.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            ctx.errors.mentions("must be a valid URL"),
             "errors: {:?}",
             ctx.errors
         );
@@ -1152,7 +1149,7 @@ mod tests {
             let mut ctx = Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "p".into());
             assert!(
-                ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+                ctx.errors.mentions("must be a valid URL"),
                 "errors: {:?}",
                 ctx.errors
             );
@@ -1235,7 +1232,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         s.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            ctx.errors.mentions("must be a valid URL"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v2/schema.rs
+++ b/src/v2/schema.rs
@@ -1401,7 +1401,7 @@ mod tests {
         }))
         .validate_with_context(&mut ctx, "s".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("discriminator")),
+            !ctx.errors.mentions("discriminator"),
             "errors: {:?}",
             ctx.errors
         );
@@ -1488,7 +1488,7 @@ mod tests {
         }))
         .validate_with_context(&mut ctx, "s".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("SHOULD NOT")),
+            !ctx.errors.mentions("SHOULD NOT"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v2/security_scheme.rs
+++ b/src/v2/security_scheme.rs
@@ -352,6 +352,7 @@ impl ValidateWithContext<Spec> for OAuth2SecurityScheme {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -656,7 +657,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         s.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            ctx.errors.mentions("must be a valid URL"),
             "errors: {:?}",
             ctx.errors
         );
@@ -796,7 +797,7 @@ mod tests {
         };
         let mut ctx = Context::new(&spec, Options::new());
         s.validate_with_context(&mut ctx, "p".into());
-        assert!(ctx.errors.iter().any(|e| e.contains("must not be empty")));
+        assert!(ctx.errors.mentions("must not be empty"));
     }
 
     #[test]

--- a/src/v2/spec.rs
+++ b/src/v2/spec.rs
@@ -629,6 +629,7 @@ impl ValidateWithContext<Spec> for TagGroup {
 mod tests {
     use super::*;
     use crate::validation::IGNORE_UNUSED;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn validate_with_loader_resolves_external_schema_ref() {
@@ -1121,7 +1122,7 @@ mod tests {
         };
         let err = spec.validate(Options::new(), None).unwrap_err();
         assert!(
-            err.errors.iter().any(|e| e.contains("must start with `/`")),
+            err.errors.mentions("must start with `/`"),
             "errors: {:?}",
             err.errors
         );
@@ -1255,7 +1256,7 @@ mod tests {
         };
         let err = spec.validate(Options::new(), None).unwrap_err();
         assert!(
-            err.errors.iter().any(|e| e.contains("duplicate parameter")),
+            err.errors.mentions("duplicate parameter"),
             "errors: {:?}",
             err.errors
         );

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -403,6 +403,7 @@ mod tests {
     use crate::v2::spec::Spec;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     fn body_param(name: &str) -> RefOr<Parameter> {
         RefOr::new_item(Parameter::Body(Box::new(InBody {
@@ -824,7 +825,7 @@ mod tests {
         validate_security_definitions(&mut ctx);
         // Empty scopes + missing authorizationUrl produce errors from per-scheme validate.
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must not be empty")),
+            ctx.errors.mentions("must not be empty"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v2/validation.rs
+++ b/src/v2/validation.rs
@@ -558,8 +558,8 @@ mod tests {
         let params = vec![path_param("id")];
         validate_operation_parameters(&mut ctx, "op", "/no-vars", None, Some(&params));
         assert!(
-            ctx.errors.iter().any(|e| e
-                .contains("path parameter `id` does not match any `{name}` in the path template")),
+            ctx.errors
+                .mentions("path parameter `id` does not match any `{name}` in the path template"),
             "errors: {:?}",
             ctx.errors
         );
@@ -872,11 +872,7 @@ mod tests {
         let spec: &'static Spec = Box::leak(Box::new(spec));
         let mut ctx = Context::new(spec, Options::IgnoreUnusedSecuritySchemes.only());
         validate_security_definitions(&mut ctx);
-        assert!(
-            ctx.errors.iter().all(|e| !e.contains("unused")),
-            "errors: {:?}",
-            ctx.errors
-        );
+        assert!(!ctx.errors.mentions("unused"), "errors: {:?}", ctx.errors);
     }
 
     #[test]
@@ -893,11 +889,7 @@ mod tests {
         // would do when processing `Spec.security` or operation-level security.
         ctx.visit("#/securityDefinitions/used".to_owned());
         validate_security_definitions(&mut ctx);
-        assert!(
-            ctx.errors.iter().all(|e| !e.contains("unused")),
-            "errors: {:?}",
-            ctx.errors
-        );
+        assert!(!ctx.errors.mentions("unused"), "errors: {:?}", ctx.errors);
     }
 
     #[test]

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -398,7 +398,7 @@ mod tests {
         let mut ctx = Context::new(&spec, opts);
         comp.validate_with_context(&mut ctx, "#.components".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("unused")),
+            !ctx.errors.mentions("unused"),
             "no unused errors when ignored: {:?}",
             ctx.errors
         );

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -215,6 +215,7 @@ mod tests {
         OAuth2SecurityScheme, PasswordOAuth2Flow, SecurityScheme,
     };
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     fn map_with<T>(name: &str, t: T) -> BTreeMap<String, RefOr<T>> {
@@ -423,7 +424,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreUnusedSchemas.only());
         comp.validate_with_context(&mut ctx, "#.components".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must match pattern")),
+            ctx.errors.mentions("must match pattern"),
             "expected pattern error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/example.rs
+++ b/src/v3_0/example.rs
@@ -59,6 +59,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -92,7 +93,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            ctx.errors.mentions("mutually exclusive"),
             "errors: {:?}",
             ctx.errors
         );
@@ -108,7 +109,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URL")),
+            ctx.errors.mentions("must be a valid URL"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/external_documentation.rs
+++ b/src/v3_0/external_documentation.rs
@@ -44,6 +44,7 @@ impl ValidateWithContext<Spec> for ExternalDocumentation {
 mod tests {
     use super::*;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_external_documentation_deserialize() {
@@ -102,8 +103,7 @@ mod tests {
         };
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
-            ctx.errors
-                .contains(&"externalDocs.url: must not be empty".to_string()),
+            ctx.errors.has_exact("externalDocs.url: must not be empty"),
             "Validation should fail: {:?}",
             ctx.errors
         );
@@ -116,9 +116,8 @@ mod tests {
         };
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
-            ctx.errors.contains(
-                &"externalDocs.url: must be a valid URL, found `invalid-url`".to_string()
-            ),
+            ctx.errors
+                .has_exact("externalDocs.url: must be a valid URL, found `invalid-url`"),
             "Validation should fail: {:?}",
             ctx.errors
         );

--- a/src/v3_0/info.rs
+++ b/src/v3_0/info.rs
@@ -205,6 +205,7 @@ impl ValidateWithContext<Spec> for Logo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -640,8 +641,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         Logo::default().validate_with_context(&mut ctx, "logo".to_owned());
         assert!(
-            ctx.errors
-                .contains(&"logo.url: must not be empty".to_owned()),
+            ctx.errors.has_exact("logo.url: must not be empty"),
             "expected empty URL error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -385,7 +385,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "valid ref should not error: {:?}",
             ctx.errors
         );
@@ -488,7 +488,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("external reference")),
+            !ctx.errors.mentions("external reference"),
             "with option, no external error: {:?}",
             ctx.errors
         );
@@ -541,7 +541,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "ref-of-ref should resolve: {:?}",
             ctx.errors
         );
@@ -613,7 +613,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "multi-hop PathItem ref should resolve: {:?}",
             ctx.errors
         );
@@ -723,7 +723,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "with option, no .operationRef error: {:?}",
             ctx.errors
         );
@@ -787,7 +787,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "tilde-encoded ref should resolve: {:?}",
             ctx.errors
         );

--- a/src/v3_0/link.rs
+++ b/src/v3_0/link.rs
@@ -257,6 +257,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -284,7 +285,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            ctx.errors.mentions("mutually exclusive"),
             "errors: {:?}",
             ctx.errors
         );
@@ -368,7 +369,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("server.url")),
+            ctx.errors.mentions("server.url"),
             "expected server.url error: {:?}",
             ctx.errors
         );
@@ -555,7 +556,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("method `post`")),
+            ctx.errors.mentions("method `post`"),
             "expected unknown method on resolved target: {:?}",
             ctx.errors
         );
@@ -710,7 +711,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("external document")),
+            ctx.errors.mentions("external document"),
             "expected external-PathItem-ref error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/media_type.rs
+++ b/src/v3_0/media_type.rs
@@ -211,6 +211,7 @@ mod tests {
     use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -251,7 +252,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "mt".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            ctx.errors.mentions("mutually exclusive"),
             "errors: {:?}",
             ctx.errors
         );
@@ -305,7 +306,7 @@ mod tests {
         mt.validate_with_context(&mut ctx, "mt".into());
         // Should pick up nested example XOR + header example XOR.
         assert!(
-            ctx.errors.iter().any(|e| e.contains("examples[ex1]")),
+            ctx.errors.mentions("examples[ex1]"),
             "expected nested example error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -328,7 +328,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreMissingTags.only());
         op.validate_with_context(&mut ctx, "op".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("not found in spec")),
+            !ctx.errors.mentions("not found in spec"),
             "missing-tags should be silenced: {:?}",
             ctx.errors
         );

--- a/src/v3_0/operation.rs
+++ b/src/v3_0/operation.rs
@@ -255,6 +255,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn validate_walks_tags_servers_external_docs() {
@@ -312,13 +313,13 @@ mod tests {
         );
         // Server URL empty surfaces the per-server validator.
         assert!(
-            ctx.errors.iter().any(|e| e.contains("op.servers[0].url")),
+            ctx.errors.mentions("op.servers[0].url"),
             "errors: {:?}",
             ctx.errors
         );
         // ExternalDocs URL empty surfaces.
         assert!(
-            ctx.errors.iter().any(|e| e.contains("op.externalDocs.url")),
+            ctx.errors.mentions("op.externalDocs.url"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/parameter.rs
+++ b/src/v3_0/parameter.rs
@@ -505,6 +505,7 @@ mod tests {
     use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     fn ok_schema() -> RefOr<Schema> {
@@ -554,7 +555,7 @@ mod tests {
         });
         p.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be required")),
+            ctx.errors.mentions("must be required"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/response.rs
+++ b/src/v3_0/response.rs
@@ -272,6 +272,7 @@ mod tests {
     use super::*;
     use crate::v3_0::parameter::InHeaderStyle;
     use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_response_deserialize() {
@@ -734,7 +735,7 @@ mod tests {
         Response::default().validate_with_context(&mut ctx, "response".to_owned());
         assert!(
             ctx.errors
-                .contains(&"response.description: must not be empty".to_string()),
+                .has_exact("response.description: must not be empty"),
             "expected error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -1427,7 +1427,7 @@ mod tests {
             let mut ctx = Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
-                ctx.errors.iter().all(|e| !e.contains("mutually exclusive")),
+                !ctx.errors.mentions("mutually exclusive"),
                 "single flag should not error: {:?}",
                 ctx.errors
             );

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -1092,6 +1092,7 @@ impl ValidateWithContext<Spec> for NullSchema {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_single_deserialize() {
@@ -1505,7 +1506,7 @@ mod tests {
             let mut ctx = Context::new(&spec, crate::validation::Options::new());
             schema.validate_with_context(&mut ctx, format!("c[{i}]"));
             assert!(
-                ctx.errors.iter().any(|e| e.contains("namespace")),
+                ctx.errors.mentions("namespace"),
                 "case {i}: errors: {:?}",
                 ctx.errors
             );
@@ -1555,7 +1556,7 @@ mod tests {
             let mut ctx = Context::new(&spec, crate::validation::Options::new());
             schema.validate_with_context(&mut ctx, format!("c[{i}]"));
             assert!(
-                ctx.errors.iter().any(|e| e.contains("externalDocs")),
+                ctx.errors.mentions("externalDocs"),
                 "case {i}: errors: {:?}",
                 ctx.errors
             );
@@ -1575,7 +1576,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         s.validate_with_context(&mut ctx, "obj".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("obj.properties.bad")),
+            ctx.errors.mentions("obj.properties.bad"),
             "errors: {:?}",
             ctx.errors
         );
@@ -1634,12 +1635,12 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         composition.validate_with_context(&mut ctx, "s".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("pattern")),
+            ctx.errors.mentions("pattern"),
             "expected nested string pattern error: {:?}",
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("propertyName")),
+            ctx.errors.mentions("propertyName"),
             "expected discriminator empty propertyName: {:?}",
             ctx.errors
         );
@@ -1697,7 +1698,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         parsed.validate_with_context(&mut ctx, "arr".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("arr.items.pattern")),
+            ctx.errors.mentions("arr.items.pattern"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/spec.rs
+++ b/src/v3_0/spec.rs
@@ -802,6 +802,7 @@ impl ValidateWithContext<Spec> for TagGroup {
 mod tests {
     use super::*;
     use crate::validation::IGNORE_UNUSED;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn validate_with_loader_resolves_external_schema_ref() {
@@ -1426,7 +1427,7 @@ mod tests {
         RefOr::<Schema>::new_ref("#/components/schemas/AliasA")
             .validate_with_context(&mut ctx, "#.schema".to_owned());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("not found")),
+            ctx.errors.mentions("not found"),
             "cycle should be reported as an unresolved ref, not recurse: {:?}",
             ctx.errors
         );
@@ -1526,7 +1527,7 @@ mod tests {
         TagGroup::default().validate_with_context(&mut ctx, "#.x-tagGroups[0]".to_owned());
         assert!(
             ctx.errors
-                .contains(&"#.x-tagGroups[0].name: must not be empty".to_owned()),
+                .has_exact("#.x-tagGroups[0].name: must not be empty"),
             "expected name error: {:?}",
             ctx.errors
         );

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -550,8 +550,8 @@ mod tests {
         let params = vec![path_param("id")];
         validate_operation_parameters(&mut ctx, "op", "/no-vars", None, Some(&params));
         assert!(
-            ctx.errors.iter().any(|e| e
-                .contains("path parameter `id` does not match any `{name}` in the path template")),
+            ctx.errors
+                .mentions("path parameter `id` does not match any `{name}` in the path template"),
             "errors: {:?}",
             ctx.errors
         );
@@ -584,7 +584,7 @@ mod tests {
         let mut ctx = Context::new(spec, Options::IgnoreExternalReferences.only());
         validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("template variable")),
+            !ctx.errors.mentions("template variable"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_0/validation.rs
+++ b/src/v3_0/validation.rs
@@ -411,6 +411,7 @@ mod tests {
     use crate::v3_0::spec::Spec;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     fn path_param(name: &str) -> RefOr<Parameter> {
         RefOr::new_item(Parameter::Path(InPath {
@@ -793,7 +794,7 @@ mod tests {
         req.insert("missing".to_owned(), vec![]);
         validate_security_requirements(&mut ctx, "#.security", &[req]);
         assert!(
-            ctx.errors.iter().any(|e| e.contains("not declared")),
+            ctx.errors.mentions("not declared"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_1/components.rs
+++ b/src/v3_1/components.rs
@@ -229,6 +229,7 @@ mod tests {
         OAuth2SecurityScheme, PasswordOAuth2Flow,
     };
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     fn map_with<T>(name: &str, t: T) -> BTreeMap<String, RefOr<T>> {
@@ -491,7 +492,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreUnusedSchemas.only());
         comp.validate_with_context(&mut ctx, "#.components".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must match pattern")),
+            ctx.errors.mentions("must match pattern"),
             "expected pattern error: {:?}",
             ctx.errors
         );

--- a/src/v3_1/components.rs
+++ b/src/v3_1/components.rs
@@ -466,7 +466,7 @@ mod tests {
         let mut ctx = Context::new(&spec, opts);
         comp.validate_with_context(&mut ctx, "#.components".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("unused")),
+            !ctx.errors.mentions("unused"),
             "no unused errors when ignored: {:?}",
             ctx.errors
         );

--- a/src/v3_1/discriminator.rs
+++ b/src/v3_1/discriminator.rs
@@ -59,6 +59,7 @@ mod tests {
     use crate::v3_1::schema::{ObjectSchema, SingleSchema};
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn round_trip_with_mapping() {
@@ -104,7 +105,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         d.validate_with_context(&mut ctx, "d".to_owned());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("Missing")),
+            ctx.errors.mentions("Missing"),
             "expected missing schema error: {:?}",
             ctx.errors
         );

--- a/src/v3_1/example.rs
+++ b/src/v3_1/example.rs
@@ -59,6 +59,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -72,7 +73,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            ctx.errors.mentions("mutually exclusive"),
             "errors: {:?}",
             ctx.errors
         );
@@ -104,7 +105,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URI")),
+            ctx.errors.mentions("must be a valid URI"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_1/external_documentation.rs
+++ b/src/v3_1/external_documentation.rs
@@ -55,6 +55,7 @@ impl ValidateWithContext<Spec> for ExternalDocumentation {
 mod tests {
     use super::*;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_external_documentation_deserialize() {
@@ -113,8 +114,7 @@ mod tests {
         };
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
-            ctx.errors
-                .contains(&"externalDocs.url: must not be empty".to_string()),
+            ctx.errors.has_exact("externalDocs.url: must not be empty"),
             "Validation should fail: {:?}",
             ctx.errors
         );
@@ -130,7 +130,7 @@ mod tests {
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
             ctx.errors
-                .contains(&"externalDocs.url: must be a valid URI, found `not a uri`".to_string()),
+                .has_exact("externalDocs.url: must be a valid URI, found `not a uri`"),
             "Validation should fail: {:?}",
             ctx.errors
         );

--- a/src/v3_1/header.rs
+++ b/src/v3_1/header.rs
@@ -119,6 +119,7 @@ impl ValidateWithContext<Spec> for Header {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_header_deserialize() {
@@ -202,7 +203,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "h".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("h.schema")),
+            ctx.errors.mentions("h.schema"),
             "expected h.schema error: {:?}",
             ctx.errors
         );

--- a/src/v3_1/link.rs
+++ b/src/v3_1/link.rs
@@ -537,6 +537,7 @@ mod tests {
     use crate::v3_1::path_item::{PathItem, Paths};
     use crate::v3_1::response::{Response, Responses};
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     fn spec_with_pets_get() -> Spec {
@@ -592,7 +593,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            ctx.errors.mentions("mutually exclusive"),
             "errors: {:?}",
             ctx.errors
         );
@@ -674,7 +675,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("method `post`")),
+            ctx.errors.mentions("method `post`"),
             "errors: {:?}",
             ctx.errors
         );
@@ -904,7 +905,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("cyclic `$ref` chain")),
+            ctx.errors.mentions("cyclic `$ref` chain"),
             "expected cycle error: {:?}",
             ctx.errors
         );
@@ -1331,7 +1332,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("server.url")),
+            ctx.errors.mentions("server.url"),
             "expected server.url error: {:?}",
             ctx.errors
         );

--- a/src/v3_1/link.rs
+++ b/src/v3_1/link.rs
@@ -641,7 +641,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "valid ref should not error: {:?}",
             ctx.errors
         );
@@ -741,7 +741,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("external reference")),
+            !ctx.errors.mentions("external reference"),
             "with option: {:?}",
             ctx.errors
         );
@@ -813,7 +813,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "components.pathItems target should resolve: {:?}",
             ctx.errors
         );
@@ -836,7 +836,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "webhook target should resolve: {:?}",
             ctx.errors
         );
@@ -871,7 +871,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "cross-container chain should resolve: {:?}",
             ctx.errors
         );
@@ -966,7 +966,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "callback target should resolve: {:?}",
             ctx.errors
         );
@@ -1059,7 +1059,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "deep callback target should resolve: {:?}",
             ctx.errors
         );
@@ -1162,7 +1162,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "callback with `/` in name should resolve via `~1`: {:?}",
             ctx.errors
         );
@@ -1206,7 +1206,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "chain through components.callbacks must resolve: {:?}",
             ctx.errors
         );
@@ -1307,12 +1307,12 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("cyclic")),
+            !ctx.errors.mentions("cyclic"),
             "cross-container same-key must not be flagged as cycle: {:?}",
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "operationRef should resolve: {:?}",
             ctx.errors
         );

--- a/src/v3_1/media_type.rs
+++ b/src/v3_1/media_type.rs
@@ -211,6 +211,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn media_type_round_trip_full() {
@@ -287,7 +288,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         mt.validate_with_context(&mut ctx, "mt".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("examples[ex1]")),
+            ctx.errors.mentions("examples[ex1]"),
             "expected nested example error: {:?}",
             ctx.errors
         );

--- a/src/v3_1/operation.rs
+++ b/src/v3_1/operation.rs
@@ -315,7 +315,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreMissingTags.only());
         op.validate_with_context(&mut ctx, "op".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("not found in spec")),
+            !ctx.errors.mentions("not found in spec"),
             "missing-tags should be silenced: {:?}",
             ctx.errors
         );

--- a/src/v3_1/operation.rs
+++ b/src/v3_1/operation.rs
@@ -230,6 +230,7 @@ mod tests {
     use crate::v3_1::response::{Response, Responses};
     use crate::v3_1::tag::Tag;
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
 
     fn ok_responses() -> Responses {
         Responses {
@@ -300,12 +301,12 @@ mod tests {
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("op.servers[0].url")),
+            ctx.errors.mentions("op.servers[0].url"),
             "server.url: {:?}",
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("op.externalDocs.url")),
+            ctx.errors.mentions("op.externalDocs.url"),
             "externalDocs.url: {:?}",
             ctx.errors
         );

--- a/src/v3_1/parameter.rs
+++ b/src/v3_1/parameter.rs
@@ -530,6 +530,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn validate_path_param_must_be_required() {
@@ -554,7 +555,7 @@ mod tests {
         });
         p.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be required")),
+            ctx.errors.mentions("must be required"),
             "errors: {:?}",
             ctx.errors
         );
@@ -642,12 +643,12 @@ mod tests {
         });
         p.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("p.schema")),
+            ctx.errors.mentions("p.schema"),
             "expected p.schema error: {:?}",
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("p.examples[ex]")),
+            ctx.errors.mentions("p.examples[ex]"),
             "expected p.examples[ex] error: {:?}",
             ctx.errors
         );

--- a/src/v3_1/path_item.rs
+++ b/src/v3_1/path_item.rs
@@ -477,6 +477,7 @@ impl<'de> Deserialize<'de> for Paths {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -550,7 +551,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         pi.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("external reference")),
+            ctx.errors.mentions("external reference"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_1/path_item.rs
+++ b/src/v3_1/path_item.rs
@@ -558,7 +558,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreExternalReferences.only());
         pi.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("external reference")),
+            !ctx.errors.mentions("external reference"),
             "errors: {:?}",
             ctx.errors
         );
@@ -650,7 +650,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         pi.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("not declared")),
+            !ctx.errors.mentions("not declared"),
             "callback path-item target should resolve: {:?}",
             ctx.errors
         );
@@ -703,7 +703,7 @@ mod tests {
             let mut ctx = Context::new(&spec, crate::validation::Options::new());
             pi.validate_with_context(&mut ctx, "p".into());
             assert!(
-                ctx.errors.iter().all(|e| !e.contains("not declared")),
+                !ctx.errors.mentions("not declared"),
                 "{r} should resolve: {:?}",
                 ctx.errors
             );

--- a/src/v3_1/response.rs
+++ b/src/v3_1/response.rs
@@ -273,6 +273,7 @@ mod tests {
     use super::*;
     use crate::v3_1::parameter::InHeaderStyle;
     use crate::v3_1::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_response_deserialize() {
@@ -730,7 +731,7 @@ mod tests {
         Response::default().validate_with_context(&mut ctx, "response".to_owned());
         assert!(
             ctx.errors
-                .contains(&"response.description: must not be empty".to_string()),
+                .has_exact("response.description: must not be empty"),
             "expected error: {:?}",
             ctx.errors
         );

--- a/src/v3_1/schema.rs
+++ b/src/v3_1/schema.rs
@@ -1550,6 +1550,7 @@ mod extensions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_single_deserialize() {
@@ -2278,7 +2279,7 @@ mod tests {
             let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
-                ctx.errors.iter().any(|e| e.contains("externalDocs.url")),
+                ctx.errors.mentions("externalDocs.url"),
                 "expected externalDocs walk: {:?}",
                 ctx.errors
             );
@@ -2338,7 +2339,7 @@ mod tests {
             let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             schema.validate_with_context(&mut ctx, "s".into());
             assert!(
-                ctx.errors.iter().any(|e| e.contains(needle)),
+                ctx.errors.mentions(needle),
                 "case `{label}`: expected `{needle}` error: {:?}",
                 ctx.errors
             );

--- a/src/v3_1/validation.rs
+++ b/src/v3_1/validation.rs
@@ -470,6 +470,7 @@ mod tests {
     };
     use crate::v3_1::spec::Spec;
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
 
     fn path_param(name: &str) -> RefOr<Parameter> {
         RefOr::new_item(Parameter::Path(InPath {
@@ -759,7 +760,7 @@ mod tests {
         req.insert("missing".to_owned(), vec![]);
         validate_security_requirements(&mut ctx, "#.security", &[req]);
         assert!(
-            ctx.errors.iter().any(|e| e.contains("not declared")),
+            ctx.errors.mentions("not declared"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_1/validation.rs
+++ b/src/v3_1/validation.rs
@@ -594,8 +594,8 @@ mod tests {
         let params = vec![path_param("id")];
         validate_operation_parameters(&mut ctx, "op", "/no-vars", None, Some(&params));
         assert!(
-            ctx.errors.iter().any(|e| e
-                .contains("path parameter `id` does not match any `{name}` in the path template")),
+            ctx.errors
+                .mentions("path parameter `id` does not match any `{name}` in the path template"),
             "errors: {:?}",
             ctx.errors
         );
@@ -786,7 +786,7 @@ mod tests {
         let mut ctx = Context::new(spec, Options::IgnoreExternalReferences.only());
         validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("template variable")),
+            !ctx.errors.mentions("template variable"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_1/xml.rs
+++ b/src/v3_1/xml.rs
@@ -150,6 +150,7 @@ impl ValidateWithContext<Spec> for XML {
 mod tests {
     use super::*;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn serialize() {
@@ -260,7 +261,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "xml".to_owned());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URI")),
+            ctx.errors.mentions("must be a valid URI"),
             "invalid URI: {:?}",
             ctx.errors
         );

--- a/src/v3_2/components.rs
+++ b/src/v3_2/components.rs
@@ -553,7 +553,7 @@ mod tests {
         let mut ctx = Context::new(&spec, opts);
         comp.validate_with_context(&mut ctx, "#.components".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("unused")),
+            !ctx.errors.mentions("unused"),
             "no unused errors when ignored: {:?}",
             ctx.errors
         );

--- a/src/v3_2/components.rs
+++ b/src/v3_2/components.rs
@@ -247,6 +247,7 @@ mod tests {
         OAuth2SecurityScheme, PasswordOAuth2Flow,
     };
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     fn map_with<T>(name: &str, t: T) -> BTreeMap<String, RefOr<T>> {
@@ -578,7 +579,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreUnusedSchemas.only());
         comp.validate_with_context(&mut ctx, "#.components".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must match pattern")),
+            ctx.errors.mentions("must match pattern"),
             "expected pattern error: {:?}",
             ctx.errors
         );

--- a/src/v3_2/discriminator.rs
+++ b/src/v3_2/discriminator.rs
@@ -69,6 +69,7 @@ mod tests {
     use crate::v3_2::schema::{ObjectSchema, SingleSchema};
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn round_trip_with_mapping() {
@@ -115,7 +116,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         d.validate_with_context(&mut ctx, "d".to_owned());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("Missing")),
+            ctx.errors.mentions("Missing"),
             "expected missing schema error: {:?}",
             ctx.errors
         );

--- a/src/v3_2/example.rs
+++ b/src/v3_2/example.rs
@@ -237,7 +237,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("mutually exclusive")),
+            !ctx.errors.mentions("mutually exclusive"),
             "dataValue + serializedValue should be permitted: {:?}",
             ctx.errors
         );
@@ -251,7 +251,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("mutually exclusive")),
+            !ctx.errors.mentions("mutually exclusive"),
             "dataValue + externalValue should be permitted: {:?}",
             ctx.errors
         );

--- a/src/v3_2/example.rs
+++ b/src/v3_2/example.rs
@@ -109,6 +109,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -122,7 +123,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            ctx.errors.mentions("mutually exclusive"),
             "errors: {:?}",
             ctx.errors
         );
@@ -158,7 +159,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "ex".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("must be a valid URI")),
+            ctx.errors.mentions("must be a valid URI"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_2/external_documentation.rs
+++ b/src/v3_2/external_documentation.rs
@@ -55,6 +55,7 @@ impl ValidateWithContext<Spec> for ExternalDocumentation {
 mod tests {
     use super::*;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_external_documentation_deserialize() {
@@ -113,8 +114,7 @@ mod tests {
         };
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
-            ctx.errors
-                .contains(&"externalDocs.url: must not be empty".to_string()),
+            ctx.errors.has_exact("externalDocs.url: must not be empty"),
             "Validation should fail: {:?}",
             ctx.errors
         );
@@ -131,7 +131,7 @@ mod tests {
         ed.validate_with_context(&mut ctx, String::from("externalDocs"));
         assert!(
             ctx.errors
-                .contains(&"externalDocs.url: must be a valid URI, found `not a uri`".to_string()),
+                .has_exact("externalDocs.url: must be a valid URI, found `not a uri`"),
             "Validation should fail: {:?}",
             ctx.errors
         );

--- a/src/v3_2/header.rs
+++ b/src/v3_2/header.rs
@@ -119,6 +119,7 @@ impl ValidateWithContext<Spec> for Header {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_header_deserialize() {
@@ -202,7 +203,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "h".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("h.schema")),
+            ctx.errors.mentions("h.schema"),
             "expected h.schema error: {:?}",
             ctx.errors
         );

--- a/src/v3_2/link.rs
+++ b/src/v3_2/link.rs
@@ -537,6 +537,7 @@ mod tests {
     use crate::v3_2::path_item::{PathItem, Paths};
     use crate::v3_2::response::{Response, Responses};
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     fn spec_with_pets_get() -> Spec {
@@ -592,7 +593,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("mutually exclusive")),
+            ctx.errors.mentions("mutually exclusive"),
             "errors: {:?}",
             ctx.errors
         );
@@ -674,7 +675,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("method `post`")),
+            ctx.errors.mentions("method `post`"),
             "errors: {:?}",
             ctx.errors
         );
@@ -904,7 +905,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("cyclic `$ref` chain")),
+            ctx.errors.mentions("cyclic `$ref` chain"),
             "expected cycle error: {:?}",
             ctx.errors
         );
@@ -1331,7 +1332,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("server.url")),
+            ctx.errors.mentions("server.url"),
             "expected server.url error: {:?}",
             ctx.errors
         );

--- a/src/v3_2/link.rs
+++ b/src/v3_2/link.rs
@@ -641,7 +641,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "valid ref should not error: {:?}",
             ctx.errors
         );
@@ -741,7 +741,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("external reference")),
+            !ctx.errors.mentions("external reference"),
             "with option: {:?}",
             ctx.errors
         );
@@ -813,7 +813,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "components.pathItems target should resolve: {:?}",
             ctx.errors
         );
@@ -836,7 +836,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "webhook target should resolve: {:?}",
             ctx.errors
         );
@@ -871,7 +871,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "cross-container chain should resolve: {:?}",
             ctx.errors
         );
@@ -966,7 +966,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "callback target should resolve: {:?}",
             ctx.errors
         );
@@ -1059,7 +1059,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "deep callback target should resolve: {:?}",
             ctx.errors
         );
@@ -1162,7 +1162,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "callback with `/` in name should resolve via `~1`: {:?}",
             ctx.errors
         );
@@ -1206,7 +1206,7 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "chain through components.callbacks must resolve: {:?}",
             ctx.errors
         );
@@ -1307,12 +1307,12 @@ mod tests {
         }
         .validate_with_context(&mut ctx, "l".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("cyclic")),
+            !ctx.errors.mentions("cyclic"),
             "cross-container same-key must not be flagged as cycle: {:?}",
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".operationRef")),
+            !ctx.errors.mentions(".operationRef"),
             "operationRef should resolve: {:?}",
             ctx.errors
         );

--- a/src/v3_2/media_type.rs
+++ b/src/v3_2/media_type.rs
@@ -304,6 +304,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn media_type_round_trip_full() {
@@ -387,7 +388,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         mt.validate_with_context(&mut ctx, "mt".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("examples[ex1]")),
+            ctx.errors.mentions("examples[ex1]"),
             "expected nested example error: {:?}",
             ctx.errors
         );

--- a/src/v3_2/operation.rs
+++ b/src/v3_2/operation.rs
@@ -204,7 +204,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         Operation::default().validate_with_context(&mut ctx, "op".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains(".responses")),
+            !ctx.errors.mentions(".responses"),
             "no responses errors expected: {:?}",
             ctx.errors
         );
@@ -266,7 +266,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreMissingTags.only());
         op.validate_with_context(&mut ctx, "op".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("not found in spec")),
+            !ctx.errors.mentions("not found in spec"),
             "missing-tags should be silenced: {:?}",
             ctx.errors
         );

--- a/src/v3_2/operation.rs
+++ b/src/v3_2/operation.rs
@@ -181,6 +181,7 @@ mod tests {
     use crate::v3_2::response::{Response, Responses};
     use crate::v3_2::tag::Tag;
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
 
     fn ok_responses() -> Responses {
         Responses {
@@ -251,12 +252,12 @@ mod tests {
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("op.servers[0].url")),
+            ctx.errors.mentions("op.servers[0].url"),
             "server.url: {:?}",
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("op.externalDocs.url")),
+            ctx.errors.mentions("op.externalDocs.url"),
             "externalDocs.url: {:?}",
             ctx.errors
         );

--- a/src/v3_2/parameter.rs
+++ b/src/v3_2/parameter.rs
@@ -636,10 +636,8 @@ mod tests {
         });
         p.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.mentions("p.required")
-                && ctx
-                    .errors
-                    .mentions("must be `true` for `in: path` parameters"),
+            ctx.errors
+                .mentions_all(&["p.required", "must be `true` for `in: path` parameters",]),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_2/parameter.rs
+++ b/src/v3_2/parameter.rs
@@ -611,6 +611,7 @@ mod tests {
     use super::*;
     use crate::validation::Context;
     use crate::validation::Options;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn validate_path_param_must_be_required() {
@@ -635,8 +636,10 @@ mod tests {
         });
         p.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("p.required")
-                && e.contains("must be `true` for `in: path` parameters")),
+            ctx.errors.mentions("p.required")
+                && ctx
+                    .errors
+                    .mentions("must be `true` for `in: path` parameters"),
             "errors: {:?}",
             ctx.errors
         );
@@ -730,12 +733,12 @@ mod tests {
         });
         p.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("p.schema")),
+            ctx.errors.mentions("p.schema"),
             "expected p.schema error: {:?}",
             ctx.errors
         );
         assert!(
-            ctx.errors.iter().any(|e| e.contains("p.examples[ex]")),
+            ctx.errors.mentions("p.examples[ex]"),
             "expected p.examples[ex] error: {:?}",
             ctx.errors
         );

--- a/src/v3_2/path_item.rs
+++ b/src/v3_2/path_item.rs
@@ -600,7 +600,7 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::IgnoreExternalReferences.only());
         pi.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("external reference")),
+            !ctx.errors.mentions("external reference"),
             "errors: {:?}",
             ctx.errors
         );
@@ -692,7 +692,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         pi.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("not declared")),
+            !ctx.errors.mentions("not declared"),
             "callback path-item target should resolve: {:?}",
             ctx.errors
         );
@@ -745,7 +745,7 @@ mod tests {
             let mut ctx = Context::new(&spec, crate::validation::Options::new());
             pi.validate_with_context(&mut ctx, "p".into());
             assert!(
-                ctx.errors.iter().all(|e| !e.contains("not declared")),
+                !ctx.errors.mentions("not declared"),
                 "{r} should resolve: {:?}",
                 ctx.errors
             );

--- a/src/v3_2/path_item.rs
+++ b/src/v3_2/path_item.rs
@@ -519,6 +519,7 @@ impl<'de> Deserialize<'de> for Paths {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
     use serde_json::json;
 
     #[test]
@@ -592,7 +593,7 @@ mod tests {
         let mut ctx = Context::new(&spec, crate::validation::Options::new());
         pi.validate_with_context(&mut ctx, "p".into());
         assert!(
-            ctx.errors.iter().any(|e| e.contains("external reference")),
+            ctx.errors.mentions("external reference"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_2/response.rs
+++ b/src/v3_2/response.rs
@@ -283,6 +283,7 @@ mod tests {
     use super::*;
     use crate::v3_2::parameter::InHeaderStyle;
     use crate::v3_2::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_response_deserialize() {
@@ -760,7 +761,7 @@ mod tests {
         .validate_with_context(&mut ctx, "response".to_owned());
         assert!(
             ctx.errors
-                .contains(&"response.description: must not be empty".to_string()),
+                .has_exact("response.description: must not be empty"),
             "expected error: {:?}",
             ctx.errors
         );

--- a/src/v3_2/schema.rs
+++ b/src/v3_2/schema.rs
@@ -1476,6 +1476,7 @@ mod extensions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::ValidationErrorsExt;
 
     #[test]
     fn test_single_deserialize() {
@@ -2204,7 +2205,7 @@ mod tests {
             let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             s.validate_with_context(&mut ctx, "s".into());
             assert!(
-                ctx.errors.iter().any(|e| e.contains("externalDocs.url")),
+                ctx.errors.mentions("externalDocs.url"),
                 "expected externalDocs walk: {:?}",
                 ctx.errors
             );
@@ -2264,7 +2265,7 @@ mod tests {
             let mut ctx = crate::validation::Context::new(&spec, crate::validation::Options::new());
             schema.validate_with_context(&mut ctx, "s".into());
             assert!(
-                ctx.errors.iter().any(|e| e.contains(needle)),
+                ctx.errors.mentions(needle),
                 "case `{label}`: expected `{needle}` error: {:?}",
                 ctx.errors
             );

--- a/src/v3_2/validation.rs
+++ b/src/v3_2/validation.rs
@@ -506,6 +506,7 @@ mod tests {
     };
     use crate::v3_2::spec::Spec;
     use crate::validation::Context;
+    use crate::validation::ValidationErrorsExt;
 
     fn path_param(name: &str) -> RefOr<Parameter> {
         RefOr::new_item(Parameter::Path(InPath {
@@ -798,7 +799,7 @@ mod tests {
         req.insert("missing".to_owned(), vec![]);
         validate_security_requirements(&mut ctx, "#.security", &[req]);
         assert!(
-            ctx.errors.iter().any(|e| e.contains("not declared")),
+            ctx.errors.mentions("not declared"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/v3_2/validation.rs
+++ b/src/v3_2/validation.rs
@@ -630,8 +630,8 @@ mod tests {
         let params = vec![path_param("id")];
         validate_operation_parameters(&mut ctx, "op", "/no-vars", None, Some(&params));
         assert!(
-            ctx.errors.iter().any(|e| e
-                .contains("path parameter `id` does not match any `{name}` in the path template")),
+            ctx.errors
+                .mentions("path parameter `id` does not match any `{name}` in the path template"),
             "errors: {:?}",
             ctx.errors
         );
@@ -825,7 +825,7 @@ mod tests {
         let mut ctx = Context::new(spec, Options::IgnoreExternalReferences.only());
         validate_operation_parameters(&mut ctx, "op", "/users/{id}", None, Some(&params));
         assert!(
-            ctx.errors.iter().all(|e| !e.contains("template variable")),
+            !ctx.errors.mentions("template variable"),
             "errors: {:?}",
             ctx.errors
         );

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -163,7 +163,12 @@ impl ValidationErrorsExt for [ValidationError] {
     }
 
     fn has_exact(&self, expected: &str) -> bool {
-        self.iter().any(|e| *e == expected)
+        // UFCS to make it explicit we're calling the `PartialEq<str>`
+        // impl on a `&ValidationError`, not auto-deref'ing through
+        // `*e` (which compiles via auto-ref but reads as if we were
+        // moving the element out of the slice).
+        self.iter()
+            .any(|e| <ValidationError as PartialEq<str>>::eq(e, expected))
     }
 }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -447,17 +447,17 @@ pub(crate) trait PushError<T> {
 
 impl<T> PushError<&str> for Context<'_, T> {
     fn error(&mut self, path: String, msg: &str) {
-        // `&str` is the only overload that has to materialise an
-        // owned `String` for the message; the other two already own
-        // theirs and call into `push_owned` directly.
-        self.errors
-            .push(make_validation_error(path, msg.to_owned()));
+        // Stay on `&str` so the no-split path allocates exactly once
+        // (for the message), and the split path allocates exactly
+        // once (for the tail) — never both.
+        self.errors.push(make_validation_error_from_str(path, msg));
     }
 }
 
 impl<T> PushError<String> for Context<'_, T> {
     fn error(&mut self, path: String, msg: String) {
-        self.errors.push(make_validation_error(path, msg));
+        self.errors
+            .push(make_validation_error_from_string(path, msg));
     }
 }
 
@@ -467,60 +467,60 @@ impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
         // once; we then move it into `ValidationError` (via the
         // splitter) without copying again.
         self.errors
-            .push(make_validation_error(path, args.to_string()));
+            .push(make_validation_error_from_string(path, args.to_string()));
     }
 }
 
-/// Build a `ValidationError`, normalising the recursive validators'
-/// leading-dot convention into the structured shape.
+/// Build a `ValidationError` from an owned `String` message,
+/// normalising the recursive validators' leading-dot convention into
+/// the structured shape (see [`split_leading_dot`] for the contract).
 ///
-/// Many call sites push a message of the form `".<segment>: <text>"`,
-/// where the `.<segment>` is intended as a *path extension* relative
-/// to the parent's path and `<text>` is the actual diagnostic. With
-/// the pre-refactor `Vec<String>` shape that was rendered correctly
-/// by concatenation; with the structured shape it would leak the
-/// path-extension marker into `message`, breaking programmatic
-/// callers that filter by `.path` or render `.message` alone.
+/// In the common (no-split) path the message moves into the result
+/// without any extra allocation. The leading-dot path allocates a
+/// fresh `String` for the trimmed tail — we can't shrink an owned
+/// `String` from the front cheaply, so the original allocation is
+/// thrown away in that branch.
+fn make_validation_error_from_string(mut path: String, msg: String) -> ValidationError {
+    if let Some((segment, tail)) = split_leading_dot(&msg) {
+        path.push_str(segment);
+        return ValidationError::new(path, tail.to_owned());
+    }
+    ValidationError::new(path, msg)
+}
+
+/// Build a `ValidationError` from a borrowed `&str` message. Equivalent
+/// to [`make_validation_error_from_string`] but allocates only the
+/// piece it actually needs (whole message, or just the tail) — so a
+/// leading-dot push from a `&str` literal pays one allocation, not
+/// two.
+fn make_validation_error_from_str(mut path: String, msg: &str) -> ValidationError {
+    if let Some((segment, tail)) = split_leading_dot(msg) {
+        path.push_str(segment);
+        return ValidationError::new(path, tail.to_owned());
+    }
+    ValidationError::new(path, msg.to_owned())
+}
+
+/// Inspect `msg` for the leading-dot path-extension convention. If
+/// `msg` starts with `.` AND contains `": "`, returns the path
+/// extension (`".<segment>"`, including the leading dot) and the
+/// remaining diagnostic text. Returns `None` otherwise, in which case
+/// callers should store the message verbatim.
 ///
-/// This builder recognises that convention:
-///
-/// * If `msg` starts with `.` AND contains `": "`, the segment up to
-///   `": "` is appended to `path` and the text after `": "` becomes
-///   the message — so `path = "#.x"`, `msg = ".allOf: must not be
-///   empty"` becomes `path = "#.x.allOf"`, `message = "must not be
-///   empty"`.
-/// * Otherwise the inputs are stored verbatim.
-///
-/// Either way the [`ValidationError::Display`] output is identical to
-/// the pre-refactor rendering.
-///
-/// Both arguments are taken by value: the `path` and the `message`
-/// each move into the final `ValidationError` without any extra
-/// allocation in the normal path. The leading-dot fast path does
-/// allocate a small `String` for the trimmed tail, since the message
-/// has to drop a prefix and we can't shrink an owned `String` in
-/// place without an unsafe split — that's the rare branch and not on
-/// any hot path.
-fn make_validation_error(mut path: String, msg: String) -> ValidationError {
+/// Example: `msg = ".allOf: must not be empty"` →
+/// `Some((".allOf", "must not be empty"))`.
+fn split_leading_dot(msg: &str) -> Option<(&str, &str)> {
     if msg.starts_with('.')
         && let Some(sep_at) = msg[1..].find(": ")
     {
         // `sep_at` is measured from index 1 (after the leading `.`).
-        // Segment runs `1..1+sep_at`; separator is at `1+sep_at..1+sep_at+2`;
-        // tail starts at `1+sep_at+2`.
+        // `.<segment>` runs `0..1+sep_at`; separator is at
+        // `1+sep_at..1+sep_at+2`; tail starts at `1+sep_at+2`.
         let segment_end = 1 + sep_at;
         let tail_start = segment_end + 2;
-        // Append `.<segment>` to `path`. `&msg[..segment_end]` is
-        // `".<segment>"`, which already starts with the dot we need.
-        path.push_str(&msg[..segment_end]);
-        // Move the tail into a fresh String. (We can't shrink `msg`
-        // from the front cheaply; the cost is one allocation in this
-        // rare path.)
-        let message = msg[tail_start..].to_owned();
-        return ValidationError::new(path, message);
+        return Some((&msg[..segment_end], &msg[tail_start..]));
     }
-    // Common path: no leading dot, no split — move both arguments in.
-    ValidationError::new(path, msg)
+    None
 }
 
 impl<T> Context<'_, T> {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -119,9 +119,14 @@ pub struct Error {
 
 /// Convenience predicates over a collection of [`ValidationError`]s.
 ///
-/// Implemented for both [`Error`] (which owns the full report after
-/// [`Validate::validate`] returns) and `Vec<ValidationError>` (which
-/// the in-progress recursive validators accumulate as `ctx.errors`).
+/// Implemented for [`Error`] (the full report after
+/// [`Validate::validate`] returns), `Vec<ValidationError>` (which the
+/// in-progress recursive validators accumulate as `ctx.errors`), and
+/// `[ValidationError]` slices. Method calls on `Vec` work via the
+/// slice impl through auto-deref; the explicit `Vec` impl is also
+/// provided so the type satisfies `T: ValidationErrorsExt` bounds in
+/// generic downstream code.
+///
 /// Lets callers and tests query a report with a single method call
 /// instead of repeating `iter().any(|e| ...)`.
 ///
@@ -159,6 +164,24 @@ impl ValidationErrorsExt for [ValidationError] {
 
     fn has_exact(&self, expected: &str) -> bool {
         self.iter().any(|e| *e == expected)
+    }
+}
+
+// Explicit `Vec` impl so `Vec<ValidationError>` satisfies
+// `T: ValidationErrorsExt` bounds (the slice impl is reached via
+// auto-deref for direct method calls, but trait-bound resolution
+// needs the impl on the nominal type).
+impl ValidationErrorsExt for Vec<ValidationError> {
+    fn mentions(&self, needle: &str) -> bool {
+        self.as_slice().mentions(needle)
+    }
+
+    fn mentions_all(&self, needles: &[&str]) -> bool {
+        self.as_slice().mentions_all(needles)
+    }
+
+    fn has_exact(&self, expected: &str) -> bool {
+        self.as_slice().has_exact(expected)
     }
 }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -42,14 +42,20 @@ impl ValidationError {
         Self { path, message }
     }
 
-    /// Returns `true` if `needle` appears anywhere in the rendered
-    /// `Display` form, including across the path/message boundary.
+    /// Substring search across the rendered `Display` form, including
+    /// across the path/message boundary. Returns `true` if `needle`
+    /// appears anywhere in the rendered string.
+    ///
     /// The rendered form is normally `"<path>: <message>"`, or
     /// `"<path><message>"` if `message` starts with `.` (see the
-    /// type-level docs for that fallback). Convenience for tests
-    /// that previously did `errors.contains(...)` against the old
-    /// `Vec<String>` shape and want to keep working without splitting
-    /// search terms.
+    /// type-level docs for that fallback).
+    ///
+    /// This mirrors the old `String::contains` semantics used by
+    /// in-crate test patterns like
+    /// `errors.iter().any(|e| e.contains("..."))` against the
+    /// pre-refactor `Vec<String>` shape. It is **not** analogous to
+    /// `Vec::contains`, which is an exact element match — for exact
+    /// matching against the rendered string see [`ValidationErrorsExt::has_exact`].
     pub fn contains(&self, needle: &str) -> bool {
         // Fast path: the needle lives entirely inside one field.
         if self.path.contains(needle) || self.message.contains(needle) {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -133,6 +133,15 @@ pub trait ValidationErrorsExt {
     /// `message` (via [`ValidationError::contains`]).
     fn mentions(&self, needle: &str) -> bool;
 
+    /// Returns `true` if a *single* error mentions every needle in
+    /// `needles`. Use this when several substrings must coexist in
+    /// the same diagnostic — chaining two [`mentions`] calls with
+    /// `&&` does not, because the two matches could come from
+    /// different entries in the list.
+    ///
+    /// [`mentions`]: ValidationErrorsExt::mentions
+    fn mentions_all(&self, needles: &[&str]) -> bool;
+
     /// Returns `true` if any error renders to exactly `expected`
     /// (matching the `Display` form, e.g.
     /// `"#.info.title: must not be empty"`).
@@ -144,6 +153,10 @@ impl ValidationErrorsExt for [ValidationError] {
         self.iter().any(|e| e.contains(needle))
     }
 
+    fn mentions_all(&self, needles: &[&str]) -> bool {
+        self.iter().any(|e| needles.iter().all(|n| e.contains(n)))
+    }
+
     fn has_exact(&self, expected: &str) -> bool {
         self.iter().any(|e| *e == expected)
     }
@@ -152,6 +165,10 @@ impl ValidationErrorsExt for [ValidationError] {
 impl ValidationErrorsExt for Error {
     fn mentions(&self, needle: &str) -> bool {
         self.errors.mentions(needle)
+    }
+
+    fn mentions_all(&self, needles: &[&str]) -> bool {
+        self.errors.mentions_all(needles)
     }
 
     fn has_exact(&self, expected: &str) -> bool {
@@ -396,38 +413,42 @@ pub(crate) trait PushError<T> {
 
 impl<T> PushError<&str> for Context<'_, T> {
     fn error(&mut self, path: String, msg: &str) {
-        let (path, message) = split_leading_dot(path, msg);
-        self.errors.push(ValidationError::new(path, message));
+        // `&str` is the only overload that has to materialise an
+        // owned `String` for the message; the other two already own
+        // theirs and call into `push_owned` directly.
+        self.errors
+            .push(make_validation_error(path, msg.to_owned()));
     }
 }
 
 impl<T> PushError<String> for Context<'_, T> {
     fn error(&mut self, path: String, msg: String) {
-        // The `&str` overload is doing the path-extension split, so go
-        // through it to keep the normalization in one place.
-        <Self as PushError<&str>>::error(self, path, msg.as_str());
+        self.errors.push(make_validation_error(path, msg));
     }
 }
 
 impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
     fn error(&mut self, path: String, args: fmt::Arguments<'_>) {
-        <Self as PushError<&str>>::error(self, path, args.to_string().as_str());
+        // `Arguments::to_string` materialises the formatted message
+        // once; we then move it into `ValidationError` (via the
+        // splitter) without copying again.
+        self.errors
+            .push(make_validation_error(path, args.to_string()));
     }
 }
 
-/// Normalises the recursive validators' leading-dot convention into
-/// the structured `ValidationError` shape.
+/// Build a `ValidationError`, normalising the recursive validators'
+/// leading-dot convention into the structured shape.
 ///
 /// Many call sites push a message of the form `".<segment>: <text>"`,
 /// where the `.<segment>` is intended as a *path extension* relative
 /// to the parent's path and `<text>` is the actual diagnostic. With
 /// the pre-refactor `Vec<String>` shape that was rendered correctly
 /// by concatenation; with the structured shape it would leak the
-/// path-extension marker into `message`, breaking
-/// programmatic callers that filter by `.path` or render `.message`
-/// alone.
+/// path-extension marker into `message`, breaking programmatic
+/// callers that filter by `.path` or render `.message` alone.
 ///
-/// This splitter recognises that convention:
+/// This builder recognises that convention:
 ///
 /// * If `msg` starts with `.` AND contains `": "`, the segment up to
 ///   `": "` is appended to `path` and the text after `": "` becomes
@@ -438,18 +459,34 @@ impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
 ///
 /// Either way the [`ValidationError::Display`] output is identical to
 /// the pre-refactor rendering.
-fn split_leading_dot(mut path: String, msg: &str) -> (String, String) {
-    if let Some(rest) = msg.strip_prefix('.')
-        && let Some(sep_at) = rest.find(": ")
+///
+/// Both arguments are taken by value: the `path` and the `message`
+/// each move into the final `ValidationError` without any extra
+/// allocation in the normal path. The leading-dot fast path does
+/// allocate a small `String` for the trimmed tail, since the message
+/// has to drop a prefix and we can't shrink an owned `String` in
+/// place without an unsafe split — that's the rare branch and not on
+/// any hot path.
+fn make_validation_error(mut path: String, msg: String) -> ValidationError {
+    if msg.starts_with('.')
+        && let Some(sep_at) = msg[1..].find(": ")
     {
-        let (segment, after) = rest.split_at(sep_at);
-        // `after` still has the leading `": "`; skip it.
-        let message = &after[2..];
-        path.push('.');
-        path.push_str(segment);
-        return (path, message.to_owned());
+        // `sep_at` is measured from index 1 (after the leading `.`).
+        // Segment runs `1..1+sep_at`; separator is at `1+sep_at..1+sep_at+2`;
+        // tail starts at `1+sep_at+2`.
+        let segment_end = 1 + sep_at;
+        let tail_start = segment_end + 2;
+        // Append `.<segment>` to `path`. `&msg[..segment_end]` is
+        // `".<segment>"`, which already starts with the dot we need.
+        path.push_str(&msg[..segment_end]);
+        // Move the tail into a fresh String. (We can't shrink `msg`
+        // from the front cheaply; the cost is one allocation in this
+        // rare path.)
+        let message = msg[tail_start..].to_owned();
+        return ValidationError::new(path, message);
     }
-    (path, msg.to_owned())
+    // Common path: no leading dot, no split — move both arguments in.
+    ValidationError::new(path, msg)
 }
 
 impl<T> Context<'_, T> {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -6,9 +6,125 @@ use thiserror::Error as ThisError;
 
 use crate::loader::Loader;
 
+/// A single validation finding. Carries the JSON-Pointer-style path
+/// of the failing element and a human-readable message.
+///
+/// Constructed internally by the recursive validators via
+/// [`PushError::error`]; emitted to callers as the elements of
+/// [`Error::errors`]. The [`Display`] impl renders as
+/// `"<path>: <message>"`, except messages beginning with `.` are
+/// concatenated directly onto the path (so callers can use a leading
+/// dot to keep the path-extension form like `"#.info.title"` from a
+/// child message of `".title: must not be empty"`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ValidationError {
+    pub path: String,
+    pub message: String,
+}
+
+impl ValidationError {
+    pub(crate) fn new(path: String, message: String) -> Self {
+        Self { path, message }
+    }
+
+    /// Returns `true` if `needle` appears in either the path or the
+    /// message. Convenience for tests that previously did
+    /// `errors.contains(...)` against the old
+    /// `Vec<String>` shape.
+    pub fn contains(&self, needle: &str) -> bool {
+        self.path.contains(needle) || self.message.contains(needle)
+    }
+}
+
+// Convenience equality with the rendered string form, so existing tests
+// that compare a `ValidationError` against a literal like
+// `"#.info.title: must not be empty"` keep working without rewriting
+// every assertion. The comparison is byte-wise across the joined form
+// `<path><sep><message>` (sep = `""` when the message starts with `.`,
+// otherwise `": "`), avoiding an allocation per call.
+impl PartialEq<str> for ValidationError {
+    fn eq(&self, other: &str) -> bool {
+        let (sep, rest) = if let Some(rest) = self.message.strip_prefix('.') {
+            (".", rest)
+        } else {
+            (": ", self.message.as_str())
+        };
+        let plen = self.path.len();
+        let slen = sep.len();
+        other.len() == plen + slen + rest.len()
+            && other.starts_with(&self.path)
+            && other[plen..].starts_with(sep)
+            && other[plen + slen..] == *rest
+    }
+}
+
+impl PartialEq<&str> for ValidationError {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+impl PartialEq<String> for ValidationError {
+    fn eq(&self, other: &String) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(rest) = self.message.strip_prefix('.') {
+            write!(f, "{}.{}", self.path, rest)
+        } else {
+            write!(f, "{}: {}", self.path, self.message)
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error {
-    pub errors: Vec<String>,
+    pub errors: Vec<ValidationError>,
+}
+
+/// Convenience predicates over a collection of [`ValidationError`]s.
+///
+/// Implemented for both [`Error`] (which owns the full report after
+/// [`Validate::validate`] returns) and `Vec<ValidationError>` (which
+/// the in-progress recursive validators accumulate as `ctx.errors`).
+/// Lets callers and tests query a report with a single method call
+/// instead of repeating `iter().any(|e| ...)`.
+///
+/// Method names are `mentions` / `has_exact` rather than
+/// `contains` / `contains_exact` to avoid clashing with the inherent
+/// `slice::contains(&T)` method on `Vec<ValidationError>`.
+pub trait ValidationErrorsExt {
+    /// Returns `true` if any error mentions `needle` in its `path` or
+    /// `message` (via [`ValidationError::contains`]).
+    fn mentions(&self, needle: &str) -> bool;
+
+    /// Returns `true` if any error renders to exactly `expected`
+    /// (matching the `Display` form, e.g.
+    /// `"#.info.title: must not be empty"`).
+    fn has_exact(&self, expected: &str) -> bool;
+}
+
+impl ValidationErrorsExt for [ValidationError] {
+    fn mentions(&self, needle: &str) -> bool {
+        self.iter().any(|e| e.contains(needle))
+    }
+
+    fn has_exact(&self, expected: &str) -> bool {
+        self.iter().any(|e| *e == expected)
+    }
+}
+
+impl ValidationErrorsExt for Error {
+    fn mentions(&self, needle: &str) -> bool {
+        self.errors.mentions(needle)
+    }
+
+    fn has_exact(&self, expected: &str) -> bool {
+        self.errors.has_exact(expected)
+    }
 }
 
 impl Display for Error {
@@ -232,7 +348,7 @@ pub(crate) struct Context<'a, T> {
     /// by [`Options::IgnoreExternalReferences`]).
     pub loader: Option<&'a mut Loader>,
     pub visited: HashSet<String>,
-    pub errors: Vec<String>,
+    pub errors: Vec<ValidationError>,
     pub options: EnumSet<Options>,
 }
 
@@ -248,23 +364,20 @@ pub(crate) trait PushError<T> {
 
 impl<T> PushError<&str> for Context<'_, T> {
     fn error(&mut self, path: String, msg: &str) {
-        if msg.starts_with('.') {
-            self.errors.push(format!("{path}{msg}"));
-        } else {
-            self.errors.push(format!("{path}: {msg}"));
-        }
+        self.errors.push(ValidationError::new(path, msg.to_owned()));
     }
 }
 
 impl<T> PushError<String> for Context<'_, T> {
     fn error(&mut self, path: String, msg: String) {
-        self.error(path, msg.as_str());
+        self.errors.push(ValidationError::new(path, msg));
     }
 }
 
 impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
     fn error(&mut self, path: String, args: fmt::Arguments<'_>) {
-        self.error(path, args.to_string().as_str());
+        self.errors
+            .push(ValidationError::new(path, args.to_string()));
     }
 }
 
@@ -344,9 +457,15 @@ mod tests {
     #[test]
     fn error_display_formats_with_count_and_bulleted_messages() {
         let err = Error {
-            errors: vec!["first".into(), "second".into()],
+            errors: vec![
+                ValidationError::new("#.a".into(), "first".into()),
+                ValidationError::new("#.b".into(), "second".into()),
+            ],
         };
-        assert_eq!(format!("{err}"), "2 errors found:\n- first\n- second\n");
+        assert_eq!(
+            format!("{err}"),
+            "2 errors found:\n- #.a: first\n- #.b: second\n"
+        );
     }
 
     #[test]
@@ -399,10 +518,10 @@ mod tests {
         assert!(r.is_ok());
 
         let mut ctx: Context<()> = Context::new(&(), Options::new());
-        ctx.errors.push("kaboom".into());
+        ctx.error("#".into(), "kaboom");
         let r: Result<(), Error> = ctx.into();
         let err = r.unwrap_err();
-        assert_eq!(err.errors, vec!["kaboom".to_string()]);
+        assert!(err.has_exact("#: kaboom"));
     }
 
     #[test]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -6,8 +6,18 @@ use thiserror::Error as ThisError;
 
 use crate::loader::Loader;
 
-/// A single validation finding. Carries the JSON-Pointer-style path
-/// of the failing element and a human-readable message.
+/// A single validation finding. Carries the dotted path of the
+/// failing element and a human-readable message.
+///
+/// The `path` is built by this crate's recursive validators using a
+/// JSONPath-flavored syntax — `#` for the document root, `.` for
+/// field descent, and `[…]` for keyed map / array index segments
+/// (e.g. `#.paths[/pets].get.responses.default.content[application/json].schema`).
+/// It is **not** RFC 6901 JSON Pointer; there is no `~0` / `~1`
+/// escaping and `/` is a literal character that often appears inside
+/// `[…]` segments. Downstream consumers should treat `path` as an
+/// opaque human-readable locator, not a parser input for a JSON
+/// Pointer library.
 ///
 /// Constructed internally by the recursive validators via
 /// [`PushError::error`]; emitted to callers as the elements of
@@ -40,33 +50,40 @@ impl ValidationError {
 // that compare a `ValidationError` against a literal like
 // `"#.info.title: must not be empty"` keep working without rewriting
 // every assertion. The comparison is byte-wise across the joined form
-// `<path><sep><message>` (sep = `""` when the message starts with `.`,
-// otherwise `": "`), avoiding an allocation per call.
+// `<path><sep><tail>`:
+//
+// * if `message` starts with `.`, the separator is `"."` and `tail`
+//   is the rest of the message (the `Display` form is therefore
+//   `<path>.<tail>` — e.g. path `#.x` + message `.foo` → `#.x.foo`);
+// * otherwise the separator is `": "` and `tail` is the full message.
+//
+// Walking the joined form directly avoids the per-call allocation that
+// `self.to_string() == other` would do.
 impl PartialEq<str> for ValidationError {
     fn eq(&self, other: &str) -> bool {
-        let (sep, rest) = if let Some(rest) = self.message.strip_prefix('.') {
+        let (sep, tail) = if let Some(rest) = self.message.strip_prefix('.') {
             (".", rest)
         } else {
             (": ", self.message.as_str())
         };
         let plen = self.path.len();
         let slen = sep.len();
-        other.len() == plen + slen + rest.len()
+        other.len() == plen + slen + tail.len()
             && other.starts_with(&self.path)
             && other[plen..].starts_with(sep)
-            && other[plen + slen..] == *rest
+            && other[plen + slen..] == *tail
     }
 }
 
 impl PartialEq<&str> for ValidationError {
     fn eq(&self, other: &&str) -> bool {
-        self == *other
+        <ValidationError as PartialEq<str>>::eq(self, other)
     }
 }
 
 impl PartialEq<String> for ValidationError {
     fn eq(&self, other: &String) -> bool {
-        self == other.as_str()
+        <ValidationError as PartialEq<str>>::eq(self, other.as_str())
     }
 }
 
@@ -453,6 +470,25 @@ impl<'a, T> From<Context<'a, T>> for Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validation_error_partial_eq_against_str_string_and_ref_str_terminates() {
+        // Regression for an earlier `PartialEq<&str>` impl that
+        // delegated `self == *other` and recursed through itself
+        // forever (stack overflow). All three RHS shapes must agree
+        // with the `Display` form and return promptly.
+        let e = ValidationError::new("#.info.title".into(), "must not be empty".into());
+        let literal: &str = "#.info.title: must not be empty";
+        let owned: String = literal.to_owned();
+        assert!(e == *literal);
+        assert!(e == literal);
+        assert!(e == owned);
+        assert!(e != "different");
+
+        // `.`-prefixed message variant.
+        let e = ValidationError::new("#.x".into(), ".foo: bad".into());
+        assert!(e == "#.x.foo: bad");
+    }
 
     #[test]
     fn error_display_formats_with_count_and_bulleted_messages() {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -21,11 +21,16 @@ use crate::loader::Loader;
 ///
 /// Constructed internally by the recursive validators; emitted to
 /// callers as the elements of [`Error::errors`] after
-/// [`Validate::validate`] returns. The [`Display`] impl renders as
-/// `"<path>: <message>"`. As a defensive fallback, messages that
-/// still begin with `.` (rare — the internal pusher splits leading
-/// path extensions into `path` at push time) are concatenated
-/// directly onto the path so the rendered form remains correct.
+/// [`Validate::validate`] returns.
+///
+/// The [`Display`] impl normally renders as `"<path>: <message>"`.
+/// As a defensive fallback, if `message` starts with `.` (rare —
+/// the internal pusher splits leading-dot path extensions into
+/// `path` at push time, so this only happens for directly-constructed
+/// values that bypass the pusher), the rendering instead concatenates
+/// the message directly onto the path with no separator, producing
+/// `"<path><message>"` (e.g. `path = "#.x"`, `message = ".foo"` →
+/// `"#.x.foo"`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ValidationError {
     pub path: String,
@@ -38,10 +43,13 @@ impl ValidationError {
     }
 
     /// Returns `true` if `needle` appears anywhere in the rendered
-    /// `Display` form (`"<path>: <message>"`), including across the
-    /// path/message boundary. Convenience for tests that previously
-    /// did `errors.contains(...)` against the old `Vec<String>` shape
-    /// and want to keep working without splitting search terms.
+    /// `Display` form, including across the path/message boundary.
+    /// The rendered form is normally `"<path>: <message>"`, or
+    /// `"<path><message>"` if `message` starts with `.` (see the
+    /// type-level docs for that fallback). Convenience for tests
+    /// that previously did `errors.contains(...)` against the old
+    /// `Vec<String>` shape and want to keep working without splitting
+    /// search terms.
     pub fn contains(&self, needle: &str) -> bool {
         // Fast path: the needle lives entirely inside one field.
         if self.path.contains(needle) || self.message.contains(needle) {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -19,13 +19,13 @@ use crate::loader::Loader;
 /// opaque human-readable locator, not a parser input for a JSON
 /// Pointer library.
 ///
-/// Constructed internally by the recursive validators via
-/// [`PushError::error`]; emitted to callers as the elements of
-/// [`Error::errors`]. The [`Display`] impl renders as
-/// `"<path>: <message>"`, except messages beginning with `.` are
-/// concatenated directly onto the path (so callers can use a leading
-/// dot to keep the path-extension form like `"#.info.title"` from a
-/// child message of `".title: must not be empty"`).
+/// Constructed internally by the recursive validators; emitted to
+/// callers as the elements of [`Error::errors`] after
+/// [`Validate::validate`] returns. The [`Display`] impl renders as
+/// `"<path>: <message>"`. As a defensive fallback, messages that
+/// still begin with `.` (rare — the internal pusher splits leading
+/// path extensions into `path` at push time) are concatenated
+/// directly onto the path so the rendered form remains correct.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ValidationError {
     pub path: String,
@@ -37,12 +37,19 @@ impl ValidationError {
         Self { path, message }
     }
 
-    /// Returns `true` if `needle` appears in either the path or the
-    /// message. Convenience for tests that previously did
-    /// `errors.contains(...)` against the old
-    /// `Vec<String>` shape.
+    /// Returns `true` if `needle` appears anywhere in the rendered
+    /// `Display` form (`"<path>: <message>"`), including across the
+    /// path/message boundary. Convenience for tests that previously
+    /// did `errors.contains(...)` against the old `Vec<String>` shape
+    /// and want to keep working without splitting search terms.
     pub fn contains(&self, needle: &str) -> bool {
-        self.path.contains(needle) || self.message.contains(needle)
+        // Fast path: the needle lives entirely inside one field.
+        if self.path.contains(needle) || self.message.contains(needle) {
+            return true;
+        }
+        // Slow path: needle crosses the path/message boundary — fall
+        // back to the rendered form.
+        self.to_string().contains(needle)
     }
 }
 
@@ -381,21 +388,60 @@ pub(crate) trait PushError<T> {
 
 impl<T> PushError<&str> for Context<'_, T> {
     fn error(&mut self, path: String, msg: &str) {
-        self.errors.push(ValidationError::new(path, msg.to_owned()));
+        let (path, message) = split_leading_dot(path, msg);
+        self.errors.push(ValidationError::new(path, message));
     }
 }
 
 impl<T> PushError<String> for Context<'_, T> {
     fn error(&mut self, path: String, msg: String) {
-        self.errors.push(ValidationError::new(path, msg));
+        // The `&str` overload is doing the path-extension split, so go
+        // through it to keep the normalization in one place.
+        <Self as PushError<&str>>::error(self, path, msg.as_str());
     }
 }
 
 impl<T> PushError<fmt::Arguments<'_>> for Context<'_, T> {
     fn error(&mut self, path: String, args: fmt::Arguments<'_>) {
-        self.errors
-            .push(ValidationError::new(path, args.to_string()));
+        <Self as PushError<&str>>::error(self, path, args.to_string().as_str());
     }
+}
+
+/// Normalises the recursive validators' leading-dot convention into
+/// the structured `ValidationError` shape.
+///
+/// Many call sites push a message of the form `".<segment>: <text>"`,
+/// where the `.<segment>` is intended as a *path extension* relative
+/// to the parent's path and `<text>` is the actual diagnostic. With
+/// the pre-refactor `Vec<String>` shape that was rendered correctly
+/// by concatenation; with the structured shape it would leak the
+/// path-extension marker into `message`, breaking
+/// programmatic callers that filter by `.path` or render `.message`
+/// alone.
+///
+/// This splitter recognises that convention:
+///
+/// * If `msg` starts with `.` AND contains `": "`, the segment up to
+///   `": "` is appended to `path` and the text after `": "` becomes
+///   the message — so `path = "#.x"`, `msg = ".allOf: must not be
+///   empty"` becomes `path = "#.x.allOf"`, `message = "must not be
+///   empty"`.
+/// * Otherwise the inputs are stored verbatim.
+///
+/// Either way the [`ValidationError::Display`] output is identical to
+/// the pre-refactor rendering.
+fn split_leading_dot(mut path: String, msg: &str) -> (String, String) {
+    if let Some(rest) = msg.strip_prefix('.')
+        && let Some(sep_at) = rest.find(": ")
+    {
+        let (segment, after) = rest.split_at(sep_at);
+        // `after` still has the leading `": "`; skip it.
+        let message = &after[2..];
+        path.push('.');
+        path.push_str(segment);
+        return (path, message.to_owned());
+    }
+    (path, msg.to_owned())
 }
 
 impl<T> Context<'_, T> {
@@ -470,6 +516,41 @@ impl<'a, T> From<Context<'a, T>> for Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn push_error_splits_leading_dot_message_into_path_extension() {
+        let mut ctx: Context<()> = Context::new(&(), Options::new());
+        ctx.error("#.x".into(), ".allOf: must not be empty");
+        assert_eq!(ctx.errors.len(), 1);
+        let e = &ctx.errors[0];
+        // The leading-dot segment is appended to `path`; `message`
+        // holds only the diagnostic text. Display still renders the
+        // original `"#.x.allOf: must not be empty"` form.
+        assert_eq!(e.path, "#.x.allOf");
+        assert_eq!(e.message, "must not be empty");
+        assert_eq!(e.to_string(), "#.x.allOf: must not be empty");
+    }
+
+    #[test]
+    fn push_error_keeps_message_verbatim_without_leading_dot() {
+        let mut ctx: Context<()> = Context::new(&(), Options::new());
+        ctx.error("#.x".into(), "must not be empty");
+        let e = &ctx.errors[0];
+        assert_eq!(e.path, "#.x");
+        assert_eq!(e.message, "must not be empty");
+    }
+
+    #[test]
+    fn validation_error_contains_matches_across_boundary() {
+        // `contains` should match a substring that crosses the
+        // path/message boundary in the rendered form, even though the
+        // underlying fields hold them separately.
+        let e = ValidationError::new("#.x.items".into(), "is required".into());
+        assert!(e.contains("items: is required"));
+        assert!(e.contains("#.x"));
+        assert!(e.contains("is required"));
+        assert!(!e.contains("not in either"));
+    }
 
     #[test]
     fn validation_error_partial_eq_against_str_string_and_ref_str_terminates() {

--- a/tests/loader_test.rs
+++ b/tests/loader_test.rs
@@ -20,7 +20,7 @@ use std::fs;
 
 use roas::loader::{JsonFileFetcher, Loader};
 use roas::v3_2::spec::Spec;
-use roas::validation::{Options, Validate};
+use roas::validation::{Options, Validate, ValidationErrorsExt};
 use url::Url;
 
 const PETSTORE_SPEC_PATH: &str = "tests/loader_data/petstore.json";
@@ -80,11 +80,11 @@ fn validate_with_empty_loader_surfaces_no_fetcher_error() {
         .validate(Options::IgnoreMissingTags.only(), Some(&mut loader))
         .expect_err("missing fetcher must surface as a validation error");
     assert!(
-        err.errors.iter().any(|e| {
-            e.contains("error.json#/Error")
-                && e.contains("failed to resolve")
-                && e.contains("no fetcher registered")
-        }),
+        err.errors.mentions_all(&[
+            "error.json#/Error",
+            "failed to resolve",
+            "no fetcher registered",
+        ]),
         "expected `failed to resolve` + `no fetcher registered` error, got: {:?}",
         err.errors,
     );


### PR DESCRIPTION
`Error::errors` and the internal `Context::errors` are now `Vec<ValidationError>` instead of `Vec<String>`. Each `ValidationError` carries an explicit `path` and `message`, so callers can route errors programmatically, group by component, or render them differently from the canonical `<path>: <message>` form. The bundled `Display` impl still produces exactly that form, so anything that consumed the string output keeps working.

## What's new

- **`ValidationError { path, message }`** — the new structured entry. `Display` renders as `"<path>: <message>"`. Internal push sites that use the legacy leading-dot shorthand (`".allOf: must not be empty"` against parent path `#.x`) are normalised at push time into `path = "#.x.allOf"`, `message = "must not be empty"`; the rendered string is byte-identical to the pre-refactor form.
- **`ValidationErrorsExt`** — extension trait implemented for `[ValidationError]`, `Vec<ValidationError>`, and `Error`. Three methods:
  - `mentions(needle)`: substring search across path + message of any error (replacement for `iter().any(|e| e.contains(...))`).
  - `mentions_all(&[needles])`: substring search where a *single* error must mention every needle in the slice (replacement for `iter().any(|e| e.contains(a) && e.contains(b))`; chaining two `mentions` calls with `&&` doesn't preserve the same-error invariant).
  - `has_exact(rendered)`: exact match against the `Display`-form of any error (replacement for `iter().any(|e| e == "...")`).
  
  Method names sidestep the inherent `slice::contains(&T)` that otherwise wins by name resolution. The explicit `Vec` impl is provided alongside the slice impl so the type also satisfies `T: ValidationErrorsExt` bounds in generic code; direct method calls reach the slice impl via auto-deref either way.
- `PushError::error` builds the struct rather than `format!`-ing a string; otherwise the internal validator API is unchanged. Allocation cost: one heap allocation per push regardless of whether the leading-dot normalisation fires.

## Breaking changes for downstream

- `roas::validation::Error::errors`: `Vec<String>` → `Vec<ValidationError>`. Callers that read `.errors[i]` as a string should switch to `.errors[i].to_string()` or `format!("{e}")`, or inspect the new `.path` / `.message` fields directly.
- `roas::validation::Context::errors` (crate-internal but listed for thoroughness): same shift.

## What's intentionally not in this PR

- `InvalidComponentName` stays a separate struct. Different lifecycle (builder-time, single-shot vs. validate-time, aggregated), different consumer pattern (programmatic `.name` inspection vs. `path/message`). A `From<InvalidComponentName> for ValidationError` is *not* added speculatively — add it when a concrete caller needs to bundle builder errors into a validation report.
- No category enum on `ValidationError`. The struct shape leaves room for an optional `category: Option<Category>` later; adding it now without a consumer would mean churn on every new check for no benefit.