### PR TITLE
loader: add LoaderError::Fetch; mark enum non_exhaustive; bump 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 authors = ["Sergey Vilgelm <sergey@vilgelm.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/roas/README.md
+++ b/crates/roas/README.md
@@ -28,7 +28,7 @@ or manually add the following lines:
 
 ```toml
 [dependencies]
-roas = "0.12"
+roas = "0.13"
 ```
 
 The default feature is `v3_2`. To parse v2.0, v3.0 or v3.1 specs, enable the
@@ -36,7 +36,7 @@ corresponding feature:
 
 ```toml
 [dependencies]
-roas = { version = "0.12", default-features = false, features = ["v3_0"] }
+roas = { version = "0.13", default-features = false, features = ["v3_0"] }
 ```
 
 ## Examples

--- a/crates/roas/src/loader.rs
+++ b/crates/roas/src/loader.rs
@@ -59,7 +59,12 @@ impl ResourceFetcher for JsonFileFetcher {
 }
 
 /// External resource loading errors.
+///
+/// Marked `#[non_exhaustive]` so additional fetcher-shaped failure modes can be
+/// added without a breaking change. Downstream `match` arms must include a
+/// wildcard.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum LoaderError {
     #[error("no fetcher registered for `{uri}`")]
     NoFetcherRegistered { uri: String },
@@ -94,6 +99,18 @@ pub enum LoaderError {
         uri: String,
         #[source]
         source: serde_json::Error,
+    },
+
+    /// Fetcher-side transport failure: anything a fetcher could not turn into a
+    /// parseable response body (network error, non-2xx HTTP response,
+    /// connection refused, etc.). The `source` is boxed so each fetcher can
+    /// carry its own native error type (e.g. `reqwest::Error`) without `roas`
+    /// taking on the dependency.
+    #[error("failed to fetch `{uri}`")]
+    Fetch {
+        uri: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     #[error("reference `{reference}` not found in `{uri}`")]
@@ -808,6 +825,21 @@ mod tests {
             .expect_err("invalid JSON must error");
         assert!(matches!(err, LoaderError::Parse { .. }));
         fs::remove_file(file).unwrap();
+    }
+
+    #[test]
+    fn loader_error_fetch_carries_arbitrary_source_and_displays_uri() {
+        let inner = std::io::Error::other("connection refused");
+        let err = LoaderError::Fetch {
+            uri: "https://example.test/pet.json".into(),
+            source: Box::new(inner),
+        };
+        assert_eq!(
+            err.to_string(),
+            "failed to fetch `https://example.test/pet.json`",
+        );
+        let source = std::error::Error::source(&err).expect("Fetch must expose a source");
+        assert_eq!(source.to_string(), "connection refused");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a new error variant `LoaderError::Fetch { uri, source: Box<dyn Error + Send + Sync> }` and marks `LoaderError` as `#[non_exhaustive]`. Both changes are minor-version-bumping under cargo's 0.x semver rules, so the workspace moves from 0.12.0 → 0.13.0.

## Why

The current `LoaderError` only has variants shaped around filesystem and JSON-parse failures. A `ResourceFetcher` that talks to the network has no clean way to surface transport errors (connection refused, non-2xx HTTP responses, TLS failures) — they don't fit `ReadFile`, and shoehorning them into `Parse` would print "failed to parse `https://…`" for what is actually a network failure.

`LoaderError::Fetch` carries a boxed `dyn Error + Send + Sync` source so each fetcher implementation can hand its own native error type (e.g. `reqwest::Error`) up the chain without `roas` taking on the transport dependency.

`#[non_exhaustive]` is added in the same bump so the same kind of additive change can land in future patch releases without breaking downstream `match` arms.

## What changed

- `crates/roas/src/loader.rs`: new `Fetch` variant on `LoaderError`; `LoaderError` is now `#[non_exhaustive]`.
- Workspace version bumped to 0.13.0 (`[workspace.package].version` in root `Cargo.toml`).
- `crates/roas/README.md` examples updated to `roas = "0.13"`.
- Unit test asserts `Fetch` carries the boxed source through `std::error::Error::source` and renders the expected `Display` text.

No existing call site constructs `Fetch` or `match`es exhaustively over `LoaderError`; the variant exists to give an upcoming `roas-http-fetcher` crate a clean home for `reqwest::Error`-shaped failures.

## Downstream impact

- Consumers who `match` exhaustively over `LoaderError` will need a wildcard arm (one-time, because of `#[non_exhaustive]`); after this bump, adding variants is no longer breaking.