### PR TITLE
validation: refresh Options annotations + wire IgnoreNonUniqOperationIDs; bump roas 0.13.2

### DIFF
--- a/crates/roas/Cargo.toml
+++ b/crates/roas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas/src/v2/operation.rs
+++ b/crates/roas/src/v2/operation.rs
@@ -128,6 +128,7 @@ impl ValidateWithContext<Spec> for Operation {
             && !ctx
                 .visited
                 .insert(format!("#/paths/operations/{operation_id}"))
+            && !ctx.is_option(Options::IgnoreNonUniqOperationIDs)
         {
             ctx.error(
                 path.clone(),

--- a/crates/roas/src/v2/spec.rs
+++ b/crates/roas/src/v2/spec.rs
@@ -1580,4 +1580,49 @@ mod tests {
             err.errors
         );
     }
+
+    #[test]
+    fn ignore_non_uniq_operation_ids_suppresses_duplicate_error() {
+        let spec: Spec = serde_json::from_value(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/a": {
+                    "get": {
+                        "operationId": "dup",
+                        "responses": {"200": {"description": "ok"}},
+                    },
+                },
+                "/b": {
+                    "get": {
+                        "operationId": "dup",
+                        "responses": {"200": {"description": "ok"}},
+                    },
+                },
+            },
+        }))
+        .expect("spec must parse");
+
+        let err = spec
+            .validate(IGNORE_UNUSED, None)
+            .expect_err("duplicate operationId must error by default");
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("`dup` already exists")),
+            "expected duplicate diagnostic, got: {:?}",
+            err.errors,
+        );
+
+        let opts = IGNORE_UNUSED | Options::IgnoreNonUniqOperationIDs;
+        let result = spec.validate(opts, None);
+        let leftover: Vec<String> = result
+            .err()
+            .map(|e| e.errors.iter().map(|e| e.to_string()).collect())
+            .unwrap_or_default();
+        assert!(
+            leftover.iter().all(|s| !s.contains("already exists")),
+            "IgnoreNonUniqOperationIDs must suppress the duplicate, got: {leftover:?}",
+        );
+    }
 }

--- a/crates/roas/src/v3_0/spec.rs
+++ b/crates/roas/src/v3_0/spec.rs
@@ -721,6 +721,7 @@ impl Spec {
                         && !ctx
                             .visited
                             .insert(format!("#/paths/operations/{operation_id}"))
+                        && !ctx.is_option(Options::IgnoreNonUniqOperationIDs)
                     {
                         ctx.error(
                             "#".to_owned(),
@@ -1530,6 +1531,51 @@ mod tests {
                 .has_exact("#.x-tagGroups[0].name: must not be empty"),
             "expected name error: {:?}",
             ctx.errors
+        );
+    }
+
+    #[test]
+    fn ignore_non_uniq_operation_ids_suppresses_duplicate_error() {
+        let spec: Spec = serde_json::from_value(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/a": {
+                    "get": {
+                        "operationId": "dup",
+                        "responses": {"200": {"description": "ok"}},
+                    },
+                },
+                "/b": {
+                    "get": {
+                        "operationId": "dup",
+                        "responses": {"200": {"description": "ok"}},
+                    },
+                },
+            },
+        }))
+        .expect("spec must parse");
+
+        let err = spec
+            .validate(IGNORE_UNUSED, None)
+            .expect_err("duplicate operationId must error by default");
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("`dup` already in use")),
+            "expected duplicate diagnostic, got: {:?}",
+            err.errors,
+        );
+
+        let opts = IGNORE_UNUSED | Options::IgnoreNonUniqOperationIDs;
+        let result = spec.validate(opts, None);
+        let leftover: Vec<String> = result
+            .err()
+            .map(|e| e.errors.iter().map(|e| e.to_string()).collect())
+            .unwrap_or_default();
+        assert!(
+            leftover.iter().all(|s| !s.contains("already in use")),
+            "IgnoreNonUniqOperationIDs must suppress the duplicate, got: {leftover:?}",
         );
     }
 }

