### PR TITLE
feat: add roas-file-fetcher crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 serde_yaml_ng = "0.10.0"
 thiserror = "2.0.16"
+tokio = { version = "1.52", default-features = false }
 url = "2.5.8"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This repository is a Cargo workspace for [roas](https://crates.io/crates/roas) — a Rust implementation of the
 OpenAPI Specification (v2.0, v3.0.x, v3.1.x, v3.2.x).
 
-| Crate                                                | Docs                                                                                                  | crates.io                                                                                                                  |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| [`roas`](crates/roas)                                | [![docs.rs](https://docs.rs/roas/badge.svg)](https://docs.rs/roas)                                    | [![crates.io](https://img.shields.io/crates/v/roas.svg)](https://crates.io/crates/roas)                                    |
-| [`roas-http-fetcher`](crates/roas-http-fetcher)      | [![docs.rs](https://docs.rs/roas-http-fetcher/badge.svg)](https://docs.rs/roas-http-fetcher)          | [![crates.io](https://img.shields.io/crates/v/roas-http-fetcher.svg)](https://crates.io/crates/roas-http-fetcher)          |
+| Crate                                           | Docs                                                                                         | crates.io                                                                                                         |
+|-------------------------------------------------|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| [`roas`](crates/roas)                           | [![docs.rs](https://docs.rs/roas/badge.svg)](https://docs.rs/roas)                           | [![crates.io](https://img.shields.io/crates/v/roas.svg)](https://crates.io/crates/roas)                           |
+| [`roas-file-fetcher`](crates/roas-file-fetcher) | [![docs.rs](https://docs.rs/roas-file-fetcher/badge.svg)](https://docs.rs/roas-file-fetcher) | [![crates.io](https://img.shields.io/crates/v/roas-file-fetcher.svg)](https://crates.io/crates/roas-file-fetcher) |
+| [`roas-http-fetcher`](crates/roas-http-fetcher) | [![docs.rs](https://docs.rs/roas-http-fetcher/badge.svg)](https://docs.rs/roas-http-fetcher) | [![crates.io](https://img.shields.io/crates/v/roas-http-fetcher.svg)](https://crates.io/crates/roas-http-fetcher) |
 
 See each crate's `README.md` for usage, and `AGENTS.md` at the repository root for contributor guidelines.
 

--- a/crates/roas-file-fetcher/Cargo.toml
+++ b/crates/roas-file-fetcher/Cargo.toml
@@ -15,6 +15,10 @@ publish = true
 
 [features]
 default = []
+# Enable the `AsyncFileFetcher` (and the `tokio::fs::read` runtime
+# dep that backs it). With this feature off, the crate is sync-only
+# and does not depend on tokio.
+async = ["dep:tokio"]
 # Parse YAML file bodies in addition to JSON. Selection is by file path
 # extension (`.yaml` / `.yml`).
 yaml = ["dep:serde_yaml_ng"]
@@ -24,8 +28,5 @@ roas = { version = ">=0.13", path = "../roas" }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["fs", "rt"] }
+tokio = { workspace = true, optional = true, features = ["fs", "macros", "rt"] }
 url.workspace = true
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["macros"] }

--- a/crates/roas-file-fetcher/Cargo.toml
+++ b/crates/roas-file-fetcher/Cargo.toml
@@ -28,5 +28,11 @@ roas = { version = ">=0.13", path = "../roas" }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["fs", "macros", "rt"] }
+tokio = { workspace = true, optional = true, features = ["fs", "rt"] }
 url.workspace = true
+
+[dev-dependencies]
+# `macros` is needed only by `#[tokio::test]` in the async integration tests;
+# downstream consumers of the public `async` feature should not have to pull
+# in tokio-macros just to use `AsyncFileFetcher`.
+tokio = { workspace = true, features = ["macros"] }

--- a/crates/roas-file-fetcher/Cargo.toml
+++ b/crates/roas-file-fetcher/Cargo.toml
@@ -24,8 +24,8 @@ roas = { version = ">=0.13", path = "../roas" }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng = { workspace = true, optional = true }
-tokio = { version = "1", default-features = false, features = ["fs", "rt"] }
+tokio = { workspace = true, features = ["fs", "rt"] }
 url.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", default-features = false, features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }

--- a/crates/roas-file-fetcher/Cargo.toml
+++ b/crates/roas-file-fetcher/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "roas-file-fetcher"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+description = "Filesystem fetcher for the roas OpenAPI loader, with an async variant and optional YAML support"
+readme = "README.md"
+categories = ["web-programming", "parser-implementations"]
+include = ["src", "Cargo.toml", "README.md"]
+publish = true
+
+[features]
+default = []
+# Parse YAML file bodies in addition to JSON. Selection is by file path
+# extension (`.yaml` / `.yml`).
+yaml = ["dep:serde_yaml_ng"]
+
+[dependencies]
+roas = { version = ">=0.13", path = "../roas" }
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml_ng = { workspace = true, optional = true }
+tokio = { version = "1", default-features = false, features = ["fs", "macros", "rt"] }
+url.workspace = true

--- a/crates/roas-file-fetcher/Cargo.toml
+++ b/crates/roas-file-fetcher/Cargo.toml
@@ -24,5 +24,8 @@ roas = { version = ">=0.13", path = "../roas" }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng = { workspace = true, optional = true }
-tokio = { version = "1", default-features = false, features = ["fs", "macros", "rt"] }
+tokio = { version = "1", default-features = false, features = ["fs", "rt"] }
 url.workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", default-features = false, features = ["macros"] }

--- a/crates/roas-file-fetcher/README.md
+++ b/crates/roas-file-fetcher/README.md
@@ -7,21 +7,17 @@ Filesystem [`ResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.Res
 [![crates.io](https://img.shields.io/crates/v/roas-file-fetcher.svg)](https://crates.io/crates/roas-file-fetcher)
 [![docs.rs](https://docs.rs/roas-file-fetcher/badge.svg)](https://docs.rs/roas-file-fetcher)
 
-Two zero-sized fetcher types share the same API:
-
-- `FileFetcher` — blocking, backed by `std::fs::read`, for `Loader::register_fetcher`.
-- `AsyncFileFetcher` — async, backed by `tokio::fs::read`, for `Loader::register_async_fetcher`. Requires a tokio runtime when the returned future is awaited.
-
-Both reject anything other than `file://` URIs with `LoaderError::UnsupportedFetcherUri`. I/O errors surface as `LoaderError::ReadFile`; body parse errors surface as `LoaderError::Parse`.
+`FileFetcher` is blocking, backed by `std::fs::read`, for `Loader::register_fetcher`. Non-`file://` URIs are rejected with `LoaderError::UnsupportedFetcherUri`. I/O errors surface as `LoaderError::ReadFile`; body parse errors surface as `LoaderError::Parse`.
 
 ## Features
 
-- (default) JSON file bodies are parsed with `serde_json`.
-- `yaml` — also accept YAML file bodies. Format selection is by file path extension (`.yaml` / `.yml`). Pulls in `serde_yaml_ng`.
+- (default) Sync-only, JSON bodies, no tokio dep.
+- `async` — also expose `AsyncFileFetcher`, backed by `tokio::fs::read`, for `Loader::register_async_fetcher`. Requires an active tokio runtime when the returned future is awaited. Pulls in `tokio` with `fs` + `rt` features.
+- `yaml` — accept YAML file bodies in addition to JSON. Selection is by file path extension (`.yaml` / `.yml`). Pulls in `serde_yaml_ng`.
 
 ```toml
 [dependencies]
-roas-file-fetcher = { version = "0.1", features = ["yaml"] }
+roas-file-fetcher = { version = "0.1", features = ["async", "yaml"] }
 ```
 
 ## Usage
@@ -37,6 +33,8 @@ use roas_file_fetcher::FileFetcher;
 let mut loader = Loader::new();
 loader.register_fetcher("file://", FileFetcher::new());
 ```
+
+With the `async` feature enabled:
 
 ```rust
 use roas::loader::Loader;

--- a/crates/roas-file-fetcher/README.md
+++ b/crates/roas-file-fetcher/README.md
@@ -1,0 +1,52 @@
+# roas-file-fetcher
+
+Filesystem [`ResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.ResourceFetcher.html) and
+[`AsyncResourceFetcher`](https://docs.rs/roas/latest/roas/loader/trait.AsyncResourceFetcher.html) for the
+[`roas`](https://crates.io/crates/roas) OpenAPI loader.
+
+[![crates.io](https://img.shields.io/crates/v/roas-file-fetcher.svg)](https://crates.io/crates/roas-file-fetcher)
+[![docs.rs](https://docs.rs/roas-file-fetcher/badge.svg)](https://docs.rs/roas-file-fetcher)
+
+Two zero-sized fetcher types share the same API:
+
+- `FileFetcher` — blocking, backed by `std::fs::read`, for `Loader::register_fetcher`.
+- `AsyncFileFetcher` — async, backed by `tokio::fs::read`, for `Loader::register_async_fetcher`. Requires a tokio runtime when the returned future is awaited.
+
+Both reject anything other than `file://` URIs with `LoaderError::UnsupportedFetcherUri`. I/O errors surface as `LoaderError::ReadFile`; body parse errors surface as `LoaderError::Parse`.
+
+## Features
+
+- (default) JSON file bodies are parsed with `serde_json`.
+- `yaml` — also accept YAML file bodies. Format selection is by file path extension (`.yaml` / `.yml`). Pulls in `serde_yaml_ng`.
+
+```toml
+[dependencies]
+roas-file-fetcher = { version = "0.1", features = ["yaml"] }
+```
+
+## Usage
+
+```shell
+cargo add roas-file-fetcher
+```
+
+```rust
+use roas::loader::Loader;
+use roas_file_fetcher::FileFetcher;
+
+let mut loader = Loader::new();
+loader.register_fetcher("file://", FileFetcher::new());
+```
+
+```rust
+use roas::loader::Loader;
+use roas_file_fetcher::AsyncFileFetcher;
+
+let mut loader = Loader::new();
+loader.register_async_fetcher("file://", AsyncFileFetcher::new());
+```
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at
+your option.

--- a/crates/roas-file-fetcher/src/lib.rs
+++ b/crates/roas-file-fetcher/src/lib.rs
@@ -1,0 +1,169 @@
+//! Filesystem [`ResourceFetcher`] / [`AsyncResourceFetcher`] for the [`roas`]
+//! OpenAPI loader.
+//!
+//! Two zero-sized fetcher types share the same API:
+//!   * [`FileFetcher`] — blocking, backed by [`std::fs::read`].
+//!   * [`AsyncFileFetcher`] — async, backed by [`tokio::fs::read`]; requires
+//!     an active tokio runtime when the returned future is awaited.
+//!
+//! Both reject anything other than `file://` URIs with
+//! [`LoaderError::UnsupportedFetcherUri`]. I/O failures surface as
+//! [`LoaderError::ReadFile`]; body parse failures as [`LoaderError::Parse`].
+//!
+//! With the `yaml` feature enabled, both fetchers parse YAML file bodies in
+//! addition to JSON. Selection is by file path extension (`.yaml` / `.yml`).
+
+use roas::loader::{AsyncResourceFetcher, FetchFuture, LoaderError, ResourceFetcher};
+#[cfg(feature = "yaml")]
+use serde::de::Error as _;
+use serde_json::Value;
+use std::path::PathBuf;
+use url::Url;
+
+/// Blocking filesystem fetcher, suitable for
+/// [`Loader::register_fetcher`](roas::loader::Loader::register_fetcher).
+#[derive(Clone, Debug, Default)]
+pub struct FileFetcher;
+
+impl FileFetcher {
+    /// Construct a blocking file fetcher.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Async filesystem fetcher, suitable for
+/// [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
+/// A tokio runtime must be active when the returned future is awaited.
+#[derive(Clone, Debug, Default)]
+pub struct AsyncFileFetcher;
+
+impl AsyncFileFetcher {
+    /// Construct an async file fetcher.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ResourceFetcher for FileFetcher {
+    fn fetch(&mut self, uri: &Url) -> Result<Value, LoaderError> {
+        check_scheme(uri)?;
+        let path = uri_to_path(uri)?;
+        let bytes =
+            std::fs::read(&path).map_err(|source| LoaderError::ReadFile { path, source })?;
+        parse_body(uri, &bytes)
+    }
+}
+
+impl AsyncResourceFetcher for AsyncFileFetcher {
+    fn fetch<'a>(&'a mut self, uri: &'a Url) -> FetchFuture<'a> {
+        Box::pin(async move {
+            check_scheme(uri)?;
+            let path = uri_to_path(uri)?;
+            let bytes = tokio::fs::read(&path)
+                .await
+                .map_err(|source| LoaderError::ReadFile { path, source })?;
+            parse_body(uri, &bytes)
+        })
+    }
+}
+
+fn check_scheme(uri: &Url) -> Result<(), LoaderError> {
+    if uri.scheme() == "file" {
+        Ok(())
+    } else {
+        Err(LoaderError::UnsupportedFetcherUri(uri.as_str().to_string()))
+    }
+}
+
+fn uri_to_path(uri: &Url) -> Result<PathBuf, LoaderError> {
+    uri.to_file_path()
+        .map_err(|()| LoaderError::InvalidFileUri(uri.as_str().to_string()))
+}
+
+fn parse_body(uri: &Url, bytes: &[u8]) -> Result<Value, LoaderError> {
+    if is_yaml(uri) {
+        parse_yaml(uri, bytes)
+    } else {
+        serde_json::from_slice(bytes).map_err(|source| LoaderError::Parse {
+            uri: uri.as_str().to_string(),
+            source,
+        })
+    }
+}
+
+/// Decide whether to treat the file body as YAML.
+///
+/// With the `yaml` feature off this always returns `false`. With it on, the
+/// URL path is checked against the `.yaml` / `.yml` extensions (case-insensitive).
+#[allow(unused_variables)]
+fn is_yaml(uri: &Url) -> bool {
+    #[cfg(feature = "yaml")]
+    {
+        let path = uri.path().to_ascii_lowercase();
+        path.ends_with(".yaml") || path.ends_with(".yml")
+    }
+    #[cfg(not(feature = "yaml"))]
+    {
+        false
+    }
+}
+
+#[cfg(feature = "yaml")]
+fn parse_yaml(uri: &Url, bytes: &[u8]) -> Result<Value, LoaderError> {
+    serde_yaml_ng::from_slice(bytes).map_err(|yaml_err| LoaderError::Parse {
+        uri: uri.as_str().to_string(),
+        source: serde_json::Error::custom(yaml_err.to_string()),
+    })
+}
+
+#[cfg(not(feature = "yaml"))]
+#[allow(dead_code)]
+fn parse_yaml(_uri: &Url, _bytes: &[u8]) -> Result<Value, LoaderError> {
+    unreachable!("parse_yaml is only reached when the `yaml` feature is enabled")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Helper: extract `&Path` from `LoaderError::ReadFile` so the error tests
+    /// stay one line each.
+    fn read_file_path(err: &LoaderError) -> Option<&Path> {
+        match err {
+            LoaderError::ReadFile { path, .. } => Some(path.as_path()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn file_fetcher_default_constructs() {
+        let _: FileFetcher = Default::default();
+        let _ = FileFetcher::new();
+        let _: AsyncFileFetcher = Default::default();
+        let _ = AsyncFileFetcher::new();
+    }
+
+    #[test]
+    fn check_scheme_accepts_only_file() {
+        check_scheme(&Url::parse("file:///tmp/x.json").unwrap()).unwrap();
+        let err = check_scheme(&Url::parse("http://example.test/x.json").unwrap())
+            .expect_err("http must be rejected");
+        assert!(matches!(err, LoaderError::UnsupportedFetcherUri(s) if s.starts_with("http://")));
+    }
+
+    #[test]
+    fn read_file_path_extracts_path_from_read_file_variant() {
+        let err = LoaderError::ReadFile {
+            path: PathBuf::from("/nope"),
+            source: std::io::Error::other("missing"),
+        };
+        assert_eq!(read_file_path(&err), Some(Path::new("/nope")));
+        let parse_err = LoaderError::Parse {
+            uri: "x".into(),
+            source: serde_json::from_str::<Value>("@").unwrap_err(),
+        };
+        assert_eq!(read_file_path(&parse_err), None);
+    }
+}

--- a/crates/roas-file-fetcher/src/lib.rs
+++ b/crates/roas-file-fetcher/src/lib.rs
@@ -1,19 +1,22 @@
-//! Filesystem [`ResourceFetcher`] / [`AsyncResourceFetcher`] for the [`roas`]
-//! OpenAPI loader.
+//! Filesystem [`ResourceFetcher`] for the [`roas`] OpenAPI loader.
 //!
-//! Two zero-sized fetcher types share the same API:
-//!   * [`FileFetcher`] — blocking, backed by [`std::fs::read`].
-//!   * [`AsyncFileFetcher`] — async, backed by [`tokio::fs::read`]; requires
-//!     an active tokio runtime when the returned future is awaited.
+//! [`FileFetcher`] is blocking and backed by [`std::fs::read`]. Non-`file://`
+//! URIs are rejected with [`LoaderError::UnsupportedFetcherUri`]; I/O failures
+//! surface as [`LoaderError::ReadFile`]; body parse failures as
+//! [`LoaderError::Parse`].
 //!
-//! Both reject anything other than `file://` URIs with
-//! [`LoaderError::UnsupportedFetcherUri`]. I/O failures surface as
-//! [`LoaderError::ReadFile`]; body parse failures as [`LoaderError::Parse`].
-//!
-//! With the `yaml` feature enabled, both fetchers parse YAML file bodies in
-//! addition to JSON. Selection is by file path extension (`.yaml` / `.yml`).
+//! Optional features:
+//!   * `async` — also expose [`AsyncFileFetcher`] for
+//!     [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher),
+//!     backed by [`tokio::fs::read`]. Requires an active tokio runtime when
+//!     the returned future is awaited. Off by default; enabling it pulls in
+//!     `tokio` with `fs` + `rt` features.
+//!   * `yaml` — parse YAML file bodies in addition to JSON. Selection is by
+//!     file path extension (`.yaml` / `.yml`). Pulls in `serde_yaml_ng`.
 
-use roas::loader::{AsyncResourceFetcher, FetchFuture, LoaderError, ResourceFetcher};
+#[cfg(feature = "async")]
+use roas::loader::{AsyncResourceFetcher, FetchFuture};
+use roas::loader::{LoaderError, ResourceFetcher};
 #[cfg(feature = "yaml")]
 use serde::de::Error as _;
 use serde_json::Value;
@@ -35,9 +38,13 @@ impl FileFetcher {
 /// Async filesystem fetcher, suitable for
 /// [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher).
 /// A tokio runtime must be active when the returned future is awaited.
+///
+/// Available only with the `async` feature.
+#[cfg(feature = "async")]
 #[derive(Clone, Debug, Default)]
 pub struct AsyncFileFetcher;
 
+#[cfg(feature = "async")]
 impl AsyncFileFetcher {
     /// Construct an async file fetcher.
     pub fn new() -> Self {
@@ -55,6 +62,7 @@ impl ResourceFetcher for FileFetcher {
     }
 }
 
+#[cfg(feature = "async")]
 impl AsyncResourceFetcher for AsyncFileFetcher {
     fn fetch<'a>(&'a mut self, uri: &'a Url) -> FetchFuture<'a> {
         Box::pin(async move {
@@ -141,6 +149,11 @@ mod tests {
     fn file_fetcher_default_constructs() {
         let _: FileFetcher = Default::default();
         let _ = FileFetcher::new();
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn async_file_fetcher_default_constructs() {
         let _: AsyncFileFetcher = Default::default();
         let _ = AsyncFileFetcher::new();
     }

--- a/crates/roas-file-fetcher/src/lib.rs
+++ b/crates/roas-file-fetcher/src/lib.rs
@@ -6,11 +6,11 @@
 //! [`LoaderError::Parse`].
 //!
 //! Optional features:
-//!   * `async` — also expose [`AsyncFileFetcher`] for
-//!     [`Loader::register_async_fetcher`](roas::loader::Loader::register_async_fetcher),
-//!     backed by [`tokio::fs::read`]. Requires an active tokio runtime when
-//!     the returned future is awaited. Off by default; enabling it pulls in
-//!     `tokio` with `fs` + `rt` features.
+//!   * `async` — also expose `AsyncFileFetcher` for
+//!     `roas::loader::Loader::register_async_fetcher`, backed by
+//!     `tokio::fs::read`. Requires an active tokio runtime when the returned
+//!     future is awaited. Off by default; enabling it pulls in `tokio` with
+//!     `fs` + `rt` features.
 //!   * `yaml` — parse YAML file bodies in addition to JSON. Selection is by
 //!     file path extension (`.yaml` / `.yml`). Pulls in `serde_yaml_ng`.
 

--- a/crates/roas-file-fetcher/tests/file_test.rs
+++ b/crates/roas-file-fetcher/tests/file_test.rs
@@ -1,5 +1,9 @@
-use roas::loader::{AsyncResourceFetcher, LoaderError, ResourceFetcher};
-use roas_file_fetcher::{AsyncFileFetcher, FileFetcher};
+#[cfg(feature = "async")]
+use roas::loader::AsyncResourceFetcher;
+use roas::loader::{LoaderError, ResourceFetcher};
+#[cfg(feature = "async")]
+use roas_file_fetcher::AsyncFileFetcher;
+use roas_file_fetcher::FileFetcher;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -113,6 +117,7 @@ fn file_fetcher_without_yaml_feature_parses_yaml_path_as_json_and_errors() {
     assert!(matches!(err, LoaderError::Parse { .. }));
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn async_file_fetcher_reads_and_parses_json_body() {
     let file = TempFile::write("async-ok.json", br#"{"hello":"world"}"#);
@@ -121,6 +126,7 @@ async fn async_file_fetcher_reads_and_parses_json_body() {
     assert_eq!(value, serde_json::json!({ "hello": "world" }));
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn async_file_fetcher_rejects_non_file_scheme_with_unsupported_fetcher_uri() {
     let mut fetcher = AsyncFileFetcher::new();
@@ -131,6 +137,7 @@ async fn async_file_fetcher_rejects_non_file_scheme_with_unsupported_fetcher_uri
     assert!(matches!(err, LoaderError::UnsupportedFetcherUri(_)));
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn async_file_fetcher_surfaces_missing_file_as_read_file_error() {
     let url = Url::from_file_path(temp_file("async-missing.json")).unwrap();
@@ -142,6 +149,7 @@ async fn async_file_fetcher_surfaces_missing_file_as_read_file_error() {
     assert!(matches!(err, LoaderError::ReadFile { .. }));
 }
 
+#[cfg(feature = "async")]
 #[tokio::test]
 async fn async_file_fetcher_surfaces_invalid_json_body_as_parse_error() {
     let file = TempFile::write("async-bad.json", b"not json");
@@ -153,7 +161,7 @@ async fn async_file_fetcher_surfaces_invalid_json_body_as_parse_error() {
     assert!(matches!(err, LoaderError::Parse { .. }));
 }
 
-#[cfg(feature = "yaml")]
+#[cfg(all(feature = "async", feature = "yaml"))]
 #[tokio::test]
 async fn async_file_fetcher_parses_yaml_when_path_extension_is_yaml() {
     let file = TempFile::write("async-ok.yaml", b"name: pet\ncount: 3\n");
@@ -162,7 +170,7 @@ async fn async_file_fetcher_parses_yaml_when_path_extension_is_yaml() {
     assert_eq!(value, serde_json::json!({ "name": "pet", "count": 3 }));
 }
 
-#[cfg(feature = "yaml")]
+#[cfg(all(feature = "async", feature = "yaml"))]
 #[tokio::test]
 async fn async_file_fetcher_yaml_parse_error_surfaces_as_loader_error_parse() {
     let file = TempFile::write("async-bad.yaml", b"key:\n\tvalue: oops\n");

--- a/crates/roas-file-fetcher/tests/file_test.rs
+++ b/crates/roas-file-fetcher/tests/file_test.rs
@@ -1,0 +1,175 @@
+use roas::loader::{AsyncResourceFetcher, LoaderError, ResourceFetcher};
+use roas_file_fetcher::{AsyncFileFetcher, FileFetcher};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use url::Url;
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Unique temp-file path scoped to the test process so parallel tests don't
+/// trample each other.
+fn temp_file(suffix: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "roas-file-fetcher-{}-{}-{suffix}",
+        std::process::id(),
+        n,
+    ))
+}
+
+struct TempFile(PathBuf);
+
+impl TempFile {
+    fn write(suffix: &str, body: &[u8]) -> Self {
+        let path = temp_file(suffix);
+        fs::write(&path, body).expect("write temp file");
+        Self(path)
+    }
+
+    fn url(&self) -> Url {
+        Url::from_file_path(&self.0).expect("file path to url")
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+#[test]
+fn file_fetcher_reads_and_parses_json_body() {
+    let file = TempFile::write("ok.json", br#"{"hello":"world"}"#);
+    let mut fetcher = FileFetcher::new();
+    let value = fetcher.fetch(&file.url()).expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "hello": "world" }));
+}
+
+#[test]
+fn file_fetcher_rejects_non_file_scheme_with_unsupported_fetcher_uri() {
+    let mut fetcher = FileFetcher::new();
+    let err = fetcher
+        .fetch(&Url::parse("https://example.test/x.json").unwrap())
+        .expect_err("https must be rejected");
+    assert!(matches!(err, LoaderError::UnsupportedFetcherUri(_)));
+}
+
+#[test]
+fn file_fetcher_surfaces_missing_file_as_read_file_error() {
+    let url = Url::from_file_path(temp_file("missing.json")).unwrap();
+    let mut fetcher = FileFetcher::new();
+    let err = fetcher.fetch(&url).expect_err("missing file must error");
+    assert!(matches!(err, LoaderError::ReadFile { .. }));
+}
+
+#[test]
+fn file_fetcher_surfaces_invalid_json_body_as_parse_error() {
+    let file = TempFile::write("bad.json", b"not json");
+    let mut fetcher = FileFetcher::new();
+    let err = fetcher
+        .fetch(&file.url())
+        .expect_err("invalid JSON must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}
+
+#[cfg(feature = "yaml")]
+#[test]
+fn file_fetcher_parses_yaml_when_path_extension_is_yaml() {
+    let file = TempFile::write("ok.yaml", b"name: pet\ncount: 3\n");
+    let mut fetcher = FileFetcher::new();
+    let value = fetcher.fetch(&file.url()).expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "name": "pet", "count": 3 }));
+}
+
+#[cfg(feature = "yaml")]
+#[test]
+fn file_fetcher_parses_yaml_when_path_extension_is_yml() {
+    let file = TempFile::write("ok.yml", b"items:\n  - a\n  - b\n");
+    let mut fetcher = FileFetcher::new();
+    let value = fetcher.fetch(&file.url()).expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "items": ["a", "b"] }));
+}
+
+#[cfg(feature = "yaml")]
+#[test]
+fn file_fetcher_yaml_parse_error_surfaces_as_loader_error_parse() {
+    let file = TempFile::write("bad.yaml", b"key:\n\tvalue: oops\n");
+    let mut fetcher = FileFetcher::new();
+    let err = fetcher
+        .fetch(&file.url())
+        .expect_err("malformed YAML must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}
+
+#[cfg(not(feature = "yaml"))]
+#[test]
+fn file_fetcher_without_yaml_feature_parses_yaml_path_as_json_and_errors() {
+    let file = TempFile::write("noyaml.yaml", b"name: pet\n");
+    let mut fetcher = FileFetcher::new();
+    let err = fetcher
+        .fetch(&file.url())
+        .expect_err("yaml body parsed as json must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}
+
+#[tokio::test]
+async fn async_file_fetcher_reads_and_parses_json_body() {
+    let file = TempFile::write("async-ok.json", br#"{"hello":"world"}"#);
+    let mut fetcher = AsyncFileFetcher::new();
+    let value = fetcher.fetch(&file.url()).await.expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "hello": "world" }));
+}
+
+#[tokio::test]
+async fn async_file_fetcher_rejects_non_file_scheme_with_unsupported_fetcher_uri() {
+    let mut fetcher = AsyncFileFetcher::new();
+    let err = fetcher
+        .fetch(&Url::parse("https://example.test/x.json").unwrap())
+        .await
+        .expect_err("https must be rejected");
+    assert!(matches!(err, LoaderError::UnsupportedFetcherUri(_)));
+}
+
+#[tokio::test]
+async fn async_file_fetcher_surfaces_missing_file_as_read_file_error() {
+    let url = Url::from_file_path(temp_file("async-missing.json")).unwrap();
+    let mut fetcher = AsyncFileFetcher::new();
+    let err = fetcher
+        .fetch(&url)
+        .await
+        .expect_err("missing file must error");
+    assert!(matches!(err, LoaderError::ReadFile { .. }));
+}
+
+#[tokio::test]
+async fn async_file_fetcher_surfaces_invalid_json_body_as_parse_error() {
+    let file = TempFile::write("async-bad.json", b"not json");
+    let mut fetcher = AsyncFileFetcher::new();
+    let err = fetcher
+        .fetch(&file.url())
+        .await
+        .expect_err("invalid JSON must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}
+
+#[cfg(feature = "yaml")]
+#[tokio::test]
+async fn async_file_fetcher_parses_yaml_when_path_extension_is_yaml() {
+    let file = TempFile::write("async-ok.yaml", b"name: pet\ncount: 3\n");
+    let mut fetcher = AsyncFileFetcher::new();
+    let value = fetcher.fetch(&file.url()).await.expect("fetch ok");
+    assert_eq!(value, serde_json::json!({ "name": "pet", "count": 3 }));
+}
+
+#[cfg(feature = "yaml")]
+#[tokio::test]
+async fn async_file_fetcher_yaml_parse_error_surfaces_as_loader_error_parse() {
+    let file = TempFile::write("async-bad.yaml", b"key:\n\tvalue: oops\n");
+    let mut fetcher = AsyncFileFetcher::new();
+    let err = fetcher
+        .fetch(&file.url())
+        .await
+        .expect_err("malformed YAML must error");
+    assert!(matches!(err, LoaderError::Parse { .. }));
+}

--- a/crates/roas-http-fetcher/Cargo.toml
+++ b/crates/roas-http-fetcher/Cargo.toml
@@ -30,4 +30,4 @@ thiserror.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros", "net", "time"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "time"] }


### PR DESCRIPTION
## Summary

Adds `roas-file-fetcher`, a filesystem-backed implementation of `roas::loader::ResourceFetcher` and `AsyncResourceFetcher`. The shape mirrors `roas-http-fetcher`:

- `FileFetcher` — blocking, backed by `std::fs::read`, for `Loader::register_fetcher`.
- `AsyncFileFetcher` — async, backed by `tokio::fs::read`, for `Loader::register_async_fetcher`. Requires an active tokio runtime when the returned future is awaited.

Both are zero-sized unit structs. Non-`file://` URIs are rejected with `LoaderError::UnsupportedFetcherUri`; I/O failures surface as `LoaderError::ReadFile`; body parse failures as `LoaderError::Parse`.

## `yaml` feature

Optional Cargo feature (off by default) pulls in `serde_yaml_ng` and parses `.yaml` / `.yml` paths as YAML. With the feature off the extension is ignored and JSON parsing is attempted regardless (so a `.yaml` file fails with `LoaderError::Parse` — same as today's in-tree `JsonFileFetcher`). YAML parse errors fold into the same `LoaderError::Parse` variant the JSON path uses (via `serde::de::Error::custom`), so the error contract is uniform.

## Coexistence with the in-tree `JsonFileFetcher`

`roas` continues to ship `JsonFileFetcher` as a no-extra-deps built-in. `roas-file-fetcher` is the opt-in superset for callers who want async support and/or YAML — they bring tokio and (optionally) serde_yaml_ng with them.

## Tests

Integration tests under `crates/roas-file-fetcher/tests/file_test.rs` write to `std::env::temp_dir()` with a process-scoped unique counter (no extra dev-deps) and cover both flavours across:

- 200 OK with JSON body → parsed `Value`.
- Non-`file://` scheme → `LoaderError::UnsupportedFetcherUri`.
- Missing file → `LoaderError::ReadFile`.
- Invalid JSON body → `LoaderError::Parse`.
- (`yaml` feature) `.yaml` extension → parsed as YAML.
- (`yaml` feature) `.yml` extension → parsed as YAML.
- (`yaml` feature) Malformed YAML → `LoaderError::Parse`.
- (no `yaml` feature) `.yaml` extension → JSON parse failure.

16 tests with `--features yaml`, 12 with default features.

## License audit

`tokio` is the only new transitive dep; all its license-relevant subcrates (`mio`, `windows-sys` family, etc.) already permitted by the workspace `deny.toml`.