### PR TITLE
roas: add clap ValueEnum impl for Options; bump 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/sv-tools/roas"
 keywords = ["openapi", "swagger"]
 
 [workspace.dependencies]
+clap = { version = "4.5.50", features = ["derive"] }
 enumset = "1.1.10"
 lazy-regex = "3.6.0"
 monostate = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/sv-tools/roas"
 keywords = ["openapi", "swagger"]
 
 [workspace.dependencies]
-clap = { version = "4.5.50", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 enumset = "1.1.10"
 lazy-regex = "3.6.0"
 monostate = "1.0.0"

--- a/crates/roas/Cargo.toml
+++ b/crates/roas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -27,7 +27,12 @@ v3_1 = []
 # Support for OpenAPI v3.2.x
 v3_2 = []
 
+# `clap::ValueEnum` impl for `validation::Options`, for downstream CLIs that
+# want to surface each `Ignore*` flag as a value-enum choice.
+clap = ["dep:clap"]
+
 [dependencies]
+clap = { workspace = true, optional = true }
 enumset.workspace = true
 lazy-regex.workspace = true
 monostate.workspace = true

--- a/crates/roas/src/validation.rs
+++ b/crates/roas/src/validation.rs
@@ -307,6 +307,130 @@ pub enum Options {
     IgnoreEmptyExternalDocumentationUrl,
 }
 
+/// `clap::ValueEnum` impl for [`Options`], available behind the `clap` Cargo
+/// feature. Each variant maps to a kebab-case name with the leading `Ignore`
+/// dropped — e.g. `Options::IgnoreMissingTags` ↔ `"missing-tags"` — so
+/// downstream CLIs can wire `Options` directly into a `--ignore` style flag
+/// without a hand-rolled mirror enum.
+#[cfg(feature = "clap")]
+impl clap::ValueEnum for Options {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Options::IgnoreMissingTags,
+            Options::IgnoreExternalReferences,
+            Options::IgnoreInvalidUrls,
+            Options::IgnoreNonUniqOperationIDs,
+            Options::IgnoreUnusedPathItems,
+            Options::IgnoreUnusedTags,
+            Options::IgnoreUnusedSchemas,
+            Options::IgnoreUnusedParameters,
+            Options::IgnoreUnusedResponses,
+            Options::IgnoreUnusedServerVariables,
+            Options::IgnoreUnusedExamples,
+            Options::IgnoreUnusedRequestBodies,
+            Options::IgnoreUnusedHeaders,
+            Options::IgnoreUnusedSecuritySchemes,
+            Options::IgnoreUnusedLinks,
+            Options::IgnoreUnusedCallbacks,
+            Options::IgnoreUnusedMediaTypes,
+            Options::IgnoreEmptyInfoTitle,
+            Options::IgnoreEmptyInfoVersion,
+            Options::IgnoreEmptyResponseDescription,
+            Options::IgnoreEmptyExternalDocumentationUrl,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        let (name, help) = match self {
+            Options::IgnoreMissingTags => (
+                "missing-tags",
+                "Skip the `tag referenced but not declared` check (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreExternalReferences => (
+                "external-references",
+                "Don't error on external `$ref`s (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreInvalidUrls => (
+                "invalid-urls",
+                "Skip URL syntax validation (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreNonUniqOperationIDs => (
+                "non-uniq-operation-ids",
+                "Allow duplicate `operationId` values (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedPathItems => (
+                "unused-path-items",
+                "Allow declared-but-unreferenced path items (v3.1)",
+            ),
+            Options::IgnoreUnusedTags => (
+                "unused-tags",
+                "Skip the `tag declared but not used` check (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedSchemas => (
+                "unused-schemas",
+                "Allow unused schemas / definitions (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedParameters => (
+                "unused-parameters",
+                "Allow unused components / parameters (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedResponses => (
+                "unused-responses",
+                "Allow unused components / responses (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedServerVariables => (
+                "unused-server-variables",
+                "Allow unused server variables (v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedExamples => (
+                "unused-examples",
+                "Allow unused components / examples (v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedRequestBodies => (
+                "unused-request-bodies",
+                "Allow unused components / request bodies (v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedHeaders => (
+                "unused-headers",
+                "Allow unused components / headers (v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedSecuritySchemes => (
+                "unused-security-schemes",
+                "Allow unused components / security schemes (v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedLinks => (
+                "unused-links",
+                "Allow unused components / links (v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedCallbacks => (
+                "unused-callbacks",
+                "Allow unused components / callbacks (v3.0, v3.1)",
+            ),
+            Options::IgnoreUnusedMediaTypes => (
+                "unused-media-types",
+                "Allow unused components / media types (v3.2)",
+            ),
+            Options::IgnoreEmptyInfoTitle => (
+                "empty-info-title",
+                "Allow empty `info.title` (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreEmptyInfoVersion => (
+                "empty-info-version",
+                "Allow empty `info.version` (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreEmptyResponseDescription => (
+                "empty-response-description",
+                "Allow empty response `description` (v2.0, v3.0, v3.1)",
+            ),
+            Options::IgnoreEmptyExternalDocumentationUrl => (
+                "empty-external-documentation-url",
+                "Allow empty `externalDocs.url` (v2.0, v3.0, v3.1)",
+            ),
+        };
+        Some(clap::builder::PossibleValue::new(name).help(help))
+    }
+}
+
 /// A set of options to ignore unused objects.
 pub const IGNORE_UNUSED: EnumSet<Options> = enum_set!(
     Options::IgnoreUnusedTags
@@ -588,6 +712,52 @@ impl<'a, T> From<Context<'a, T>> for Result<(), Error> {
             Ok(())
         } else {
             Err(Error { errors: val.errors })
+        }
+    }
+}
+
+#[cfg(all(test, feature = "clap"))]
+mod clap_value_enum_tests {
+    use super::*;
+    use clap::ValueEnum;
+
+    #[test]
+    fn value_variants_covers_every_options_variant_exactly_once() {
+        // Folding the listed variants into an EnumSet collapses any duplicate
+        // — equal cardinality + equality vs the full `EnumSet::all()` proves
+        // we list each variant exactly once and miss none. Catches drift when
+        // new `Options` variants are added without updating `value_variants`.
+        let variants = <Options as ValueEnum>::value_variants();
+        let listed: EnumSet<Options> = variants.iter().copied().collect();
+        assert_eq!(listed.len(), variants.len(), "duplicate variant listed");
+        assert_eq!(listed, EnumSet::<Options>::all());
+    }
+
+    #[test]
+    fn possible_value_names_are_unique_and_kebab_case() {
+        let mut seen: Vec<String> = Vec::new();
+        for variant in <Options as ValueEnum>::value_variants() {
+            let pv = variant
+                .to_possible_value()
+                .expect("every variant must have a possible value");
+            let name = pv.get_name().to_string();
+            assert!(
+                name.bytes().all(|b| b.is_ascii_lowercase() || b == b'-'),
+                "name `{name}` is not kebab-case",
+            );
+            assert!(!seen.contains(&name), "duplicate name `{name}`");
+            seen.push(name);
+        }
+    }
+
+    #[test]
+    fn from_str_round_trips_for_every_variant() {
+        for variant in <Options as ValueEnum>::value_variants() {
+            let pv = variant.to_possible_value().unwrap();
+            let name = pv.get_name();
+            let parsed = <Options as ValueEnum>::from_str(name, false)
+                .expect("name must parse back to a variant");
+            assert_eq!(parsed, *variant);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in \`clap\` Cargo feature on \`roas\` that implements \`clap::ValueEnum\` for \`validation::Options\`, with each variant mapped to a kebab-case name with the leading \`Ignore\` dropped (e.g. \`Options::IgnoreMissingTags\` ↔ \`\"missing-tags\"\`).

## Why

Downstream CLIs that surface \`Options\` as a value-enum flag currently have to keep a hand-rolled mirror enum + a \`to_option\` mapper, because the orphan rule blocks \`impl ValueEnum for Options\` outside of either crate. That mirror drifts whenever a new \`Options\` variant is added — in practice \`roas-cli\`'s mirror only covered 10 of the 21 variants \`roas\` already exposes.

Putting the impl in \`roas\` upstream collapses the duplication: \`roas-cli\` (and any other downstream tool) can write \`#[arg(long, value_enum)] ignore: Vec<Options>\` directly.

## Design

- New optional dep \`clap = { workspace = true, optional = true }\` on \`roas\`.
- New feature \`clap = [\"dep:clap\"]\`. Off by default; library consumers who don't need CLI integration see no change.
- \`clap = { version = \"4.5.50\", features = [\"derive\"] }\` is added to \`[workspace.dependencies]\` so the feature inherits a shared pin.
- \`impl clap::ValueEnum for Options\` lives in \`crates/roas/src/validation.rs\` under \`#[cfg(feature = \"clap\")]\`. Implemented manually (not derived) so the value names can drop the redundant \`Ignore\` prefix.

## Tests

Three guards under \`#[cfg(all(test, feature = \"clap\"))]\`:

- \`value_variants_covers_every_options_variant_exactly_once\` — folds the listed variants into an \`EnumSet\` and asserts equality with \`EnumSet::<Options>::all()\`. Catches drift the next time someone adds a variant without updating the value-enum list.
- \`possible_value_names_are_unique_and_kebab_case\` — guards the naming convention.
- \`from_str_round_trips_for_every_variant\` — ensures \`ValueEnum::from_str\` can parse every name back.

\`cargo nextest run -p roas --all-features\` passes (854 tests). \`cargo publish --dry-run --all-features -p roas\` is clean.

## Next step

Once this merges and \`roas@0.13.1\` publishes, PR #135 (roas-cli) will be rebased to drop its local \`IgnoreKind\` mirror and use \`Vec<Options>\` directly with \`features = [\"clap\"]\` enabled on the roas dep.