### PR TITLE
feat: add roas-http-fetcher crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ enumset = "1.1.10"
 lazy-regex = "3.6.0"
 monostate = "1.0.0"
 regex = "1.11.2"
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 thiserror = "2.0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ regex = "1.11.2"
 reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
+serde_yaml_ng = "0.10.0"
 thiserror = "2.0.16"
 url = "2.5.8"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This repository is a Cargo workspace for [roas](https://crates.io/crates/roas) — a Rust implementation of the
 OpenAPI Specification (v2.0, v3.0.x, v3.1.x, v3.2.x).
 
-| Crate                                                | Docs                                                                                  | crates.io                                                                                                  |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [`roas`](crates/roas)                                | [![docs.rs](https://docs.rs/roas/badge.svg)](https://docs.rs/roas)                    | [![crates.io](https://img.shields.io/crates/v/roas.svg)](https://crates.io/crates/roas)                    |
+| Crate                                                | Docs                                                                                                  | crates.io                                                                                                                  |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [`roas`](crates/roas)                                | [![docs.rs](https://docs.rs/roas/badge.svg)](https://docs.rs/roas)                                    | [![crates.io](https://img.shields.io/crates/v/roas.svg)](https://crates.io/crates/roas)                                    |
+| [`roas-http-fetcher`](crates/roas-http-fetcher)      | [![docs.rs](https://docs.rs/roas-http-fetcher/badge.svg)](https://docs.rs/roas-http-fetcher)          | [![crates.io](https://img.shields.io/crates/v/roas-http-fetcher.svg)](https://crates.io/crates/roas-http-fetcher)          |
 
 See each crate's `README.md` for usage, and `AGENTS.md` at the repository root for contributor guidelines.
 

--- a/crates/roas-http-fetcher/Cargo.toml
+++ b/crates/roas-http-fetcher/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "roas-http-fetcher"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+description = "HTTP/HTTPS fetcher for the roas OpenAPI loader"
+readme = "README.md"
+categories = ["web-programming", "parser-implementations"]
+include = ["src", "Cargo.toml", "README.md"]
+publish = true
+
+[dependencies]
+roas = { version = "0.13", path = "../roas" }
+reqwest.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+url.workspace = true

--- a/crates/roas-http-fetcher/Cargo.toml
+++ b/crates/roas-http-fetcher/Cargo.toml
@@ -28,3 +28,6 @@ serde_json.workspace = true
 serde_yaml_ng = { workspace = true, optional = true }
 thiserror.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros", "net", "time"] }

--- a/crates/roas-http-fetcher/Cargo.toml
+++ b/crates/roas-http-fetcher/Cargo.toml
@@ -13,9 +13,18 @@ categories = ["web-programming", "parser-implementations"]
 include = ["src", "Cargo.toml", "README.md"]
 publish = true
 
+[features]
+default = []
+# Parse YAML response bodies in addition to JSON. The fetcher sniffs the
+# response Content-Type and falls back to the URL path extension to decide
+# which parser to use.
+yaml = ["dep:serde_yaml_ng"]
+
 [dependencies]
 roas = { version = "0.13", path = "../roas" }
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+serde_yaml_ng = { workspace = true, optional = true }
 thiserror.workspace = true
 url.workspace = true

--- a/crates/roas-http-fetcher/Cargo.toml
+++ b/crates/roas-http-fetcher/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 yaml = ["dep:serde_yaml_ng"]
 
 [dependencies]
-roas = { version = "0.13", path = "../roas" }
+roas = { version = ">=0.13", path = "../roas" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/roas-http-fetcher/README.md
+++ b/crates/roas-http-fetcher/README.md
@@ -1,13 +1,18 @@
 # roas-http-fetcher
 
-HTTP/HTTPS [`ResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.ResourceFetcher.html) for the
+HTTP/HTTPS [`ResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.ResourceFetcher.html) and
+[`AsyncResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.AsyncResourceFetcher.html) for the
 [`roas`](https://crates.io/crates/roas) OpenAPI loader.
 
 [![crates.io](https://img.shields.io/crates/v/roas-http-fetcher.svg)](https://crates.io/crates/roas-http-fetcher)
 [![docs.rs](https://docs.rs/roas-http-fetcher/badge.svg)](https://docs.rs/roas-http-fetcher)
 
-Built on `reqwest`'s blocking client with `rustls-tls`. The fetcher is `Clone` so a single underlying connection pool
-can be shared across `http://` and `https://` registrations on the same `Loader`.
+Built on `reqwest` with `rustls-tls`. The crate exposes two fetchers:
+
+- `HttpFetcher` — `reqwest::blocking::Client`, for `Loader::register_fetcher`.
+- `AsyncHttpFetcher` — `reqwest::Client`, for `Loader::register_async_fetcher`. Requires a tokio runtime when awaited.
+
+Both are `Clone` so a single underlying connection pool can be shared across `http://` and `https://` registrations.
 
 ## Features
 
@@ -35,6 +40,18 @@ let mut loader = Loader::new();
 let http = HttpFetcher::new();
 loader.register_fetcher("https://", http.clone());
 loader.register_fetcher("http://", http);
+```
+
+For async loaders use `AsyncHttpFetcher` with `register_async_fetcher` instead — same shape:
+
+```rust
+use roas::loader::Loader;
+use roas_http_fetcher::AsyncHttpFetcher;
+
+let mut loader = Loader::new();
+let http = AsyncHttpFetcher::new();
+loader.register_async_fetcher("https://", http.clone());
+loader.register_async_fetcher("http://", http);
 ```
 
 A non-2xx HTTP response, transport failure, or unreadable body is surfaced through

--- a/crates/roas-http-fetcher/README.md
+++ b/crates/roas-http-fetcher/README.md
@@ -7,12 +7,12 @@ HTTP/HTTPS [`ResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.Res
 [![crates.io](https://img.shields.io/crates/v/roas-http-fetcher.svg)](https://crates.io/crates/roas-http-fetcher)
 [![docs.rs](https://docs.rs/roas-http-fetcher/badge.svg)](https://docs.rs/roas-http-fetcher)
 
-Built on `reqwest` with `rustls-tls`. The crate exposes two fetchers:
+Built on `reqwest` with `rustls-tls`. A single generic `Fetcher<C>` underlies two type aliases:
 
-- `HttpFetcher` — `reqwest::blocking::Client`, for `Loader::register_fetcher`.
-- `AsyncHttpFetcher` — `reqwest::Client`, for `Loader::register_async_fetcher`. Requires a tokio runtime when awaited.
+- `HttpFetcher` (= `Fetcher<reqwest::blocking::Client>`) — implements `ResourceFetcher` for `Loader::register_fetcher`.
+- `AsyncHttpFetcher` (= `Fetcher<reqwest::Client>`) — implements `AsyncResourceFetcher` for `Loader::register_async_fetcher`. A tokio runtime must be active when the returned future is awaited.
 
-Both are `Clone` so a single underlying connection pool can be shared across `http://` and `https://` registrations.
+Both forms are `Clone` so a single fetcher can be registered for both `http://` and `https://` prefixes on the same `Loader`, sharing one underlying connection pool. Schemes other than `http` / `https` are rejected with `LoaderError::UnsupportedFetcherUri`. The default constructor builds a client with a 30-second request timeout; `try_new()` is the fallible variant that surfaces TLS / IO environment failures from `reqwest::ClientBuilder`.
 
 ## Features
 

--- a/crates/roas-http-fetcher/README.md
+++ b/crates/roas-http-fetcher/README.md
@@ -1,0 +1,35 @@
+# roas-http-fetcher
+
+HTTP/HTTPS [`ResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.ResourceFetcher.html) for the
+[`roas`](https://crates.io/crates/roas) OpenAPI loader.
+
+[![crates.io](https://img.shields.io/crates/v/roas-http-fetcher.svg)](https://crates.io/crates/roas-http-fetcher)
+[![docs.rs](https://docs.rs/roas-http-fetcher/badge.svg)](https://docs.rs/roas-http-fetcher)
+
+Built on `reqwest`'s blocking client with `rustls-tls`. The fetcher is `Clone` so a single underlying connection pool
+can be shared across `http://` and `https://` registrations on the same `Loader`.
+
+## Usage
+
+```shell
+cargo add roas-http-fetcher
+```
+
+```rust
+use roas::loader::Loader;
+use roas_http_fetcher::HttpFetcher;
+
+let mut loader = Loader::new();
+let http = HttpFetcher::new();
+loader.register_fetcher("https://", http.clone());
+loader.register_fetcher("http://", http);
+```
+
+A non-2xx HTTP response, transport failure, or unreadable body is surfaced through
+[`LoaderError::Fetch`](https://docs.rs/roas/latest/roas/loader/enum.LoaderError.html) with a
+[`HttpFetchError`](https://docs.rs/roas-http-fetcher/latest/roas_http_fetcher/enum.HttpFetchError.html) source.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at
+your option.

--- a/crates/roas-http-fetcher/README.md
+++ b/crates/roas-http-fetcher/README.md
@@ -9,6 +9,18 @@ HTTP/HTTPS [`ResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.Res
 Built on `reqwest`'s blocking client with `rustls-tls`. The fetcher is `Clone` so a single underlying connection pool
 can be shared across `http://` and `https://` registrations on the same `Loader`.
 
+## Features
+
+- (default) JSON response bodies are parsed with `serde_json`.
+- `yaml` — also accept YAML response bodies. The fetcher sniffs `Content-Type`
+  first (`application/yaml`, `application/x-yaml`, `text/yaml`, etc.) and falls
+  back to the URL path extension (`.yaml` / `.yml`). Pulls in `serde_yaml_ng`.
+
+```toml
+[dependencies]
+roas-http-fetcher = { version = "0.1", features = ["yaml"] }
+```
+
 ## Usage
 
 ```shell

--- a/crates/roas-http-fetcher/src/lib.rs
+++ b/crates/roas-http-fetcher/src/lib.rs
@@ -152,9 +152,8 @@ impl ResourceFetcher for Fetcher<Client> {
 impl AsyncResourceFetcher for Fetcher<AsyncClient> {
     fn fetch<'a>(&'a mut self, uri: &'a Url) -> FetchFuture<'a> {
         let client = self.client.clone();
-        let uri = uri.clone();
         Box::pin(async move {
-            check_scheme(&uri)?;
+            check_scheme(uri)?;
             let response = client.get(uri.as_str()).send().await.map_err(|source| {
                 fetch_error(uri.as_str().to_string(), HttpFetchError::Request { source })
             })?;
@@ -177,7 +176,7 @@ impl AsyncResourceFetcher for Fetcher<AsyncClient> {
                 fetch_error(uri.as_str().to_string(), HttpFetchError::Body { source })
             })?;
 
-            parse_body(&uri, content_type.as_deref(), &bytes)
+            parse_body(uri, content_type.as_deref(), &bytes)
         })
     }
 }

--- a/crates/roas-http-fetcher/src/lib.rs
+++ b/crates/roas-http-fetcher/src/lib.rs
@@ -1,17 +1,28 @@
-//! HTTP/HTTPS [`ResourceFetcher`] for the [`roas`] OpenAPI loader.
+//! HTTP/HTTPS [`ResourceFetcher`] / [`AsyncResourceFetcher`] for the [`roas`]
+//! OpenAPI loader.
 //!
-//! See the crate-level README for a usage example. Transport failures, non-2xx
-//! responses, and unreadable bodies are surfaced through [`LoaderError::Fetch`]
-//! with a [`HttpFetchError`] source.
+//! Two fetchers are exposed:
+//!   * [`HttpFetcher`] — backed by `reqwest::blocking::Client`, plugs into
+//!     [`Loader::register_fetcher`](roas::loader::Loader::register_fetcher).
+//!   * [`AsyncHttpFetcher`] — backed by `reqwest::Client`, plugs into
+//!     [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
+//!     Requires a tokio runtime to be active when the future is awaited.
 //!
-//! With the `yaml` feature enabled, the fetcher parses YAML response bodies in
-//! addition to JSON. Format selection sniffs the response `Content-Type`
+//! Both fetchers are `Clone` so a single underlying connection pool can be
+//! shared across multiple registrations (e.g. one for `http://` and one for
+//! `https://`). Transport failures, non-2xx responses, and unreadable bodies
+//! are surfaced through [`LoaderError::Fetch`] with a [`HttpFetchError`]
+//! source.
+//!
+//! With the `yaml` feature enabled, both fetchers parse YAML response bodies
+//! in addition to JSON. Format selection sniffs the response `Content-Type`
 //! header first and falls back to the URL path extension (`.yaml` / `.yml`).
 
+use reqwest::Client as AsyncClient;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use reqwest::header::CONTENT_TYPE;
-use roas::loader::{LoaderError, ResourceFetcher};
+use roas::loader::{AsyncResourceFetcher, FetchFuture, LoaderError, ResourceFetcher};
 #[cfg(feature = "yaml")]
 use serde::de::Error as _;
 use serde_json::Value;
@@ -79,6 +90,72 @@ impl ResourceFetcher for HttpFetcher {
             .map_err(|source| fetch_error(uri_string.clone(), HttpFetchError::Body { source }))?;
 
         parse_body(&uri_string, uri, content_type.as_deref(), &bytes)
+    }
+}
+
+/// Async HTTP/HTTPS fetcher backed by `reqwest::Client`.
+///
+/// `AsyncHttpFetcher` mirrors [`HttpFetcher`] for callers that drive the
+/// loader through [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
+/// It is `Clone` and shares the underlying connection pool across clones.
+/// A tokio runtime must be active when the returned future is awaited.
+#[derive(Clone, Debug)]
+pub struct AsyncHttpFetcher {
+    client: AsyncClient,
+}
+
+impl AsyncHttpFetcher {
+    /// Build an async HTTP fetcher with a default `rustls-tls` client and a
+    /// 30-second request timeout.
+    pub fn new() -> Self {
+        Self::with_client(
+            AsyncClient::builder()
+                .timeout(DEFAULT_TIMEOUT)
+                .build()
+                .expect("default reqwest::Client must build"),
+        )
+    }
+
+    /// Build a fetcher from a caller-provided `reqwest::Client`. Use this to
+    /// override timeouts, redirect policy, TLS config, or proxy settings.
+    pub fn with_client(client: AsyncClient) -> Self {
+        Self { client }
+    }
+}
+
+impl Default for AsyncHttpFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AsyncResourceFetcher for AsyncHttpFetcher {
+    fn fetch<'a>(&'a mut self, uri: &'a Url) -> FetchFuture<'a> {
+        let client = self.client.clone();
+        let uri = uri.clone();
+        Box::pin(async move {
+            let uri_string = uri.as_str().to_string();
+            let response = client.get(uri.clone()).send().await.map_err(|source| {
+                fetch_error(uri_string.clone(), HttpFetchError::Request { source })
+            })?;
+
+            let status = response.status();
+            if !status.is_success() {
+                return Err(fetch_error(uri_string, HttpFetchError::Status { status }));
+            }
+
+            let content_type = response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+
+            let bytes = response.bytes().await.map_err(|source| {
+                fetch_error(uri_string.clone(), HttpFetchError::Body { source })
+            })?;
+
+            parse_body(&uri_string, &uri, content_type.as_deref(), &bytes)
+        })
     }
 }
 

--- a/crates/roas-http-fetcher/src/lib.rs
+++ b/crates/roas-http-fetcher/src/lib.rs
@@ -1,0 +1,152 @@
+//! HTTP/HTTPS [`ResourceFetcher`] for the [`roas`] OpenAPI loader.
+//!
+//! See the crate-level README for a usage example. Transport failures, non-2xx
+//! responses, and unreadable bodies are surfaced through [`LoaderError::Fetch`]
+//! with a [`HttpFetchError`] source.
+
+use reqwest::StatusCode;
+use reqwest::blocking::Client;
+use roas::loader::{LoaderError, ResourceFetcher};
+use serde_json::Value;
+use std::time::Duration;
+use url::Url;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// HTTP/HTTPS fetcher backed by `reqwest::blocking::Client`.
+///
+/// `HttpFetcher` is `Clone` so a single underlying connection pool can be
+/// shared across multiple `Loader` registrations (e.g. one for `http://` and
+/// one for `https://`).
+#[derive(Clone, Debug)]
+pub struct HttpFetcher {
+    client: Client,
+}
+
+impl HttpFetcher {
+    /// Build an HTTP fetcher with a default `rustls-tls` client and a 30-second
+    /// request timeout.
+    pub fn new() -> Self {
+        Self::with_client(
+            Client::builder()
+                .timeout(DEFAULT_TIMEOUT)
+                .build()
+                .expect("default reqwest::blocking::Client must build"),
+        )
+    }
+
+    /// Build a fetcher from a caller-provided `reqwest::blocking::Client`. Use
+    /// this to override timeouts, redirect policy, TLS config, or proxy
+    /// settings.
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Default for HttpFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResourceFetcher for HttpFetcher {
+    fn fetch(&mut self, uri: &Url) -> Result<Value, LoaderError> {
+        let uri_string = uri.as_str().to_string();
+        let response = self.client.get(uri.clone()).send().map_err(|source| {
+            fetch_error(uri_string.clone(), HttpFetchError::Request { source })
+        })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(fetch_error(uri_string, HttpFetchError::Status { status }));
+        }
+
+        let bytes = response
+            .bytes()
+            .map_err(|source| fetch_error(uri_string.clone(), HttpFetchError::Body { source }))?;
+
+        serde_json::from_slice(&bytes).map_err(|source| LoaderError::Parse {
+            uri: uri_string,
+            source,
+        })
+    }
+}
+
+/// Transport-layer failure exposed by [`HttpFetcher`].
+///
+/// `HttpFetchError` is what the boxed `source` of [`LoaderError::Fetch`]
+/// carries when produced by this crate. Downstream code that needs the
+/// structured detail (e.g. a status-code-specific retry) can downcast via
+/// `std::error::Error::source` and `downcast_ref::<HttpFetchError>()`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum HttpFetchError {
+    /// The underlying request could not be dispatched: DNS lookup failed, the
+    /// connection was refused, the request timed out, etc.
+    #[error("HTTP request failed")]
+    Request {
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// The server returned a non-success status code.
+    #[error("non-success HTTP response: {status}")]
+    Status { status: StatusCode },
+
+    /// The response headers came back fine but the body could not be read.
+    #[error("failed to read response body")]
+    Body {
+        #[source]
+        source: reqwest::Error,
+    },
+}
+
+fn fetch_error(uri: String, source: HttpFetchError) -> LoaderError {
+    LoaderError::Fetch {
+        uri,
+        source: Box::new(source),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_fetcher_default_constructs() {
+        let _ = HttpFetcher::default();
+        let _ = HttpFetcher::new();
+    }
+
+    #[test]
+    fn http_fetcher_is_clone_and_shares_pool() {
+        // Reqwest's blocking Client is Arc-backed internally, so cloning is
+        // cheap and shares the connection pool. The contract we care about
+        // here is that the wrapper is Clone — exercising it suffices.
+        let fetcher = HttpFetcher::new();
+        let _second = fetcher.clone();
+    }
+
+    #[test]
+    fn fetch_error_helper_boxes_into_loader_error_fetch() {
+        let inner = HttpFetchError::Status {
+            status: StatusCode::NOT_FOUND,
+        };
+        let err = fetch_error("https://example.test/x.json".into(), inner);
+        match err {
+            LoaderError::Fetch { uri, source } => {
+                assert_eq!(uri, "https://example.test/x.json");
+                let downcast = source
+                    .downcast_ref::<HttpFetchError>()
+                    .expect("source must downcast to HttpFetchError");
+                assert!(matches!(
+                    downcast,
+                    HttpFetchError::Status {
+                        status: StatusCode::NOT_FOUND
+                    }
+                ));
+            }
+            other => panic!("expected LoaderError::Fetch, got {other:?}"),
+        }
+    }
+}

--- a/crates/roas-http-fetcher/src/lib.rs
+++ b/crates/roas-http-fetcher/src/lib.rs
@@ -1,21 +1,22 @@
 //! HTTP/HTTPS [`ResourceFetcher`] / [`AsyncResourceFetcher`] for the [`roas`]
 //! OpenAPI loader.
 //!
-//! Two fetchers are exposed:
-//!   * [`HttpFetcher`] — backed by `reqwest::blocking::Client`, plugs into
-//!     [`Loader::register_fetcher`](roas::loader::Loader::register_fetcher).
-//!   * [`AsyncHttpFetcher`] — backed by `reqwest::Client`, plugs into
-//!     [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
-//!     Requires a tokio runtime to be active when the future is awaited.
+//! [`HttpFetcher`] is generic over the underlying `reqwest` client type. The
+//! default selects the blocking client, so `HttpFetcher::new()` returns a
+//! synchronous fetcher suitable for [`Loader::register_fetcher`](roas::loader::Loader::register_fetcher).
+//! The [`AsyncHttpFetcher`] alias selects `reqwest::Client` for use with
+//! [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher);
+//! a tokio runtime must be active when the returned future is awaited.
 //!
-//! Both fetchers are `Clone` so a single underlying connection pool can be
-//! shared across multiple registrations (e.g. one for `http://` and one for
-//! `https://`). Transport failures, non-2xx responses, and unreadable bodies
-//! are surfaced through [`LoaderError::Fetch`] with a [`HttpFetchError`]
-//! source.
+//! Both forms are `Clone` so a single fetcher can be registered for both
+//! `http://` and `https://` prefixes, sharing one underlying connection pool.
+//! Transport failures, non-2xx responses, and unreadable bodies are surfaced
+//! through [`LoaderError::Fetch`] with a [`HttpFetchError`] source. Schemes
+//! other than `http` / `https` are rejected with
+//! [`LoaderError::UnsupportedFetcherUri`].
 //!
-//! With the `yaml` feature enabled, both fetchers parse YAML response bodies
-//! in addition to JSON. Format selection sniffs the response `Content-Type`
+//! With the `yaml` feature enabled, both forms parse YAML response bodies in
+//! addition to JSON. Format selection sniffs the response `Content-Type`
 //! header first and falls back to the URL path extension (`.yaml` / `.yml`).
 
 use reqwest::Client as AsyncClient;
@@ -31,89 +32,78 @@ use url::Url;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// HTTP/HTTPS fetcher backed by `reqwest::blocking::Client`.
+/// HTTP/HTTPS fetcher generic over the underlying `reqwest` client.
 ///
-/// `HttpFetcher` is `Clone` so a single underlying connection pool can be
-/// shared across multiple `Loader` registrations (e.g. one for `http://` and
-/// one for `https://`).
+/// Most callers should reach for one of the two concrete aliases —
+/// [`HttpFetcher`] (blocking) or [`AsyncHttpFetcher`] (async) — rather than
+/// naming `Fetcher<C>` directly. Naming the aliases lets Rust pick the right
+/// inherent `new` / `try_new` impl at the call site without turbofish.
+///
+/// The struct is `Clone` (the underlying `reqwest` client is `Arc`-backed),
+/// so a single fetcher can be registered for both `http://` and `https://`
+/// prefixes on the same `Loader`, sharing one connection pool.
 #[derive(Clone, Debug)]
-pub struct HttpFetcher {
-    client: Client,
+pub struct Fetcher<C> {
+    client: C,
 }
 
-impl HttpFetcher {
-    /// Build an HTTP fetcher with a default `rustls-tls` client and a 30-second
-    /// request timeout.
+/// Blocking HTTP/HTTPS fetcher, suitable for
+/// [`Loader::register_fetcher`](roas::loader::Loader::register_fetcher).
+pub type HttpFetcher = Fetcher<Client>;
+
+/// Async HTTP/HTTPS fetcher, suitable for
+/// [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
+/// A tokio runtime must be active when the returned future is awaited.
+pub type AsyncHttpFetcher = Fetcher<AsyncClient>;
+
+impl Fetcher<Client> {
+    /// Build a blocking HTTP fetcher with a default `rustls-tls` client and a
+    /// 30-second request timeout.
+    ///
+    /// Panics if the default `reqwest::blocking::Client` cannot be built.
+    /// See [`try_new`](Self::try_new) for a fallible variant.
     pub fn new() -> Self {
-        Self::with_client(
-            Client::builder()
-                .timeout(DEFAULT_TIMEOUT)
-                .build()
-                .expect("default reqwest::blocking::Client must build"),
-        )
+        Self::try_new().expect("default reqwest::blocking::Client must build")
     }
 
-    /// Build a fetcher from a caller-provided `reqwest::blocking::Client`. Use
-    /// this to override timeouts, redirect policy, TLS config, or proxy
+    /// Fallible variant of [`new`](Self::new) that surfaces TLS / IO
+    /// environment failures from the underlying `ClientBuilder`.
+    pub fn try_new() -> Result<Self, reqwest::Error> {
+        Ok(Self::with_client(
+            Client::builder().timeout(DEFAULT_TIMEOUT).build()?,
+        ))
+    }
+
+    /// Build a fetcher from a caller-provided `reqwest::blocking::Client`.
+    /// Use this to override timeouts, redirect policy, TLS config, or proxy
     /// settings.
     pub fn with_client(client: Client) -> Self {
         Self { client }
     }
 }
 
-impl Default for HttpFetcher {
+impl Default for Fetcher<Client> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ResourceFetcher for HttpFetcher {
-    fn fetch(&mut self, uri: &Url) -> Result<Value, LoaderError> {
-        let uri_string = uri.as_str().to_string();
-        let response = self.client.get(uri.clone()).send().map_err(|source| {
-            fetch_error(uri_string.clone(), HttpFetchError::Request { source })
-        })?;
-
-        let status = response.status();
-        if !status.is_success() {
-            return Err(fetch_error(uri_string, HttpFetchError::Status { status }));
-        }
-
-        let content_type = response
-            .headers()
-            .get(CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
-
-        let bytes = response
-            .bytes()
-            .map_err(|source| fetch_error(uri_string.clone(), HttpFetchError::Body { source }))?;
-
-        parse_body(&uri_string, uri, content_type.as_deref(), &bytes)
-    }
-}
-
-/// Async HTTP/HTTPS fetcher backed by `reqwest::Client`.
-///
-/// `AsyncHttpFetcher` mirrors [`HttpFetcher`] for callers that drive the
-/// loader through [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
-/// It is `Clone` and shares the underlying connection pool across clones.
-/// A tokio runtime must be active when the returned future is awaited.
-#[derive(Clone, Debug)]
-pub struct AsyncHttpFetcher {
-    client: AsyncClient,
-}
-
-impl AsyncHttpFetcher {
+impl Fetcher<AsyncClient> {
     /// Build an async HTTP fetcher with a default `rustls-tls` client and a
     /// 30-second request timeout.
+    ///
+    /// Panics if the default `reqwest::Client` cannot be built. See
+    /// [`try_new`](Self::try_new) for a fallible variant.
     pub fn new() -> Self {
-        Self::with_client(
-            AsyncClient::builder()
-                .timeout(DEFAULT_TIMEOUT)
-                .build()
-                .expect("default reqwest::Client must build"),
-        )
+        Self::try_new().expect("default reqwest::Client must build")
+    }
+
+    /// Fallible variant of [`new`](Self::new) that surfaces TLS / IO
+    /// environment failures from the underlying `ClientBuilder`.
+    pub fn try_new() -> Result<Self, reqwest::Error> {
+        Ok(Self::with_client(
+            AsyncClient::builder().timeout(DEFAULT_TIMEOUT).build()?,
+        ))
     }
 
     /// Build a fetcher from a caller-provided `reqwest::Client`. Use this to
@@ -123,25 +113,57 @@ impl AsyncHttpFetcher {
     }
 }
 
-impl Default for AsyncHttpFetcher {
+impl Default for Fetcher<AsyncClient> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl AsyncResourceFetcher for AsyncHttpFetcher {
+impl ResourceFetcher for Fetcher<Client> {
+    fn fetch(&mut self, uri: &Url) -> Result<Value, LoaderError> {
+        check_scheme(uri)?;
+        let response = self.client.get(uri.as_str()).send().map_err(|source| {
+            fetch_error(uri.as_str().to_string(), HttpFetchError::Request { source })
+        })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(fetch_error(
+                uri.as_str().to_string(),
+                HttpFetchError::Status { status },
+            ));
+        }
+
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        let bytes = response.bytes().map_err(|source| {
+            fetch_error(uri.as_str().to_string(), HttpFetchError::Body { source })
+        })?;
+
+        parse_body(uri, content_type.as_deref(), &bytes)
+    }
+}
+
+impl AsyncResourceFetcher for Fetcher<AsyncClient> {
     fn fetch<'a>(&'a mut self, uri: &'a Url) -> FetchFuture<'a> {
         let client = self.client.clone();
         let uri = uri.clone();
         Box::pin(async move {
-            let uri_string = uri.as_str().to_string();
-            let response = client.get(uri.clone()).send().await.map_err(|source| {
-                fetch_error(uri_string.clone(), HttpFetchError::Request { source })
+            check_scheme(&uri)?;
+            let response = client.get(uri.as_str()).send().await.map_err(|source| {
+                fetch_error(uri.as_str().to_string(), HttpFetchError::Request { source })
             })?;
 
             let status = response.status();
             if !status.is_success() {
-                return Err(fetch_error(uri_string, HttpFetchError::Status { status }));
+                return Err(fetch_error(
+                    uri.as_str().to_string(),
+                    HttpFetchError::Status { status },
+                ));
             }
 
             let content_type = response
@@ -151,25 +173,27 @@ impl AsyncResourceFetcher for AsyncHttpFetcher {
                 .map(|s| s.to_string());
 
             let bytes = response.bytes().await.map_err(|source| {
-                fetch_error(uri_string.clone(), HttpFetchError::Body { source })
+                fetch_error(uri.as_str().to_string(), HttpFetchError::Body { source })
             })?;
 
-            parse_body(&uri_string, &uri, content_type.as_deref(), &bytes)
+            parse_body(&uri, content_type.as_deref(), &bytes)
         })
     }
 }
 
-fn parse_body(
-    uri_string: &str,
-    uri: &Url,
-    content_type: Option<&str>,
-    bytes: &[u8],
-) -> Result<Value, LoaderError> {
+fn check_scheme(uri: &Url) -> Result<(), LoaderError> {
+    match uri.scheme() {
+        "http" | "https" => Ok(()),
+        _ => Err(LoaderError::UnsupportedFetcherUri(uri.as_str().to_string())),
+    }
+}
+
+fn parse_body(uri: &Url, content_type: Option<&str>, bytes: &[u8]) -> Result<Value, LoaderError> {
     if is_yaml(content_type, uri) {
-        parse_yaml(uri_string, bytes)
+        parse_yaml(uri, bytes)
     } else {
         serde_json::from_slice(bytes).map_err(|source| LoaderError::Parse {
-            uri: uri_string.to_string(),
+            uri: uri.as_str().to_string(),
             source,
         })
     }
@@ -210,16 +234,16 @@ fn is_yaml(content_type: Option<&str>, uri: &Url) -> bool {
 }
 
 #[cfg(feature = "yaml")]
-fn parse_yaml(uri_string: &str, bytes: &[u8]) -> Result<Value, LoaderError> {
+fn parse_yaml(uri: &Url, bytes: &[u8]) -> Result<Value, LoaderError> {
     serde_yaml_ng::from_slice(bytes).map_err(|yaml_err| LoaderError::Parse {
-        uri: uri_string.to_string(),
+        uri: uri.as_str().to_string(),
         source: serde_json::Error::custom(yaml_err.to_string()),
     })
 }
 
 #[cfg(not(feature = "yaml"))]
 #[allow(dead_code)]
-fn parse_yaml(_uri_string: &str, _bytes: &[u8]) -> Result<Value, LoaderError> {
+fn parse_yaml(_uri: &Url, _bytes: &[u8]) -> Result<Value, LoaderError> {
     unreachable!("parse_yaml is only reached when the `yaml` feature is enabled")
 }
 
@@ -267,15 +291,24 @@ mod tests {
     fn http_fetcher_default_constructs() {
         let _ = HttpFetcher::default();
         let _ = HttpFetcher::new();
+        let _ = AsyncHttpFetcher::default();
+        let _ = AsyncHttpFetcher::new();
+    }
+
+    #[test]
+    fn http_fetcher_try_new_succeeds_for_default_config() {
+        HttpFetcher::try_new().expect("blocking client must build");
+        AsyncHttpFetcher::try_new().expect("async client must build");
     }
 
     #[test]
     fn http_fetcher_is_clone_and_shares_pool() {
-        // Reqwest's blocking Client is Arc-backed internally, so cloning is
-        // cheap and shares the connection pool. The contract we care about
-        // here is that the wrapper is Clone — exercising it suffices.
+        // Reqwest's clients are Arc-backed internally, so cloning is cheap and
+        // shares the connection pool. Exercising clone covers the contract.
         let fetcher = HttpFetcher::new();
         let _second = fetcher.clone();
+        let async_fetcher = AsyncHttpFetcher::new();
+        let _async_second = async_fetcher.clone();
     }
 
     #[test]
@@ -299,5 +332,18 @@ mod tests {
             }
             other => panic!("expected LoaderError::Fetch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn check_scheme_accepts_http_and_https() {
+        check_scheme(&Url::parse("http://example.test/x.json").unwrap()).unwrap();
+        check_scheme(&Url::parse("https://example.test/x.json").unwrap()).unwrap();
+    }
+
+    #[test]
+    fn check_scheme_rejects_file_uri_with_unsupported_fetcher_uri() {
+        let err = check_scheme(&Url::parse("file:///tmp/x.json").unwrap())
+            .expect_err("file:// must be rejected");
+        assert!(matches!(err, LoaderError::UnsupportedFetcherUri(s) if s.starts_with("file://")));
     }
 }

--- a/crates/roas-http-fetcher/src/lib.rs
+++ b/crates/roas-http-fetcher/src/lib.rs
@@ -3,10 +3,17 @@
 //! See the crate-level README for a usage example. Transport failures, non-2xx
 //! responses, and unreadable bodies are surfaced through [`LoaderError::Fetch`]
 //! with a [`HttpFetchError`] source.
+//!
+//! With the `yaml` feature enabled, the fetcher parses YAML response bodies in
+//! addition to JSON. Format selection sniffs the response `Content-Type`
+//! header first and falls back to the URL path extension (`.yaml` / `.yml`).
 
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
+use reqwest::header::CONTENT_TYPE;
 use roas::loader::{LoaderError, ResourceFetcher};
+#[cfg(feature = "yaml")]
+use serde::de::Error as _;
 use serde_json::Value;
 use std::time::Duration;
 use url::Url;
@@ -61,15 +68,82 @@ impl ResourceFetcher for HttpFetcher {
             return Err(fetch_error(uri_string, HttpFetchError::Status { status }));
         }
 
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
         let bytes = response
             .bytes()
             .map_err(|source| fetch_error(uri_string.clone(), HttpFetchError::Body { source }))?;
 
-        serde_json::from_slice(&bytes).map_err(|source| LoaderError::Parse {
-            uri: uri_string,
+        parse_body(&uri_string, uri, content_type.as_deref(), &bytes)
+    }
+}
+
+fn parse_body(
+    uri_string: &str,
+    uri: &Url,
+    content_type: Option<&str>,
+    bytes: &[u8],
+) -> Result<Value, LoaderError> {
+    if is_yaml(content_type, uri) {
+        parse_yaml(uri_string, bytes)
+    } else {
+        serde_json::from_slice(bytes).map_err(|source| LoaderError::Parse {
+            uri: uri_string.to_string(),
             source,
         })
     }
+}
+
+/// Decide whether to treat the response body as YAML.
+///
+/// With the `yaml` feature off this always returns `false`. With it on, the
+/// decision is `Content-Type`-first, URL-extension-second:
+///   1. `Content-Type` containing `yaml` (covers `application/yaml`,
+///      `application/x-yaml`, `text/yaml`, `text/x-yaml`, etc.).
+///   2. URL path ending in `.yaml` or `.yml`.
+#[allow(unused_variables)]
+fn is_yaml(content_type: Option<&str>, uri: &Url) -> bool {
+    #[cfg(feature = "yaml")]
+    {
+        if let Some(ct) = content_type {
+            let mime = ct
+                .split(';')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_ascii_lowercase();
+            if mime.contains("yaml") {
+                return true;
+            }
+            if !mime.is_empty() && mime != "application/octet-stream" {
+                return false;
+            }
+        }
+        let path = uri.path().to_ascii_lowercase();
+        path.ends_with(".yaml") || path.ends_with(".yml")
+    }
+    #[cfg(not(feature = "yaml"))]
+    {
+        false
+    }
+}
+
+#[cfg(feature = "yaml")]
+fn parse_yaml(uri_string: &str, bytes: &[u8]) -> Result<Value, LoaderError> {
+    serde_yaml_ng::from_slice(bytes).map_err(|yaml_err| LoaderError::Parse {
+        uri: uri_string.to_string(),
+        source: serde_json::Error::custom(yaml_err.to_string()),
+    })
+}
+
+#[cfg(not(feature = "yaml"))]
+#[allow(dead_code)]
+fn parse_yaml(_uri_string: &str, _bytes: &[u8]) -> Result<Value, LoaderError> {
+    unreachable!("parse_yaml is only reached when the `yaml` feature is enabled")
 }
 
 /// Transport-layer failure exposed by [`HttpFetcher`].

--- a/crates/roas-http-fetcher/src/lib.rs
+++ b/crates/roas-http-fetcher/src/lib.rs
@@ -1,12 +1,13 @@
 //! HTTP/HTTPS [`ResourceFetcher`] / [`AsyncResourceFetcher`] for the [`roas`]
 //! OpenAPI loader.
 //!
-//! [`HttpFetcher`] is generic over the underlying `reqwest` client type. The
-//! default selects the blocking client, so `HttpFetcher::new()` returns a
-//! synchronous fetcher suitable for [`Loader::register_fetcher`](roas::loader::Loader::register_fetcher).
-//! The [`AsyncHttpFetcher`] alias selects `reqwest::Client` for use with
-//! [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher);
-//! a tokio runtime must be active when the returned future is awaited.
+//! The generic [`Fetcher<C>`](Fetcher) is parameterised over the underlying
+//! `reqwest` client type. Two concrete aliases cover the common cases:
+//!   * [`HttpFetcher`] (= `Fetcher<reqwest::blocking::Client>`) — synchronous;
+//!     use with [`Loader::register_fetcher`](roas::loader::Loader::register_fetcher).
+//!   * [`AsyncHttpFetcher`] (= `Fetcher<reqwest::Client>`) — async; use with
+//!     [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
+//!     A tokio runtime must be active when the returned future is awaited.
 //!
 //! Both forms are `Clone` so a single fetcher can be registered for both
 //! `http://` and `https://` prefixes, sharing one underlying connection pool.

--- a/crates/roas-http-fetcher/tests/http_test.rs
+++ b/crates/roas-http-fetcher/tests/http_test.rs
@@ -29,6 +29,7 @@ impl TestResponse {
         }
     }
 
+    #[cfg(feature = "yaml")]
     fn with_content_type(mut self, ct: &'static str) -> Self {
         self.content_type = Some(ct);
         self

--- a/crates/roas-http-fetcher/tests/http_test.rs
+++ b/crates/roas-http-fetcher/tests/http_test.rs
@@ -317,3 +317,46 @@ async fn async_http_fetcher_parses_yaml_when_content_type_signals_yaml() {
     let value = fetcher.fetch(&server.url("doc")).await.expect("fetch ok");
     assert_eq!(value, serde_json::json!({ "name": "pet", "count": 3 }));
 }
+
+#[cfg(feature = "yaml")]
+#[tokio::test]
+async fn async_http_fetcher_parses_yaml_from_url_extension_when_content_type_missing() {
+    let body = b"items:\n  - a\n  - b\n".to_vec();
+    let server = TestServer::start(move |_req| TestResponse::ok_body(body.clone()));
+    let mut fetcher = AsyncHttpFetcher::new();
+    let value = fetcher
+        .fetch(&server.url("doc.yaml"))
+        .await
+        .expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "items": ["a", "b"] }));
+}
+
+#[cfg(feature = "yaml")]
+#[tokio::test]
+async fn async_http_fetcher_yaml_parse_error_surfaces_as_loader_error_parse() {
+    let body = b"key:\n\tvalue: oops\n".to_vec();
+    let server = TestServer::start(move |_req| {
+        TestResponse::ok_body(body.clone()).with_content_type("application/yaml")
+    });
+    let mut fetcher = AsyncHttpFetcher::new();
+    let err = fetcher
+        .fetch(&server.url("bad.yaml"))
+        .await
+        .expect_err("malformed YAML must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}
+
+#[cfg(feature = "yaml")]
+#[tokio::test]
+async fn async_http_fetcher_still_parses_json_when_content_type_is_json_despite_yaml_extension() {
+    let body = br#"{"explicit":"json"}"#.to_vec();
+    let server = TestServer::start(move |_req| {
+        TestResponse::ok_body(body.clone()).with_content_type("application/json")
+    });
+    let mut fetcher = AsyncHttpFetcher::new();
+    let value = fetcher
+        .fetch(&server.url("misleading.yaml"))
+        .await
+        .expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "explicit": "json" }));
+}

--- a/crates/roas-http-fetcher/tests/http_test.rs
+++ b/crates/roas-http-fetcher/tests/http_test.rs
@@ -228,6 +228,25 @@ fn http_fetcher_surfaces_connection_refused_as_loader_error_fetch_request() {
     }
 }
 
+#[test]
+fn http_fetcher_rejects_non_http_scheme_with_unsupported_fetcher_uri() {
+    let mut fetcher = HttpFetcher::new();
+    let err = fetcher
+        .fetch(&Url::parse("file:///tmp/x.json").unwrap())
+        .expect_err("file:// must be rejected");
+    assert!(matches!(err, LoaderError::UnsupportedFetcherUri(_)));
+}
+
+#[tokio::test]
+async fn async_http_fetcher_rejects_non_http_scheme_with_unsupported_fetcher_uri() {
+    let mut fetcher = AsyncHttpFetcher::new();
+    let err = fetcher
+        .fetch(&Url::parse("file:///tmp/x.json").unwrap())
+        .await
+        .expect_err("file:// must be rejected");
+    assert!(matches!(err, LoaderError::UnsupportedFetcherUri(_)));
+}
+
 #[tokio::test]
 async fn async_http_fetcher_returns_parsed_json_on_success() {
     let server = TestServer::start(|_req| TestResponse::ok_json(br#"{"hello":"world"}"#.to_vec()));

--- a/crates/roas-http-fetcher/tests/http_test.rs
+++ b/crates/roas-http-fetcher/tests/http_test.rs
@@ -1,0 +1,143 @@
+use roas::loader::{LoaderError, ResourceFetcher};
+use roas_http_fetcher::{HttpFetchError, HttpFetcher};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{Sender, channel};
+use std::thread::{self, JoinHandle};
+use url::Url;
+
+struct TestServer {
+    base: Url,
+    shutdown: Sender<()>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl TestServer {
+    fn start<F>(handler: F) -> Self
+    where
+        F: Fn(&str) -> (u16, &'static str, Vec<u8>) + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr");
+        listener
+            .set_nonblocking(true)
+            .expect("set listener non-blocking");
+        let base = Url::parse(&format!("http://{addr}/")).expect("parse base url");
+        let (shutdown_tx, shutdown_rx) = channel::<()>();
+
+        let join = thread::spawn(move || {
+            loop {
+                if shutdown_rx.try_recv().is_ok() {
+                    return;
+                }
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        let request_line = read_request_line(&stream);
+                        let (status, reason, body) = handler(&request_line);
+                        write_response(stream, status, reason, &body);
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                    Err(e) => panic!("accept failed: {e}"),
+                }
+            }
+        });
+
+        Self {
+            base,
+            shutdown: shutdown_tx,
+            join: Some(join),
+        }
+    }
+
+    fn url(&self, path: &str) -> Url {
+        self.base.join(path).expect("join path")
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(());
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+fn read_request_line(mut stream: &TcpStream) -> String {
+    let mut buf = [0u8; 1024];
+    let n = stream.read(&mut buf).expect("read request");
+    let raw = String::from_utf8_lossy(&buf[..n]).to_string();
+    raw.lines().next().unwrap_or("").to_string()
+}
+
+fn write_response(mut stream: TcpStream, status: u16, reason: &str, body: &[u8]) {
+    let header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
+        len = body.len(),
+    );
+    stream.write_all(header.as_bytes()).expect("write header");
+    stream.write_all(body).expect("write body");
+}
+
+#[test]
+fn http_fetcher_returns_parsed_json_on_success() {
+    let server = TestServer::start(|_req| (200, "OK", br#"{"hello":"world"}"#.to_vec()));
+    let mut fetcher = HttpFetcher::new();
+    let value = fetcher.fetch(&server.url("doc.json")).expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "hello": "world" }));
+}
+
+#[test]
+fn http_fetcher_surfaces_non_2xx_as_loader_error_fetch_with_status() {
+    let server = TestServer::start(|_req| (404, "Not Found", b"missing".to_vec()));
+    let mut fetcher = HttpFetcher::new();
+    let err = fetcher
+        .fetch(&server.url("nope.json"))
+        .expect_err("non-2xx must error");
+    match err {
+        LoaderError::Fetch { uri, source } => {
+            assert!(uri.ends_with("/nope.json"));
+            let http = source
+                .downcast_ref::<HttpFetchError>()
+                .expect("source must be HttpFetchError");
+            assert!(matches!(
+                http,
+                HttpFetchError::Status { status } if status.as_u16() == 404
+            ));
+        }
+        other => panic!("expected LoaderError::Fetch, got {other:?}"),
+    }
+}
+
+#[test]
+fn http_fetcher_surfaces_invalid_json_body_as_parse_error() {
+    let server = TestServer::start(|_req| (200, "OK", b"not json".to_vec()));
+    let mut fetcher = HttpFetcher::new();
+    let err = fetcher
+        .fetch(&server.url("bad.json"))
+        .expect_err("invalid JSON must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}
+
+#[test]
+fn http_fetcher_surfaces_connection_refused_as_loader_error_fetch_request() {
+    // Bind, capture the port, then drop the listener so nothing is listening.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener);
+    let url = Url::parse(&format!("http://{addr}/missing.json")).expect("url");
+
+    let mut fetcher = HttpFetcher::new();
+    let err = fetcher.fetch(&url).expect_err("no server must error");
+    match err {
+        LoaderError::Fetch { source, .. } => {
+            let http = source
+                .downcast_ref::<HttpFetchError>()
+                .expect("source must be HttpFetchError");
+            assert!(matches!(http, HttpFetchError::Request { .. }));
+        }
+        other => panic!("expected LoaderError::Fetch, got {other:?}"),
+    }
+}

--- a/crates/roas-http-fetcher/tests/http_test.rs
+++ b/crates/roas-http-fetcher/tests/http_test.rs
@@ -12,10 +12,33 @@ struct TestServer {
     join: Option<JoinHandle<()>>,
 }
 
+struct TestResponse {
+    status: u16,
+    reason: &'static str,
+    content_type: Option<&'static str>,
+    body: Vec<u8>,
+}
+
+impl TestResponse {
+    fn ok_json(body: Vec<u8>) -> Self {
+        Self {
+            status: 200,
+            reason: "OK",
+            content_type: None,
+            body,
+        }
+    }
+
+    fn with_content_type(mut self, ct: &'static str) -> Self {
+        self.content_type = Some(ct);
+        self
+    }
+}
+
 impl TestServer {
     fn start<F>(handler: F) -> Self
     where
-        F: Fn(&str) -> (u16, &'static str, Vec<u8>) + Send + 'static,
+        F: Fn(&str) -> TestResponse + Send + 'static,
     {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().expect("local addr");
@@ -33,8 +56,8 @@ impl TestServer {
                 match listener.accept() {
                     Ok((stream, _)) => {
                         let request_line = read_request_line(&stream);
-                        let (status, reason, body) = handler(&request_line);
-                        write_response(stream, status, reason, &body);
+                        let resp = handler(&request_line);
+                        write_response(stream, resp);
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                         thread::sleep(std::time::Duration::from_millis(5));
@@ -72,18 +95,24 @@ fn read_request_line(mut stream: &TcpStream) -> String {
     raw.lines().next().unwrap_or("").to_string()
 }
 
-fn write_response(mut stream: TcpStream, status: u16, reason: &str, body: &[u8]) {
-    let header = format!(
-        "HTTP/1.1 {status} {reason}\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
-        len = body.len(),
+fn write_response(mut stream: TcpStream, resp: TestResponse) {
+    let mut header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Length: {len}\r\nConnection: close\r\n",
+        status = resp.status,
+        reason = resp.reason,
+        len = resp.body.len(),
     );
+    if let Some(ct) = resp.content_type {
+        header.push_str(&format!("Content-Type: {ct}\r\n"));
+    }
+    header.push_str("\r\n");
     stream.write_all(header.as_bytes()).expect("write header");
-    stream.write_all(body).expect("write body");
+    stream.write_all(&resp.body).expect("write body");
 }
 
 #[test]
 fn http_fetcher_returns_parsed_json_on_success() {
-    let server = TestServer::start(|_req| (200, "OK", br#"{"hello":"world"}"#.to_vec()));
+    let server = TestServer::start(|_req| TestResponse::ok_json(br#"{"hello":"world"}"#.to_vec()));
     let mut fetcher = HttpFetcher::new();
     let value = fetcher.fetch(&server.url("doc.json")).expect("fetch ok");
     assert_eq!(value, serde_json::json!({ "hello": "world" }));
@@ -91,7 +120,12 @@ fn http_fetcher_returns_parsed_json_on_success() {
 
 #[test]
 fn http_fetcher_surfaces_non_2xx_as_loader_error_fetch_with_status() {
-    let server = TestServer::start(|_req| (404, "Not Found", b"missing".to_vec()));
+    let server = TestServer::start(|_req| TestResponse {
+        status: 404,
+        reason: "Not Found",
+        content_type: None,
+        body: b"missing".to_vec(),
+    });
     let mut fetcher = HttpFetcher::new();
     let err = fetcher
         .fetch(&server.url("nope.json"))
@@ -113,7 +147,7 @@ fn http_fetcher_surfaces_non_2xx_as_loader_error_fetch_with_status() {
 
 #[test]
 fn http_fetcher_surfaces_invalid_json_body_as_parse_error() {
-    let server = TestServer::start(|_req| (200, "OK", b"not json".to_vec()));
+    let server = TestServer::start(|_req| TestResponse::ok_json(b"not json".to_vec()));
     let mut fetcher = HttpFetcher::new();
     let err = fetcher
         .fetch(&server.url("bad.json"))
@@ -121,9 +155,60 @@ fn http_fetcher_surfaces_invalid_json_body_as_parse_error() {
     assert!(matches!(err, LoaderError::Parse { .. }));
 }
 
+#[cfg(feature = "yaml")]
+#[test]
+fn http_fetcher_parses_yaml_when_content_type_signals_yaml() {
+    let body = b"name: pet\ncount: 3\n".to_vec();
+    let server = TestServer::start(move |_req| {
+        TestResponse::ok_json(body.clone()).with_content_type("application/yaml")
+    });
+    let mut fetcher = HttpFetcher::new();
+    let value = fetcher.fetch(&server.url("doc")).expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "name": "pet", "count": 3 }));
+}
+
+#[cfg(feature = "yaml")]
+#[test]
+fn http_fetcher_parses_yaml_from_url_extension_when_content_type_missing() {
+    let body = b"items:\n  - a\n  - b\n".to_vec();
+    let server = TestServer::start(move |_req| TestResponse::ok_json(body.clone()));
+    let mut fetcher = HttpFetcher::new();
+    let value = fetcher.fetch(&server.url("doc.yaml")).expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "items": ["a", "b"] }));
+}
+
+#[cfg(feature = "yaml")]
+#[test]
+fn http_fetcher_yaml_parse_error_surfaces_as_loader_error_parse() {
+    // ` - foo: bar\nfoo: baz` would still parse; instead, use an
+    // unambiguously-broken document (tab-indented, which YAML 1.2 forbids).
+    let body = b"key:\n\tvalue: oops\n".to_vec();
+    let server = TestServer::start(move |_req| {
+        TestResponse::ok_json(body.clone()).with_content_type("application/yaml")
+    });
+    let mut fetcher = HttpFetcher::new();
+    let err = fetcher
+        .fetch(&server.url("bad.yaml"))
+        .expect_err("malformed YAML must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}
+
+#[cfg(feature = "yaml")]
+#[test]
+fn http_fetcher_still_parses_json_when_content_type_is_json_despite_yaml_extension() {
+    let body = br#"{"explicit":"json"}"#.to_vec();
+    let server = TestServer::start(move |_req| {
+        TestResponse::ok_json(body.clone()).with_content_type("application/json")
+    });
+    let mut fetcher = HttpFetcher::new();
+    let value = fetcher
+        .fetch(&server.url("misleading.yaml"))
+        .expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "explicit": "json" }));
+}
+
 #[test]
 fn http_fetcher_surfaces_connection_refused_as_loader_error_fetch_request() {
-    // Bind, capture the port, then drop the listener so nothing is listening.
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("addr");
     drop(listener);

--- a/crates/roas-http-fetcher/tests/http_test.rs
+++ b/crates/roas-http-fetcher/tests/http_test.rs
@@ -1,5 +1,5 @@
-use roas::loader::{LoaderError, ResourceFetcher};
-use roas_http_fetcher::{HttpFetchError, HttpFetcher};
+use roas::loader::{AsyncResourceFetcher, LoaderError, ResourceFetcher};
+use roas_http_fetcher::{AsyncHttpFetcher, HttpFetchError, HttpFetcher};
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::mpsc::{Sender, channel};
@@ -226,4 +226,75 @@ fn http_fetcher_surfaces_connection_refused_as_loader_error_fetch_request() {
         }
         other => panic!("expected LoaderError::Fetch, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn async_http_fetcher_returns_parsed_json_on_success() {
+    let server = TestServer::start(|_req| TestResponse::ok_json(br#"{"hello":"world"}"#.to_vec()));
+    let mut fetcher = AsyncHttpFetcher::new();
+    let value = fetcher
+        .fetch(&server.url("doc.json"))
+        .await
+        .expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "hello": "world" }));
+}
+
+#[tokio::test]
+async fn async_http_fetcher_surfaces_non_2xx_as_loader_error_fetch_with_status() {
+    let server = TestServer::start(|_req| TestResponse {
+        status: 404,
+        reason: "Not Found",
+        content_type: None,
+        body: b"missing".to_vec(),
+    });
+    let mut fetcher = AsyncHttpFetcher::new();
+    let err = fetcher
+        .fetch(&server.url("nope.json"))
+        .await
+        .expect_err("non-2xx must error");
+    match err {
+        LoaderError::Fetch { uri, source } => {
+            assert!(uri.ends_with("/nope.json"));
+            let http = source
+                .downcast_ref::<HttpFetchError>()
+                .expect("source must be HttpFetchError");
+            assert!(matches!(
+                http,
+                HttpFetchError::Status { status } if status.as_u16() == 404
+            ));
+        }
+        other => panic!("expected LoaderError::Fetch, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn async_http_fetcher_surfaces_connection_refused_as_loader_error_fetch_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener);
+    let url = Url::parse(&format!("http://{addr}/missing.json")).expect("url");
+
+    let mut fetcher = AsyncHttpFetcher::new();
+    let err = fetcher.fetch(&url).await.expect_err("no server must error");
+    match err {
+        LoaderError::Fetch { source, .. } => {
+            let http = source
+                .downcast_ref::<HttpFetchError>()
+                .expect("source must be HttpFetchError");
+            assert!(matches!(http, HttpFetchError::Request { .. }));
+        }
+        other => panic!("expected LoaderError::Fetch, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "yaml")]
+#[tokio::test]
+async fn async_http_fetcher_parses_yaml_when_content_type_signals_yaml() {
+    let body = b"name: pet\ncount: 3\n".to_vec();
+    let server = TestServer::start(move |_req| {
+        TestResponse::ok_json(body.clone()).with_content_type("application/yaml")
+    });
+    let mut fetcher = AsyncHttpFetcher::new();
+    let value = fetcher.fetch(&server.url("doc")).await.expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "name": "pet", "count": 3 }));
 }

--- a/crates/roas-http-fetcher/tests/http_test.rs
+++ b/crates/roas-http-fetcher/tests/http_test.rs
@@ -20,7 +20,7 @@ struct TestResponse {
 }
 
 impl TestResponse {
-    fn ok_json(body: Vec<u8>) -> Self {
+    fn ok_body(body: Vec<u8>) -> Self {
         Self {
             status: 200,
             reason: "OK",
@@ -113,7 +113,7 @@ fn write_response(mut stream: TcpStream, resp: TestResponse) {
 
 #[test]
 fn http_fetcher_returns_parsed_json_on_success() {
-    let server = TestServer::start(|_req| TestResponse::ok_json(br#"{"hello":"world"}"#.to_vec()));
+    let server = TestServer::start(|_req| TestResponse::ok_body(br#"{"hello":"world"}"#.to_vec()));
     let mut fetcher = HttpFetcher::new();
     let value = fetcher.fetch(&server.url("doc.json")).expect("fetch ok");
     assert_eq!(value, serde_json::json!({ "hello": "world" }));
@@ -148,7 +148,7 @@ fn http_fetcher_surfaces_non_2xx_as_loader_error_fetch_with_status() {
 
 #[test]
 fn http_fetcher_surfaces_invalid_json_body_as_parse_error() {
-    let server = TestServer::start(|_req| TestResponse::ok_json(b"not json".to_vec()));
+    let server = TestServer::start(|_req| TestResponse::ok_body(b"not json".to_vec()));
     let mut fetcher = HttpFetcher::new();
     let err = fetcher
         .fetch(&server.url("bad.json"))
@@ -161,7 +161,7 @@ fn http_fetcher_surfaces_invalid_json_body_as_parse_error() {
 fn http_fetcher_parses_yaml_when_content_type_signals_yaml() {
     let body = b"name: pet\ncount: 3\n".to_vec();
     let server = TestServer::start(move |_req| {
-        TestResponse::ok_json(body.clone()).with_content_type("application/yaml")
+        TestResponse::ok_body(body.clone()).with_content_type("application/yaml")
     });
     let mut fetcher = HttpFetcher::new();
     let value = fetcher.fetch(&server.url("doc")).expect("fetch ok");
@@ -172,7 +172,7 @@ fn http_fetcher_parses_yaml_when_content_type_signals_yaml() {
 #[test]
 fn http_fetcher_parses_yaml_from_url_extension_when_content_type_missing() {
     let body = b"items:\n  - a\n  - b\n".to_vec();
-    let server = TestServer::start(move |_req| TestResponse::ok_json(body.clone()));
+    let server = TestServer::start(move |_req| TestResponse::ok_body(body.clone()));
     let mut fetcher = HttpFetcher::new();
     let value = fetcher.fetch(&server.url("doc.yaml")).expect("fetch ok");
     assert_eq!(value, serde_json::json!({ "items": ["a", "b"] }));
@@ -185,7 +185,7 @@ fn http_fetcher_yaml_parse_error_surfaces_as_loader_error_parse() {
     // unambiguously-broken document (tab-indented, which YAML 1.2 forbids).
     let body = b"key:\n\tvalue: oops\n".to_vec();
     let server = TestServer::start(move |_req| {
-        TestResponse::ok_json(body.clone()).with_content_type("application/yaml")
+        TestResponse::ok_body(body.clone()).with_content_type("application/yaml")
     });
     let mut fetcher = HttpFetcher::new();
     let err = fetcher
@@ -199,7 +199,7 @@ fn http_fetcher_yaml_parse_error_surfaces_as_loader_error_parse() {
 fn http_fetcher_still_parses_json_when_content_type_is_json_despite_yaml_extension() {
     let body = br#"{"explicit":"json"}"#.to_vec();
     let server = TestServer::start(move |_req| {
-        TestResponse::ok_json(body.clone()).with_content_type("application/json")
+        TestResponse::ok_body(body.clone()).with_content_type("application/json")
     });
     let mut fetcher = HttpFetcher::new();
     let value = fetcher
@@ -249,7 +249,7 @@ async fn async_http_fetcher_rejects_non_http_scheme_with_unsupported_fetcher_uri
 
 #[tokio::test]
 async fn async_http_fetcher_returns_parsed_json_on_success() {
-    let server = TestServer::start(|_req| TestResponse::ok_json(br#"{"hello":"world"}"#.to_vec()));
+    let server = TestServer::start(|_req| TestResponse::ok_body(br#"{"hello":"world"}"#.to_vec()));
     let mut fetcher = AsyncHttpFetcher::new();
     let value = fetcher
         .fetch(&server.url("doc.json"))
@@ -311,7 +311,7 @@ async fn async_http_fetcher_surfaces_connection_refused_as_loader_error_fetch_re
 async fn async_http_fetcher_parses_yaml_when_content_type_signals_yaml() {
     let body = b"name: pet\ncount: 3\n".to_vec();
     let server = TestServer::start(move |_req| {
-        TestResponse::ok_json(body.clone()).with_content_type("application/yaml")
+        TestResponse::ok_body(body.clone()).with_content_type("application/yaml")
     });
     let mut fetcher = AsyncHttpFetcher::new();
     let value = fetcher.fetch(&server.url("doc")).await.expect("fetch ok");

--- a/deny.toml
+++ b/deny.toml
@@ -88,7 +88,7 @@ ignore = [
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
+allow = ["MIT", "Apache-2.0", "Unicode-3.0", "ISC", "BSD-3-Clause"]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -100,6 +100,9 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], crate = "adler32" },
+    # webpki-roots ships Mozilla's root CA bundle under the data license used
+    # by the upstream CCADB; allow it just for this crate.
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,


### PR DESCRIPTION
## Summary

Adds `roas-http-fetcher`, a `reqwest::blocking::Client`-backed implementation of `roas::loader::ResourceFetcher` that lets `Loader` resolve `http://` and `https://` `$ref`s. An optional `yaml` feature also accepts YAML response bodies.

## Design

- `HttpFetcher` wraps `reqwest::blocking::Client`. The client is `Arc`-backed internally, so the wrapper is `Clone` and a single underlying connection pool can be shared across multiple `Loader` registrations (e.g. one for `http://` and one for `https://`).
- `HttpFetcher::new()` builds a default `rustls-tls` client with a 30-second request timeout; `with_client` accepts a caller-built `Client` for callers who need to override timeouts, TLS config, redirect policy, or proxy settings.
- Transport-layer failures, non-2xx responses, and unreadable bodies are mapped to `LoaderError::Fetch { uri, source: Box<dyn Error + Send + Sync> }` (added to `roas` in 0.13.0). The boxed `source` is a new public `HttpFetchError` enum (`Request` / `Status` / `Body`); downstream code that needs status-code-specific behaviour can `downcast_ref::<HttpFetchError>()` on the source.
- Body parse failures surface through `LoaderError::Parse` — same as the existing `JsonFileFetcher` — for both JSON and (when the feature is enabled) YAML.

`HttpFetchError` is `#[non_exhaustive]` so additional transport-shaped failure modes can be added without a breaking change.

## `yaml` feature

Optional Cargo feature (off by default) pulls in `serde_yaml_ng` and teaches `HttpFetcher` to parse YAML response bodies in addition to JSON. Format selection sniffs `Content-Type` first (anything containing `yaml`: `application/yaml`, `application/x-yaml`, `text/yaml`, etc.) and falls back to the URL path extension (`.yaml` / `.yml`) when the header is absent or generic (`application/octet-stream`). An explicit `application/json` Content-Type wins over a `.yaml` URL extension. YAML parse errors are folded into the same `LoaderError::Parse` variant the JSON path uses, via `serde::de::Error::custom`, so the error contract is uniform.

## Tests

Integration tests under `crates/roas-http-fetcher/tests/http_test.rs` spin up a tiny `std::net::TcpListener`-based responder on an ephemeral port (no extra dev-deps) and exercise:

- 200 OK with JSON body → parsed `Value`.
- 404 → `LoaderError::Fetch` with `HttpFetchError::Status { status: 404 }`.
- 200 OK with non-JSON body → `LoaderError::Parse`.
- No server listening → `LoaderError::Fetch` with `HttpFetchError::Request { .. }`.
- (`yaml` feature) `Content-Type: application/yaml` → parsed as YAML.
- (`yaml` feature) Missing `Content-Type`, URL ending `.yaml` → parsed as YAML.
- (`yaml` feature) Malformed YAML → `LoaderError::Parse`.
- (`yaml` feature) `Content-Type: application/json` with `.yaml` URL → parsed as JSON (Content-Type wins).

Plus unit tests for `Clone`-ability, the default constructor, and the `fetch_error` boxing helper.

## License audit

`reqwest` + `rustls` transitively pull in licenses that aren't on the previous allow list:

- ISC (rustls-webpki, untrusted) — MIT-equivalent permissive.
- BSD-3-Clause (subtle) — MIT plus a no-endorsement clause; required by every rustls-using project.
- CDLA-Permissive-2.0 (webpki-roots only) — Mozilla CA bundle data license, allowed via a per-crate `[[licenses.exceptions]]` entry rather than the global allow list.

All three are permissive and compatible with `MIT OR Apache-2.0`.

## Publish sequencing

`cargo publish --dry-run` for both `roas` (unchanged at 0.13.0) and `roas-http-fetcher@0.1.0` (with `--all-features`) passes locally. The fetcher depends on `roas = "0.13"`, which is already on crates.io (#130), so the previous workspace bootstrap problem does not recur.