### PR TITLE
docs(README): position roas for tools.openapis.org categories (SDK / description validators / schema validators / converters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,37 @@
 # roas workspace
 
-This repository is a Cargo workspace for [roas](https://crates.io/crates/roas) — a Rust implementation of the
-OpenAPI Specification (v2.0, v3.0.x, v3.1.x, v3.2.x).
+`roas` is a Rust **SDK** for the OpenAPI Specification — a typed Rust library that
+lets you parse, validate, convert, and round-trip OpenAPI / Swagger documents
+directly from Rust code. The SDK supports every released OpenAPI version: v2.0
+(Swagger), v3.0.x, v3.1.x, and v3.2.x.
+
+## What this SDK provides
+
+- **Parsers and serialisers** — deserialise OpenAPI documents from JSON or YAML
+  into strongly-typed Rust structs (one type tree per spec version) and
+  serialise them back with full round-trip fidelity.
+- **Description validators** — validate that an OpenAPI description conforms
+  to its specification version: required fields, `$ref` resolution, tag /
+  `operationId` uniqueness, unused-component detection, and more. Each check
+  is independently togglable via the `validation::Options` enum.
+- **Schema validators** — every `Schema Object` (the JSON Schema dialect for
+  the matching OAS version) is structurally validated, including `$ref`
+  resolution, discriminator / mapping correctness, and the per-keyword rules
+  the spec mandates. The schema validator is exercised as part of the larger
+  description validator, and also reusable on its own.
+- **Version converters** — upconvert OpenAPI descriptions across major
+  versions: v2.0 → v3.0.x → v3.1.x → v3.2.x. A chain of `From<v_X::Spec> for
+  v_Y::Spec` migrations performs the conversion in pure Rust; the same
+  converters are exposed as a CLI sub-command via [`roas-cli`](crates/roas-cli).
+- **Pluggable loader** — `ResourceFetcher` / `AsyncResourceFetcher` traits
+  for resolving external `$ref`s, with first-party fetcher crates for
+  [filesystem](crates/roas-file-fetcher) and [HTTP](crates/roas-http-fetcher)
+  sources (JSON or YAML bodies, optional async).
+- **Command-line interface** — [`roas-cli`](crates/roas-cli) ships a `roas`
+  binary with `validate` and `convert` subcommands for one-shot use without
+  writing Rust.
+
+## Crates
 
 | Crate                                           | Docs                                                                                         | crates.io                                                                                                         |
 |-------------------------------------------------|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
@@ -10,11 +40,23 @@ OpenAPI Specification (v2.0, v3.0.x, v3.1.x, v3.2.x).
 | [`roas-http-fetcher`](crates/roas-http-fetcher) | [![docs.rs](https://docs.rs/roas-http-fetcher/badge.svg)](https://docs.rs/roas-http-fetcher) | [![crates.io](https://img.shields.io/crates/v/roas-http-fetcher.svg)](https://crates.io/crates/roas-http-fetcher) |
 | [`roas-cli`](crates/roas-cli)                   | —                                                                                            | [![crates.io](https://img.shields.io/crates/v/roas-cli.svg)](https://crates.io/crates/roas-cli)                   |
 
-See each crate's `README.md` for usage, and `AGENTS.md` at the repository root for contributor guidelines.
+## OpenAPI versions
+
+| Spec      | Status |
+|-----------|--------|
+| OpenAPI [v2.0](https://spec.openapis.org/oas/v2.0.html) (Swagger) | parser, description validator, schema validator, converter to v3 |
+| OpenAPI [v3.0.x](https://spec.openapis.org/oas/v3.0.4.html)       | parser, description validator, schema validator, converter to v3.1 / v3.2 |
+| OpenAPI [v3.1.x](https://spec.openapis.org/oas/v3.1.2.html)       | parser, description validator, schema validator, converter to v3.2 |
+| OpenAPI [v3.2.x](https://spec.openapis.org/oas/v3.2.0.html)       | parser, description validator, schema validator (target of all upconverters) |
+
+See each crate's `README.md` for usage examples, and `AGENTS.md` at the
+repository root for contributor guidelines.
 
 > [!CAUTION]
-> The project is in early development; treat any `0.x.x` version as unstable and subject to breaking changes.
+> The project is in early development; treat any `0.x.x` version as unstable
+> and subject to breaking changes.
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
+[MIT license](LICENSE-MIT) at your option.


### PR DESCRIPTION
## Summary

[tools.openapis.org](https://tools.openapis.org) sorts submitted tools into ~28 categories via a Bayesian classifier trained on existing tools' READMEs (`lib/data/transform/classifer.js` in the OAI/tools.openapis.org repo). To make `roas` land in the four categories we care about — **SDK**, **Description Validators**, **Schema Validators**, **Converters** — the root README needs to use the vocabulary the classifier learned from peer tools in each of those buckets.

## What changed

Rewrites the root `README.md` so each target category has a dedicated, prominent bullet in a new "What this SDK provides" section, plus a per-version table that repeats the role labels:

- **SDK** — opens with \"\`roas\` is a Rust SDK for the OpenAPI Specification\"; reinforces \"SDK\" / \"Rust library\" through the intro.
- **Description Validators** — dedicated bullet describing what the description validator checks: required fields, \`\$ref\` resolution, \`operationId\` uniqueness, unused-component detection.
- **Schema Validators** — explicit bullet covering JSON-Schema-dialect validation of \`Schema Object\`s, \`\$ref\` resolution, discriminator / mapping correctness.
- **Converters** — bullet describing the v2 → v3.0 → v3.1 → v3.2 chain of \`From<v_X::Spec> for v_Y::Spec\` migrations; same labels surface again in the per-version table.

No code, no build, no public API change — purely the GitHub-rendered README that the classifier reads.

## Existing topic surface (already correct)

The repo already has every relevant topic:

```
openapi  openapi3  openapi31  openapi32  swagger  openapi2  rust
```

`openapi3` and `openapi31` are the two topics tools.openapis.org's `gulpfile.js/metadata.json` scans today. `swagger` / `openapi2` will pull us in once their issue [#19](https://github.com/OAI/tools.openapis.org/issues/19) ships. `openapi32` is in anticipation of an upstream source addition for OAS 3.2 (not yet wired upstream — would need a one-line PR to their `metadata.json`).