### PR TITLE
roas-http-fetcher: bump to 0.2.0

### DIFF
--- a/crates/roas-http-fetcher/Cargo.toml
+++ b/crates/roas-http-fetcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-http-fetcher"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Bump \`roas-http-fetcher\` from 0.1.0 → 0.2.0.

## Why

#133 merged the reqwest 0.12 → 0.13.3 upgrade plus the rustls → native-tls TLS-backend swap. \`HttpFetcher\`'s public API didn't change, but the dep wire shape did (different TLS stack, different transitive deps, different build prerequisites on Linux: OpenSSL is now linked instead of aws-lc-rs being compiled). For a 0.x crate where the minor segment is the breaking number under cargo semver, that's a 0.2.0 bump rather than a 0.1.1 patch.

\`cargo publish --all-features --package roas-http-fetcher --dry-run\` passes locally; no source changes, just the version field.