--- a/crates/roas/src/v3_1/spec.rs
+++ b/crates/roas/src/v3_1/spec.rs
@@ -882,6 +882,7 @@ impl Spec {
                 && !ctx
                     .visited
                     .insert(format!("#/paths/operations/{operation_id}"))
+                && !ctx.is_option(Options::IgnoreNonUniqOperationIDs)
             {
                 ctx.error(
                     "#".to_owned(),
@@ -1375,6 +1376,20 @@ mod tests {
                 .any(|e| e.contains("`dup` already in use")),
             "expected operationId duplicate across paths/webhooks: {:?}",
             err.errors
+        );
+
+        // Same spec with `IgnoreNonUniqOperationIDs` set must not surface
+        // the duplicate.
+        let result = spec.validate(Options::IgnoreNonUniqOperationIDs.into(), None);
+        let errors_with_ignore: Vec<String> = result
+            .err()
+            .map(|e| e.errors.iter().map(|e| e.to_string()).collect())
+            .unwrap_or_default();
+        assert!(
+            errors_with_ignore
+                .iter()
+                .all(|s| !s.contains("already in use")),
+            "IgnoreNonUniqOperationIDs must suppress the duplicate, got: {errors_with_ignore:?}",
         );
     }
 

--- a/crates/roas/src/v3_2/spec.rs
+++ b/crates/roas/src/v3_2/spec.rs
@@ -901,6 +901,7 @@ impl Spec {
                 && !ctx
                     .visited
                     .insert(format!("#/paths/operations/{operation_id}"))
+                && !ctx.is_option(Options::IgnoreNonUniqOperationIDs)
             {
                 ctx.error(
                     "#".to_owned(),
@@ -1425,6 +1426,21 @@ mod tests {
                 .any(|e| e.contains("`dup` already in use")),
             "expected operationId duplicate across paths/webhooks: {:?}",
             err.errors
+        );
+
+        // Same spec with `IgnoreNonUniqOperationIDs` set must not surface
+        // the duplicate. (Other errors may still fire — assert specifically
+        // that the duplicate message is absent.)
+        let result = spec.validate(Options::IgnoreNonUniqOperationIDs.into(), None);
+        let errors_with_ignore: Vec<String> = result
+            .err()
+            .map(|e| e.errors.iter().map(|e| e.to_string()).collect())
+            .unwrap_or_default();
+        assert!(
+            errors_with_ignore
+                .iter()
+                .all(|s| !s.contains("already in use")),
+            "IgnoreNonUniqOperationIDs must suppress the duplicate, got: {errors_with_ignore:?}",
         );
     }
 

--- a/crates/roas/src/validation.rs
+++ b/crates/roas/src/validation.rs
@@ -223,67 +223,69 @@ impl Display for Error {
 #[derive(EnumSetType, Debug)]
 pub enum Options {
     /// Ignore missing tags.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreMissingTags,
 
     /// Ignore external references.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreExternalReferences,
 
     /// Ignore invalid URLs.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreInvalidUrls,
 
     /// Ignore non-unique operation IDs.
-    /// Applies for v2.0, v3.0, v3.1
+    ///
+    /// Currently not enforced by any version's validator — reserved for a
+    /// future operationId-uniqueness check. Setting it today is a no-op.
     IgnoreNonUniqOperationIDs,
 
     /// Ignore unused path items.
-    /// Applies for v3.1
+    /// Applies for v3.1, v3.2
     IgnoreUnusedPathItems,
 
     /// Ignore unused tags.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreUnusedTags,
 
     /// Ignore unused schemas (definitions for v2.0).
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreUnusedSchemas,
 
     /// Ignore unused parameters.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreUnusedParameters,
 
     /// Ignore unused responses.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreUnusedResponses,
 
     /// Ignore unused server variables.
-    /// Applies for v3.0, v3.1
+    /// Applies for v3.0, v3.1, v3.2
     IgnoreUnusedServerVariables,
 
     /// Ignore unused examples.
-    /// Applies for v3.0, v3.1
+    /// Applies for v3.0, v3.1, v3.2
     IgnoreUnusedExamples,
 
     /// Ignore unused request bodies.
-    /// Applies for v3.0, v3.1
+    /// Applies for v3.0, v3.1, v3.2
     IgnoreUnusedRequestBodies,
 
     /// Ignore unused headers.
-    /// Applies for v3.0, v3.1
+    /// Applies for v3.0, v3.1, v3.2
     IgnoreUnusedHeaders,
 
     /// Ignore unused security schemes.
-    /// Applies for v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreUnusedSecuritySchemes,
 
     /// Ignore unused links.
-    /// Applies for v3.0, v3.1
+    /// Applies for v3.0, v3.1, v3.2
     IgnoreUnusedLinks,
 
     /// Ignore unused callbacks.
-    /// Applies for v3.0, v3.1
+    /// Applies for v3.0, v3.1, v3.2
     IgnoreUnusedCallbacks,
 
     /// Ignore unused media types (added in OAS 3.2).
@@ -291,19 +293,19 @@ pub enum Options {
     IgnoreUnusedMediaTypes,
 
     /// Ignore empty Info.Title field.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreEmptyInfoTitle,
 
     /// Ignore empty Info.Version field.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreEmptyInfoVersion,
 
     /// Ignore empty Response.Description field.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreEmptyResponseDescription,
 
     /// Ignore empty ExternalDocumentation.URL field.
-    /// Applies for v2.0, v3.0, v3.1
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreEmptyExternalDocumentationUrl,
 }
 
@@ -344,67 +346,67 @@ impl clap::ValueEnum for Options {
         let (name, help) = match self {
             Options::IgnoreMissingTags => (
                 "missing-tags",
-                "Skip the `tag referenced but not declared` check (v2.0, v3.0, v3.1)",
+                "Skip the `tag referenced but not declared` check (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreExternalReferences => (
                 "external-references",
-                "Don't error on external `$ref`s (v2.0, v3.0, v3.1)",
+                "Don't error on external `$ref`s (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreInvalidUrls => (
                 "invalid-urls",
-                "Skip URL syntax validation (v2.0, v3.0, v3.1)",
+                "Skip URL syntax validation (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreNonUniqOperationIDs => (
                 "non-uniq-operation-ids",
-                "Allow duplicate `operationId` values (v2.0, v3.0, v3.1)",
+                "Allow duplicate `operationId` values (reserved — no validator checks this today)",
             ),
             Options::IgnoreUnusedPathItems => (
                 "unused-path-items",
-                "Allow declared-but-unreferenced path items (v3.1)",
+                "Allow declared-but-unreferenced path items (v3.1, v3.2)",
             ),
             Options::IgnoreUnusedTags => (
                 "unused-tags",
-                "Skip the `tag declared but not used` check (v2.0, v3.0, v3.1)",
+                "Skip the `tag declared but not used` check (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedSchemas => (
                 "unused-schemas",
-                "Allow unused schemas / definitions (v2.0, v3.0, v3.1)",
+                "Allow unused schemas / definitions (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedParameters => (
                 "unused-parameters",
-                "Allow unused components / parameters (v2.0, v3.0, v3.1)",
+                "Allow unused components / parameters (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedResponses => (
                 "unused-responses",
-                "Allow unused components / responses (v2.0, v3.0, v3.1)",
+                "Allow unused components / responses (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedServerVariables => (
                 "unused-server-variables",
-                "Allow unused server variables (v3.0, v3.1)",
+                "Allow unused server variables (v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedExamples => (
                 "unused-examples",
-                "Allow unused components / examples (v3.0, v3.1)",
+                "Allow unused components / examples (v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedRequestBodies => (
                 "unused-request-bodies",
-                "Allow unused components / request bodies (v3.0, v3.1)",
+                "Allow unused components / request bodies (v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedHeaders => (
                 "unused-headers",
-                "Allow unused components / headers (v3.0, v3.1)",
+                "Allow unused components / headers (v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedSecuritySchemes => (
                 "unused-security-schemes",
-                "Allow unused components / security schemes (v3.0, v3.1)",
+                "Allow unused components / security schemes (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedLinks => (
                 "unused-links",
-                "Allow unused components / links (v3.0, v3.1)",
+                "Allow unused components / links (v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedCallbacks => (
                 "unused-callbacks",
-                "Allow unused components / callbacks (v3.0, v3.1)",
+                "Allow unused components / callbacks (v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedMediaTypes => (
                 "unused-media-types",
@@ -412,19 +414,19 @@ impl clap::ValueEnum for Options {
             ),
             Options::IgnoreEmptyInfoTitle => (
                 "empty-info-title",
-                "Allow empty `info.title` (v2.0, v3.0, v3.1)",
+                "Allow empty `info.title` (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreEmptyInfoVersion => (
                 "empty-info-version",
-                "Allow empty `info.version` (v2.0, v3.0, v3.1)",
+                "Allow empty `info.version` (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreEmptyResponseDescription => (
                 "empty-response-description",
-                "Allow empty response `description` (v2.0, v3.0, v3.1)",
+                "Allow empty response `description` (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreEmptyExternalDocumentationUrl => (
                 "empty-external-documentation-url",
-                "Allow empty `externalDocs.url` (v2.0, v3.0, v3.1)",
+                "Allow empty `externalDocs.url` (v2.0, v3.0, v3.1, v3.2)",
             ),
         };
         Some(clap::builder::PossibleValue::new(name).help(help))

--- a/crates/roas/src/validation.rs
+++ b/crates/roas/src/validation.rs
@@ -235,9 +235,7 @@ pub enum Options {
     IgnoreInvalidUrls,
 
     /// Ignore non-unique operation IDs.
-    ///
-    /// Currently not enforced by any version's validator — reserved for a
-    /// future operationId-uniqueness check. Setting it today is a no-op.
+    /// Applies for v2.0, v3.0, v3.1, v3.2
     IgnoreNonUniqOperationIDs,
 
     /// Ignore unused path items.
@@ -358,7 +356,7 @@ impl clap::ValueEnum for Options {
             ),
             Options::IgnoreNonUniqOperationIDs => (
                 "non-uniq-operation-ids",
-                "Allow duplicate `operationId` values (reserved — no validator checks this today)",
+                "Allow duplicate `operationId` values (v2.0, v3.0, v3.1, v3.2)",
             ),
             Options::IgnoreUnusedPathItems => (
                 "unused-path-items",


### PR DESCRIPTION
## Summary

Two related cleanups to `validation::Options`, plus their side effects:

1. **Refresh the per-variant \"Applies for\" annotations.** The doc comments predated the v3.2 validator landing and were never refreshed. Audited each variant against `crates/roas/src/v{2,3_0,3_1,3_2}/` and updated the comments + the matching `clap::ValueEnum` `PossibleValue` help strings.
2. **Wire up `IgnoreNonUniqOperationIDs`.** While doing (1) we noticed the variant exists in the public API but is never consulted by any validator — the operationId-uniqueness check fires unconditionally in all four versions. Fix that.

## Audit table (after this PR)

| variant                              | v2.0 | v3.0 | v3.1 | v3.2 |
|--------------------------------------|------|------|------|------|
| `IgnoreMissingTags`                  |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreExternalReferences`           |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreInvalidUrls`                  |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreNonUniqOperationIDs`          |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedPathItems`              |      |      |  ✓   |  ✓   |
| `IgnoreUnusedTags`                   |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedSchemas`                |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedParameters`             |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedResponses`              |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedServerVariables`        |      |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedExamples`               |      |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedRequestBodies`          |      |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedHeaders`                |      |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedSecuritySchemes`        |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedLinks`                  |      |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedCallbacks`              |      |  ✓   |  ✓   |  ✓   |
| `IgnoreUnusedMediaTypes`             |      |      |      |  ✓   |
| `IgnoreEmptyInfoTitle`               |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreEmptyInfoVersion`             |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreEmptyResponseDescription`     |  ✓   |  ✓   |  ✓   |  ✓   |
| `IgnoreEmptyExternalDocumentationUrl`|  ✓   |  ✓   |  ✓   |  ✓   |

## What changed

- **19 variants** gained v3.2 in their doc + help-text annotation. The v3.2 validator inherits the same unused / empty / external-ref / tag checks as v3.0/v3.1 via the shared `IGNORE_UNUSED` / `IGNORE_EMPTY_REQUIRED_FIELDS` const sets, plus has its own per-field checks for tags, Info, response description, and external-docs URL.
- **`IgnoreUnusedSecuritySchemes`** was misannotated `v3.0, v3.1` but v2.0 checks it too — corrected to all four.
- **`IgnoreUnusedMediaTypes`** stays v3.2-only (media-types components map was added in OAS 3.2).
- **`IgnoreNonUniqOperationIDs`** is now wired into the duplicate-operationId pre-pass in every version's `Spec::validate` (v3.0 / v3.1 / v3.2) and `Operation::validate_with_context` (v2.0). Each site keeps the `ctx.visited.insert(...)` side effect so downstream Link / operationRef resolution still works; only the `ctx.error(...)` push is gated.

## Tests

One new unit test per version (`ignore_non_uniq_operation_ids_suppresses_duplicate_error`) — builds a spec with two operations sharing `operationId: \"dup\"`, asserts the diagnostic fires by default, then re-validates with the flag set and asserts the duplicate message is absent. Existing duplicate-operationId tests continue to fire without the flag, so the default behaviour is unchanged.

Full suite: 856 tests pass, `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean, `cargo deny check` ok, `cargo publish --dry-run -p roas --all-features` clean at 0.13.2.