### PR TITLE
roas: add `Spec::merge` (v2 / v3.0 / v3.1 / v3.2)

### DIFF
--- a/crates/roas/src/common.rs
+++ b/crates/roas/src/common.rs
@@ -4,4 +4,5 @@ pub mod bool_or;
 pub mod extensions;
 pub mod formats;
 pub(crate) mod helpers;
+pub(crate) mod merge;
 pub mod reference;

--- a/crates/roas/src/common/merge.rs
+++ b/crates/roas/src/common/merge.rs
@@ -1,0 +1,190 @@
+//! Internal primitives for `Spec::merge` across the per-version trees.
+//!
+//! Every per-version `merge` reduces to three patterns:
+//!   * **Map-merge**: for `Option<BTreeMap<K, V>>` containers (paths,
+//!     `components.<bag>`, extensions). Per-key incoming wins; the base map
+//!     is materialised lazily when only incoming has entries.
+//!   * **Scalar-replace**: for `Option<T>` fields where any incoming `Some`
+//!     should overwrite the base wholesale (`externalDocs`, v2's
+//!     `host`/`basePath`).
+//!   * **List-replace-when-non-empty**: for `Option<Vec<T>>` list fields
+//!     where the contract is "wholesale incoming wins, but an empty
+//!     incoming list doesn't wipe a populated base" (`servers`, `security`,
+//!     v2's `schemes`/`consumes`/`produces`).
+//!
+//! `tags`-style ordered lists keyed by a name field have their own
+//! per-version helper at the call site — the name field's type / lookup
+//! differs by version and the call sites are short.
+
+use std::collections::BTreeMap;
+
+/// Merge `incoming` into `base` per key, with incoming entries replacing
+/// base entries with the same key. `None` incoming is a no-op; a `Some`
+/// incoming with no entries is harmless (extends with nothing).
+pub(crate) fn merge_optional_map<K: Ord, V>(
+    base: &mut Option<BTreeMap<K, V>>,
+    incoming: Option<BTreeMap<K, V>>,
+) {
+    let Some(incoming) = incoming else { return };
+    match base {
+        Some(b) => b.extend(incoming),
+        None => *base = Some(incoming),
+    }
+}
+
+/// Replace `base` with `incoming` whenever `incoming` is `Some(_)`. Used
+/// for scalar option fields where any present value should overwrite the
+/// base wholesale.
+pub(crate) fn merge_optional<T>(base: &mut Option<T>, incoming: Option<T>) {
+    if incoming.is_some() {
+        *base = incoming;
+    }
+}
+
+/// Replace `base` with `incoming` when `incoming` is `Some` *and*
+/// non-empty. An explicit `Some(vec![])` from incoming is treated the
+/// same as `None`: we don't let an empty list wipe a populated base.
+pub(crate) fn merge_optional_list<T>(base: &mut Option<Vec<T>>, incoming: Option<Vec<T>>) {
+    match incoming {
+        Some(v) if !v.is_empty() => *base = Some(v),
+        _ => {}
+    }
+}
+
+/// Per-key merge for a `Vec<T>` keyed by `key(&T)`. Incoming entries with
+/// a key already present in base replace that slot in place; entries with
+/// new keys are appended. A `None` incoming is a no-op.
+///
+/// Used for `tags`: OAS requires `Tag.name` uniqueness across the
+/// document, so the natural merge axis is "incoming wins per name, new
+/// names appended in incoming order".
+pub(crate) fn merge_named_list<T, F>(base: &mut Option<Vec<T>>, incoming: Option<Vec<T>>, key: F)
+where
+    F: Fn(&T) -> &str,
+{
+    let Some(incoming) = incoming else { return };
+    let target = base.get_or_insert_with(Vec::new);
+    for item in incoming {
+        let k = key(&item).to_owned();
+        if let Some(slot) = target.iter_mut().find(|t| key(t) == k) {
+            *slot = item;
+        } else {
+            target.push(item);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_optional_map_replaces_matching_keys_and_appends_new() {
+        let mut base: Option<BTreeMap<String, i32>> =
+            Some([("a".to_owned(), 1), ("b".to_owned(), 2)].into());
+        let incoming: Option<BTreeMap<String, i32>> =
+            Some([("b".to_owned(), 20), ("c".to_owned(), 30)].into());
+        merge_optional_map(&mut base, incoming);
+        let m = base.unwrap();
+        assert_eq!(m.get("a"), Some(&1), "untouched key stays");
+        assert_eq!(m.get("b"), Some(&20), "collision: incoming wins");
+        assert_eq!(m.get("c"), Some(&30), "new key appended");
+    }
+
+    #[test]
+    fn merge_optional_map_materialises_base_when_only_incoming_has_entries() {
+        let mut base: Option<BTreeMap<String, i32>> = None;
+        let incoming: Option<BTreeMap<String, i32>> = Some([("a".to_owned(), 1)].into());
+        merge_optional_map(&mut base, incoming);
+        assert_eq!(base.as_ref().unwrap().get("a"), Some(&1));
+    }
+
+    #[test]
+    fn merge_optional_map_with_none_incoming_is_a_noop() {
+        let mut base: Option<BTreeMap<String, i32>> = Some([("a".to_owned(), 1)].into());
+        merge_optional_map::<String, i32>(&mut base, None);
+        assert_eq!(base.as_ref().unwrap().get("a"), Some(&1));
+    }
+
+    #[test]
+    fn merge_optional_replaces_only_when_incoming_is_some() {
+        let mut base: Option<String> = Some("base".to_owned());
+        merge_optional::<String>(&mut base, None);
+        assert_eq!(base.as_deref(), Some("base"));
+        merge_optional(&mut base, Some("incoming".to_owned()));
+        assert_eq!(base.as_deref(), Some("incoming"));
+    }
+
+    #[test]
+    fn merge_optional_list_keeps_base_when_incoming_is_none_or_empty() {
+        let mut base: Option<Vec<i32>> = Some(vec![1, 2, 3]);
+        merge_optional_list::<i32>(&mut base, None);
+        assert_eq!(base.as_deref(), Some([1, 2, 3].as_slice()));
+        merge_optional_list(&mut base, Some(Vec::<i32>::new()));
+        assert_eq!(
+            base.as_deref(),
+            Some([1, 2, 3].as_slice()),
+            "empty incoming must not wipe populated base",
+        );
+    }
+
+    #[test]
+    fn merge_optional_list_replaces_wholesale_when_incoming_is_non_empty() {
+        let mut base: Option<Vec<i32>> = Some(vec![1, 2, 3]);
+        merge_optional_list(&mut base, Some(vec![9, 8]));
+        assert_eq!(base.as_deref(), Some([9, 8].as_slice()));
+    }
+
+    #[test]
+    fn merge_named_list_replaces_matching_names_and_appends_new() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Named {
+            name: String,
+            v: i32,
+        }
+        let mut base: Option<Vec<Named>> = Some(vec![
+            Named {
+                name: "a".to_owned(),
+                v: 1,
+            },
+            Named {
+                name: "b".to_owned(),
+                v: 2,
+            },
+        ]);
+        let incoming: Option<Vec<Named>> = Some(vec![
+            Named {
+                name: "b".to_owned(),
+                v: 20,
+            },
+            Named {
+                name: "c".to_owned(),
+                v: 30,
+            },
+        ]);
+        merge_named_list(&mut base, incoming, |t| &t.name);
+        let v = base.unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(
+            v[0],
+            Named {
+                name: "a".to_owned(),
+                v: 1
+            }
+        );
+        assert_eq!(
+            v[1],
+            Named {
+                name: "b".to_owned(),
+                v: 20
+            }
+        );
+        assert_eq!(
+            v[2],
+            Named {
+                name: "c".to_owned(),
+                v: 30
+            }
+        );
+    }
+}

--- a/crates/roas/src/v2/path_item.rs
+++ b/crates/roas/src/v2/path_item.rs
@@ -98,6 +98,23 @@ pub struct PathItem {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl PathItem {
+    /// Deep-merge: every method-keyed operation in `other.operations` is
+    /// merged into `self.operations` (incoming wins per method); operations
+    /// only present in one side are preserved. So merging a base with `get`
+    /// and an incoming with `post` keeps both. `$ref` is replaced when
+    /// incoming is `Some`, and `parameters` is replaced wholesale when
+    /// incoming is non-empty.
+    pub fn merge(&mut self, other: PathItem) {
+        use crate::common::merge::{merge_optional, merge_optional_list, merge_optional_map};
+
+        merge_optional(&mut self.reference, other.reference);
+        merge_optional_map(&mut self.operations, other.operations);
+        merge_optional_list(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
 impl Serialize for PathItem {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -266,6 +283,23 @@ impl Paths {
 
     pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, PathItem> {
         self.paths.iter()
+    }
+
+    /// Per-key merge: for every `(path, PathItem)` in `other`, if `self`
+    /// already has that path the two `PathItem`s are merged in place via
+    /// [`PathItem::merge`]; otherwise the incoming entry is inserted.
+    /// Specification extensions (`^x-`) on the Paths Object itself are
+    /// merged per-key.
+    pub fn merge(&mut self, other: Paths) {
+        for (key, item) in other.paths {
+            match self.paths.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(item);
+                }
+            }
+        }
+        crate::common::merge::merge_optional_map(&mut self.extensions, other.extensions);
     }
 }
 

--- a/crates/roas/src/v2/spec.rs
+++ b/crates/roas/src/v2/spec.rs
@@ -455,6 +455,52 @@ impl Spec {
             .insert(name, response);
         Ok(RefOr::new_ref(reference))
     }
+
+    /// Merge `other` into `self` in place. Incoming entries always win:
+    ///
+    /// * **Map-like sections** (`paths`, `definitions`, `parameters`,
+    ///   `responses`, `securityDefinitions`, top-level Specification
+    ///   Extensions): incoming entries replace base entries with the same
+    ///   key; new keys are appended.
+    /// * **`tags`** (and `x-tagGroups`): deduplicated by `name`; incoming
+    ///   wins per name and new entries are appended.
+    /// * **`schemes` / `consumes` / `produces` / `security` / `x-servers`**:
+    ///   replaced wholesale when incoming is non-empty; an absent or empty
+    ///   incoming list leaves the base alone.
+    /// * **`host`, `basePath`, `externalDocs`**: replaced when incoming is
+    ///   `Some`.
+    /// * **`info` / `swagger`**: untouched — the base keeps its identity.
+    ///
+    /// `$ref`s are not rewritten. If a base definition is replaced by an
+    /// incoming one of the same name, every existing `$ref` to that name
+    /// resolves to the incoming definition.
+    pub fn merge(&mut self, other: Self) {
+        use crate::common::merge::{
+            merge_named_list, merge_optional, merge_optional_list, merge_optional_map,
+        };
+
+        merge_optional(&mut self.host, other.host);
+        merge_optional(&mut self.base_path, other.base_path);
+        merge_optional_list(&mut self.schemes, other.schemes);
+        merge_optional_list(&mut self.consumes, other.consumes);
+        merge_optional_list(&mut self.produces, other.produces);
+
+        self.paths.merge(other.paths);
+
+        merge_optional_map(&mut self.definitions, other.definitions);
+        merge_optional_map(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.responses, other.responses);
+        merge_optional_map(&mut self.security_definitions, other.security_definitions);
+
+        merge_optional_list(&mut self.security, other.security);
+        merge_named_list(&mut self.tags, other.tags, |t| t.name.as_str());
+        merge_optional(&mut self.external_docs, other.external_docs);
+        merge_optional_list(&mut self.x_servers, other.x_servers);
+        merge_named_list(&mut self.x_tag_groups, other.x_tag_groups, |g| {
+            g.name.as_str()
+        });
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
 }
 
 impl ResolveReference<Response> for Spec {
@@ -1624,5 +1670,266 @@ mod tests {
             leftover.iter().all(|s| !s.contains("already exists")),
             "IgnoreNonUniqOperationIDs must suppress the duplicate, got: {leftover:?}",
         );
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // `Spec::merge` coverage.
+    // ────────────────────────────────────────────────────────────────────
+
+    fn base_spec(value: serde_json::Value) -> Spec {
+        serde_json::from_value(value).expect("base spec must parse")
+    }
+
+    #[test]
+    fn merge_paths_deep_merges_path_items_and_appends_new() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {
+                "/a": {"get": {"responses": {"200": {"description": "base-a"}}}},
+                "/b": {"get": {"responses": {"200": {"description": "base-b"}}}}
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "Incoming", "version": "2"},
+            "paths": {
+                "/b": {"get": {"responses": {"200": {"description": "incoming-b"}}}},
+                "/c": {"get": {"responses": {"200": {"description": "incoming-c"}}}}
+            }
+        })));
+        // Round-trip to JSON to inspect descriptions without poking at every
+        // intermediate type.
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["paths"]["/a"]["get"]["responses"]["200"]["description"],
+            "base-a"
+        );
+        assert_eq!(
+            json["paths"]["/b"]["get"]["responses"]["200"]["description"],
+            "incoming-b"
+        );
+        assert_eq!(
+            json["paths"]["/c"]["get"]["responses"]["200"]["description"],
+            "incoming-c"
+        );
+        assert_eq!(base.info.title, "Base");
+    }
+
+    #[test]
+    fn merge_path_items_preserves_methods_only_present_on_one_side() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "get": {"responses": {"200": {"description": "base-get"}}}
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "post": {"responses": {"201": {"description": "incoming-post"}}}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["paths"]["/pets"]["get"]["responses"]["200"]["description"],
+            "base-get"
+        );
+        assert_eq!(
+            json["paths"]["/pets"]["post"]["responses"]["201"]["description"],
+            "incoming-post"
+        );
+    }
+
+    #[test]
+    fn merge_definitions_parameters_responses_security_definitions_per_key_incoming_wins() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "definitions": {"Pet": {"type": "string"}, "Owner": {"type": "string"}},
+            "responses": {"NotFound": {"description": "base"}}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "y", "version": "2"},
+            "paths": {},
+            "definitions": {"Pet": {"type": "object"}, "Tag": {"type": "string"}},
+            "parameters": {"Limit": {"name": "limit", "in": "query", "type": "integer"}},
+            "securityDefinitions": {"apiKey": {"type": "apiKey", "name": "X-Key", "in": "header"}}
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["definitions"]["Pet"]["type"], "object",
+            "incoming Pet replaces base",
+        );
+        assert_eq!(json["definitions"]["Owner"]["type"], "string");
+        assert_eq!(json["definitions"]["Tag"]["type"], "string");
+        // Parameters bag was None on base; incoming materialises it.
+        assert_eq!(json["parameters"]["Limit"]["in"], "query");
+        // Base-only `responses` bag retained.
+        assert_eq!(json["responses"]["NotFound"]["description"], "base");
+        // securityDefinitions was None on base; incoming materialises it.
+        assert_eq!(json["securityDefinitions"]["apiKey"]["type"], "apiKey");
+    }
+
+    #[test]
+    fn merge_tags_dedupe_by_name_and_append_new() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "base-pets"},
+                {"name": "users", "description": "base-users"}
+            ]
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "incoming-pets"},
+                {"name": "orders", "description": "new-orders"}
+            ]
+        })));
+        let tags = base.tags.unwrap();
+        assert_eq!(tags.len(), 3);
+        let pets = tags.iter().find(|t| t.name == "pets").unwrap();
+        assert_eq!(pets.description.as_deref(), Some("incoming-pets"));
+    }
+
+    #[test]
+    fn merge_host_and_base_path_replaced_when_incoming_is_some() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "host": "base.example",
+            "basePath": "/v1",
+            "paths": {}
+        }));
+        // Absent host/basePath in incoming: base stays.
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {}
+        })));
+        assert_eq!(base.host.as_deref(), Some("base.example"));
+        assert_eq!(base.base_path.as_deref(), Some("/v1"));
+
+        // Present incoming: replaces.
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "host": "incoming.example",
+            "basePath": "/v2",
+            "paths": {}
+        })));
+        assert_eq!(base.host.as_deref(), Some("incoming.example"));
+        assert_eq!(base.base_path.as_deref(), Some("/v2"));
+    }
+
+    #[test]
+    fn merge_schemes_consumes_produces_replace_only_when_non_empty() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "schemes": ["https"],
+            "consumes": ["application/json"],
+            "produces": ["application/json"]
+        }));
+        // Absent in incoming: base stays.
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {}
+        })));
+        assert_eq!(
+            base.schemes.as_ref().map(|v| v.len()),
+            Some(1),
+            "schemes unchanged when incoming has none"
+        );
+
+        // Present non-empty in incoming: replace wholesale.
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "schemes": ["http", "ws"],
+            "consumes": ["application/xml"],
+            "produces": ["application/xml"]
+        })));
+        assert_eq!(base.schemes.as_ref().map(|v| v.len()), Some(2));
+        assert_eq!(
+            base.consumes.as_deref(),
+            Some(["application/xml".to_owned()].as_slice())
+        );
+        assert_eq!(
+            base.produces.as_deref(),
+            Some(["application/xml".to_owned()].as_slice())
+        );
+    }
+
+    #[test]
+    fn merge_keeps_base_info_and_swagger_version() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "Incoming", "version": "9"},
+            "paths": {}
+        })));
+        assert_eq!(base.info.title, "Base");
+        assert_eq!(base.info.version, "1");
+    }
+
+    #[test]
+    fn merge_top_level_extensions_per_key_incoming_wins() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "base",
+            "x-base-only": "kept"
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "incoming",
+            "x-incoming-only": "added"
+        })));
+        let ext = base.extensions.unwrap();
+        assert_eq!(ext["x-shared"], serde_json::json!("incoming"));
+        assert_eq!(ext["x-base-only"], serde_json::json!("kept"));
+        assert_eq!(ext["x-incoming-only"], serde_json::json!("added"));
+    }
+
+    #[test]
+    fn merge_round_trips_through_json() {
+        let mut base = base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {"/a": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "definitions": {"Pet": {"type": "string"}}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "swagger": "2.0",
+            "info": {"title": "y", "version": "2"},
+            "paths": {"/b": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "definitions": {"Owner": {"type": "string"}}
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        let _: Spec = serde_json::from_value(json).expect("merged spec must re-parse");
     }
 }

--- a/crates/roas/src/v3_0/callback.rs
+++ b/crates/roas/src/v3_0/callback.rs
@@ -54,6 +54,25 @@ pub struct Callback {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl Callback {
+    /// Per-expression-key merge: for every `(expr, PathItem)` in `other`,
+    /// if `self` already has that expression key the two `PathItem`s are
+    /// merged in place via [`PathItem::merge`]; otherwise the incoming
+    /// entry is inserted. Specification extensions on the Callback Object
+    /// itself are merged per-key.
+    pub fn merge(&mut self, other: Callback) {
+        for (key, item) in other.paths {
+            match self.paths.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(item);
+                }
+            }
+        }
+        crate::common::merge::merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
 impl Serialize for Callback {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/roas/src/v3_0/components.rs
+++ b/crates/roas/src/v3_0/components.rs
@@ -67,6 +67,54 @@ pub struct Components {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl Components {
+    /// Per-bag, per-key merge: every entry in each of `other`'s component
+    /// bags (`schemas`, `responses`, …) replaces `self`'s entry under the
+    /// same name; new names are inserted. Specification extensions (`^x-`)
+    /// on the Components Object are merged the same way.
+    ///
+    /// `callbacks` get a deeper merge: when both sides define a callback
+    /// under the same name *and* both are inline `RefOr::Item`, the two
+    /// `Callback`s are merged via [`Callback::merge`] (per-expression-key,
+    /// deep). Any case involving `RefOr::Ref` is wholesale-replaced by
+    /// incoming.
+    pub fn merge(&mut self, other: Components) {
+        use crate::common::merge::merge_optional_map;
+        merge_optional_map(&mut self.schemas, other.schemas);
+        merge_optional_map(&mut self.responses, other.responses);
+        merge_optional_map(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.examples, other.examples);
+        merge_optional_map(&mut self.request_bodies, other.request_bodies);
+        merge_optional_map(&mut self.headers, other.headers);
+        merge_optional_map(&mut self.security_schemes, other.security_schemes);
+        merge_optional_map(&mut self.links, other.links);
+        merge_callbacks_bag(&mut self.callbacks, other.callbacks);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
+/// Per-key deep merge for `components.callbacks`: when both sides define
+/// a callback under the same name and both are inline (`RefOr::Item`),
+/// merge in place via [`Callback::merge`].
+fn merge_callbacks_bag(
+    base: &mut Option<BTreeMap<String, RefOr<Callback>>>,
+    incoming: Option<BTreeMap<String, RefOr<Callback>>>,
+) {
+    let Some(incoming) = incoming else { return };
+    let target = base.get_or_insert_with(Default::default);
+    for (key, item) in incoming {
+        match target.entry(key) {
+            std::collections::btree_map::Entry::Occupied(mut e) => match (e.get_mut(), item) {
+                (RefOr::Item(base_cb), RefOr::Item(inc_cb)) => base_cb.merge(inc_cb),
+                (slot, item) => *slot = item,
+            },
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(item);
+            }
+        }
+    }
+}
+
 impl ValidateWithContext<Spec> for Components {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         let re = regex!(r"^[a-zA-Z0-9.\-_]+$");

--- a/crates/roas/src/v3_0/path_item.rs
+++ b/crates/roas/src/v3_0/path_item.rs
@@ -87,6 +87,26 @@ pub struct PathItem {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl PathItem {
+    /// Deep-merge: every method-keyed operation in `other.operations` is
+    /// merged into `self.operations` (incoming wins per method); operations
+    /// only present in one side are preserved. So merging a base with `get`
+    /// and an incoming with `post` keeps both. Scalar fields (`$ref`,
+    /// `summary`, `description`) and `parameters` / `servers` follow the
+    /// spec-level "incoming wins when present / non-empty" contract.
+    pub fn merge(&mut self, other: PathItem) {
+        use crate::common::merge::{merge_optional, merge_optional_list, merge_optional_map};
+
+        merge_optional(&mut self.reference, other.reference);
+        merge_optional(&mut self.summary, other.summary);
+        merge_optional(&mut self.description, other.description);
+        merge_optional_map(&mut self.operations, other.operations);
+        merge_optional_list(&mut self.servers, other.servers);
+        merge_optional_list(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
 impl Serialize for PathItem {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -274,6 +294,23 @@ impl Paths {
 
     pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, PathItem> {
         self.paths.iter()
+    }
+
+    /// Per-key merge: for every `(path, PathItem)` in `other`, if `self`
+    /// already has that path the two `PathItem`s are merged in place via
+    /// [`PathItem::merge`]; otherwise the incoming entry is inserted.
+    /// Specification extensions (`^x-`) on the Paths Object itself are
+    /// merged per-key.
+    pub fn merge(&mut self, other: Paths) {
+        for (key, item) in other.paths {
+            match self.paths.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(item);
+                }
+            }
+        }
+        crate::common::merge::merge_optional_map(&mut self.extensions, other.extensions);
     }
 }
 

--- a/crates/roas/src/v3_0/spec.rs
+++ b/crates/roas/src/v3_0/spec.rs
@@ -598,6 +598,43 @@ impl Spec {
             .insert(name, RefOr::new_item(callback));
         Ok(RefOr::new_ref(reference))
     }
+
+    /// Merge `other` into `self` in place. Incoming entries always win:
+    ///
+    /// * **Map-like sections** (`paths`, every `components.<bag>`,
+    ///   top-level Specification Extensions): incoming entries replace
+    ///   base entries with the same key; new keys are appended.
+    /// * **`tags`** (and `x-tagGroups`): deduplicated by `name`; incoming
+    ///   wins per name and new entries are appended.
+    /// * **`servers` / `security`**: replaced wholesale when incoming is
+    ///   non-empty; an absent or empty incoming list leaves the base
+    ///   alone.
+    /// * **`externalDocs`**: replaced when incoming is `Some`.
+    /// * **`info` / `openapi`**: untouched — the base keeps its identity.
+    ///
+    /// `$ref`s are not rewritten. If a base component is replaced by an
+    /// incoming one of the same name, every existing `$ref` to that name
+    /// resolves to the incoming definition.
+    pub fn merge(&mut self, other: Self) {
+        use crate::common::merge::{
+            merge_named_list, merge_optional, merge_optional_list, merge_optional_map,
+        };
+
+        merge_optional_list(&mut self.servers, other.servers);
+        self.paths.merge(other.paths);
+        match (&mut self.components, other.components) {
+            (Some(base), Some(inc)) => base.merge(inc),
+            (slot @ None, Some(inc)) => *slot = Some(inc),
+            (_, None) => {}
+        }
+        merge_optional_list(&mut self.security, other.security);
+        merge_named_list(&mut self.tags, other.tags, |t| t.name.as_str());
+        merge_optional(&mut self.external_docs, other.external_docs);
+        merge_named_list(&mut self.x_tag_groups, other.x_tag_groups, |g| {
+            g.name.as_str()
+        });
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
 }
 
 impl ResolveReference<Response> for Spec {
@@ -1577,5 +1614,308 @@ mod tests {
             leftover.iter().all(|s| !s.contains("already in use")),
             "IgnoreNonUniqOperationIDs must suppress the duplicate, got: {leftover:?}",
         );
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // `Spec::merge` coverage.
+    // ────────────────────────────────────────────────────────────────────
+
+    fn base_spec(value: serde_json::Value) -> Spec {
+        serde_json::from_value(value).expect("base spec must parse")
+    }
+
+    #[test]
+    fn merge_paths_deep_merges_path_items_and_appends_new() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {
+                "/a": {"summary": "base-a"},
+                "/b": {"summary": "base-b"}
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "Incoming", "version": "2"},
+            "paths": {
+                "/b": {"summary": "incoming-b"},
+                "/c": {"summary": "incoming-c"}
+            }
+        })));
+        assert_eq!(base.paths.paths["/a"].summary.as_deref(), Some("base-a"));
+        assert_eq!(
+            base.paths.paths["/b"].summary.as_deref(),
+            Some("incoming-b")
+        );
+        assert_eq!(
+            base.paths.paths["/c"].summary.as_deref(),
+            Some("incoming-c")
+        );
+        assert_eq!(base.info.title, "Base");
+    }
+
+    #[test]
+    fn merge_path_items_preserves_methods_only_present_on_one_side() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "get": {"responses": {"200": {"description": "base-get"}}}
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "post": {"responses": {"201": {"description": "incoming-post"}}}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["paths"]["/pets"]["get"]["responses"]["200"]["description"],
+            "base-get"
+        );
+        assert_eq!(
+            json["paths"]["/pets"]["post"]["responses"]["201"]["description"],
+            "incoming-post"
+        );
+    }
+
+    #[test]
+    fn merge_components_callbacks_bag_deep_merges_inline_callbacks() {
+        // v3.0 has no `components.pathItems`, but `callbacks` exist and
+        // need the same deep-merge contract.
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "get": {"responses": {"200": {"description": "base-get"}}}
+                        },
+                        "{$request.body#/other}": {
+                            "post": {"responses": {"200": {"description": "base-only-cb"}}}
+                        }
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "post": {"responses": {"201": {"description": "incoming-post"}}}
+                        },
+                        "{$request.body#/new}": {
+                            "get": {"responses": {"200": {"description": "incoming-only-cb"}}}
+                        }
+                    }
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        let cb = &json["components"]["callbacks"]["OnEvent"];
+        assert_eq!(
+            cb["{$request.body#/url}"]["get"]["responses"]["200"]["description"],
+            "base-get"
+        );
+        assert_eq!(
+            cb["{$request.body#/url}"]["post"]["responses"]["201"]["description"],
+            "incoming-post"
+        );
+        assert_eq!(
+            cb["{$request.body#/other}"]["post"]["responses"]["200"]["description"],
+            "base-only-cb"
+        );
+        assert_eq!(
+            cb["{$request.body#/new}"]["get"]["responses"]["200"]["description"],
+            "incoming-only-cb"
+        );
+    }
+
+    #[test]
+    fn merge_components_callbacks_bag_ref_replaces_wholesale() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "get": {"responses": {"200": {"description": "base-get"}}}
+                        }
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {"$ref": "#/components/callbacks/Other"}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["components"]["callbacks"]["OnEvent"]["$ref"],
+            "#/components/callbacks/Other"
+        );
+    }
+
+    #[test]
+    fn merge_components_each_bag_incoming_wins_per_name() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "schemas": {"Pet": {"type": "string"}, "Owner": {"type": "string"}},
+                "responses": {"NotFound": {"description": "base"}}
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "y", "version": "2"},
+            "paths": {},
+            "components": {
+                "schemas": {"Pet": {"type": "object"}, "Tag": {"type": "string"}}
+            }
+        })));
+        let comp = base.components.expect("components present");
+        let schemas = comp.schemas.expect("schemas present");
+        let pet = serde_json::to_value(&schemas["Pet"]).unwrap();
+        assert_eq!(pet["type"], "object");
+        assert!(schemas.contains_key("Owner"));
+        assert!(schemas.contains_key("Tag"));
+        assert!(
+            comp.responses
+                .as_ref()
+                .is_some_and(|m| m.contains_key("NotFound"))
+        );
+    }
+
+    #[test]
+    fn merge_tags_dedupe_by_name_and_append_new() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "base-pets"},
+                {"name": "users", "description": "base-users"}
+            ]
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "incoming-pets"},
+                {"name": "orders", "description": "new-orders"}
+            ]
+        })));
+        let tags = base.tags.unwrap();
+        assert_eq!(tags.len(), 3);
+        let pets = tags.iter().find(|t| t.name == "pets").unwrap();
+        assert_eq!(pets.description.as_deref(), Some("incoming-pets"));
+    }
+
+    #[test]
+    fn merge_servers_replaces_only_when_incoming_is_non_empty() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "servers": [{"url": "https://base.example/"}]
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {}
+        })));
+        assert_eq!(
+            base.servers.as_ref().unwrap()[0].url,
+            "https://base.example/"
+        );
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "servers": [{"url": "https://incoming.example/"}]
+        })));
+        assert_eq!(
+            base.servers.as_ref().unwrap()[0].url,
+            "https://incoming.example/"
+        );
+    }
+
+    #[test]
+    fn merge_keeps_base_info_and_openapi_version() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "Incoming", "version": "9"},
+            "paths": {}
+        })));
+        assert_eq!(base.info.title, "Base");
+        assert_eq!(base.info.version, "1");
+    }
+
+    #[test]
+    fn merge_top_level_extensions_per_key_incoming_wins() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "base",
+            "x-base-only": "kept"
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "incoming",
+            "x-incoming-only": "added"
+        })));
+        let ext = base.extensions.unwrap();
+        assert_eq!(ext["x-shared"], serde_json::json!("incoming"));
+        assert_eq!(ext["x-base-only"], serde_json::json!("kept"));
+        assert_eq!(ext["x-incoming-only"], serde_json::json!("added"));
+    }
+
+    #[test]
+    fn merge_round_trips_through_json() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "x", "version": "1"},
+            "paths": {"/a": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "components": {"schemas": {"Pet": {"type": "string"}}}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.0.4",
+            "info": {"title": "y", "version": "2"},
+            "paths": {"/b": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "components": {"schemas": {"Owner": {"type": "string"}}}
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        let _: Spec = serde_json::from_value(json).expect("merged spec must re-parse");
     }
 }

--- a/crates/roas/src/v3_1/callback.rs
+++ b/crates/roas/src/v3_1/callback.rs
@@ -58,6 +58,25 @@ pub struct Callback {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl Callback {
+    /// Per-expression-key merge: for every `(expr, PathItem)` in `other`,
+    /// if `self` already has that expression key the two `PathItem`s are
+    /// merged in place via [`PathItem::merge`]; otherwise the incoming
+    /// entry is inserted. Specification extensions on the Callback Object
+    /// itself are merged per-key.
+    pub fn merge(&mut self, other: Callback) {
+        for (key, item) in other.paths {
+            match self.paths.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(item);
+                }
+            }
+        }
+        crate::common::merge::merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
 impl Serialize for Callback {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/roas/src/v3_1/components.rs
+++ b/crates/roas/src/v3_1/components.rs
@@ -71,6 +71,78 @@ pub struct Components {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl Components {
+    /// Per-bag, per-key merge: every entry in each of `other`'s component
+    /// bags (`schemas`, `responses`, …) replaces `self`'s entry under the
+    /// same name; new names are inserted. Specification extensions (`^x-`)
+    /// on the Components Object are merged the same way.
+    ///
+    /// Two bags get a deeper merge so reusable definitions don't lose
+    /// base-only methods or callback expressions on collision:
+    ///
+    /// * **`path_items`**: when both sides define a `PathItem` under the
+    ///   same name, the two are merged via [`PathItem::merge`].
+    /// * **`callbacks`**: when both sides define a callback under the same
+    ///   name *and* both are inline `RefOr::Item`, the two `Callback`s are
+    ///   merged via [`Callback::merge`]. Any case involving `RefOr::Ref`
+    ///   is wholesale-replaced by incoming.
+    pub fn merge(&mut self, other: Components) {
+        use crate::common::merge::merge_optional_map;
+        merge_optional_map(&mut self.schemas, other.schemas);
+        merge_optional_map(&mut self.responses, other.responses);
+        merge_optional_map(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.examples, other.examples);
+        merge_optional_map(&mut self.request_bodies, other.request_bodies);
+        merge_optional_map(&mut self.headers, other.headers);
+        merge_optional_map(&mut self.security_schemes, other.security_schemes);
+        merge_optional_map(&mut self.links, other.links);
+        merge_callbacks_bag(&mut self.callbacks, other.callbacks);
+        merge_path_items_bag(&mut self.path_items, other.path_items);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
+/// Per-key deep merge for `components.pathItems`: when both sides define
+/// a `PathItem` under the same name, merge in place via
+/// [`PathItem::merge`] instead of wholesale-replacing the entry.
+fn merge_path_items_bag(
+    base: &mut Option<BTreeMap<String, PathItem>>,
+    incoming: Option<BTreeMap<String, PathItem>>,
+) {
+    let Some(incoming) = incoming else { return };
+    let target = base.get_or_insert_with(Default::default);
+    for (key, item) in incoming {
+        match target.entry(key) {
+            std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(item);
+            }
+        }
+    }
+}
+
+/// Per-key deep merge for `components.callbacks`: when both sides define
+/// a callback under the same name and both are inline (`RefOr::Item`),
+/// merge in place via [`Callback::merge`].
+fn merge_callbacks_bag(
+    base: &mut Option<BTreeMap<String, RefOr<Callback>>>,
+    incoming: Option<BTreeMap<String, RefOr<Callback>>>,
+) {
+    let Some(incoming) = incoming else { return };
+    let target = base.get_or_insert_with(Default::default);
+    for (key, item) in incoming {
+        match target.entry(key) {
+            std::collections::btree_map::Entry::Occupied(mut e) => match (e.get_mut(), item) {
+                (RefOr::Item(base_cb), RefOr::Item(inc_cb)) => base_cb.merge(inc_cb),
+                (slot, item) => *slot = item,
+            },
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(item);
+            }
+        }
+    }
+}
+
 impl ValidateWithContext<Spec> for Components {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         let re = regex!(r"^[a-zA-Z0-9.\-_]+$");

--- a/crates/roas/src/v3_1/path_item.rs
+++ b/crates/roas/src/v3_1/path_item.rs
@@ -90,6 +90,26 @@ pub struct PathItem {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl PathItem {
+    /// Deep-merge: every method-keyed operation in `other.operations` is
+    /// merged into `self.operations` (incoming wins per method); operations
+    /// only present in one side are preserved. So merging a base with `get`
+    /// and an incoming with `post` keeps both. Scalar fields (`$ref`,
+    /// `summary`, `description`) and `parameters` / `servers` follow the
+    /// spec-level "incoming wins when present / non-empty" contract.
+    pub fn merge(&mut self, other: PathItem) {
+        use crate::common::merge::{merge_optional, merge_optional_list, merge_optional_map};
+
+        merge_optional(&mut self.reference, other.reference);
+        merge_optional(&mut self.summary, other.summary);
+        merge_optional(&mut self.description, other.description);
+        merge_optional_map(&mut self.operations, other.operations);
+        merge_optional_list(&mut self.servers, other.servers);
+        merge_optional_list(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
 impl Serialize for PathItem {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -390,6 +410,23 @@ impl Paths {
 
     pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, PathItem> {
         self.paths.iter()
+    }
+
+    /// Per-key merge: for every `(path, PathItem)` in `other`, if `self`
+    /// already has that path the two `PathItem`s are merged in place via
+    /// [`PathItem::merge`]; otherwise the incoming entry is inserted.
+    /// Specification extensions (`^x-`) on the Paths Object itself are
+    /// merged per-key.
+    pub fn merge(&mut self, other: Paths) {
+        for (key, item) in other.paths {
+            match self.paths.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(item);
+                }
+            }
+        }
+        crate::common::merge::merge_optional_map(&mut self.extensions, other.extensions);
     }
 }
 

--- a/crates/roas/src/v3_1/spec.rs
+++ b/crates/roas/src/v3_1/spec.rs
@@ -645,6 +645,57 @@ impl Spec {
             ..Default::default()
         })
     }
+
+    /// Merge `other` into `self` in place. Incoming entries always win:
+    ///
+    /// * **Map-like sections** (`paths`, `webhooks`, every
+    ///   `components.<bag>`, top-level Specification Extensions): incoming
+    ///   entries replace base entries with the same key; new keys are
+    ///   appended.
+    /// * **`tags`** (and `x-tagGroups`): deduplicated by `name`; incoming
+    ///   wins per name and new entries are appended.
+    /// * **`servers` / `security`**: replaced wholesale when incoming is
+    ///   non-empty; an absent or empty incoming list leaves the base
+    ///   alone.
+    /// * **`externalDocs`, `jsonSchemaDialect`**: replaced when incoming
+    ///   is `Some`.
+    /// * **`info` / `openapi`**: untouched — the base keeps its identity.
+    ///
+    /// `$ref`s are not rewritten. If a base component is replaced by an
+    /// incoming one of the same name, every existing `$ref` to that name
+    /// resolves to the incoming definition.
+    pub fn merge(&mut self, other: Self) {
+        use crate::common::merge::{
+            merge_named_list, merge_optional, merge_optional_list, merge_optional_map,
+        };
+
+        merge_optional(&mut self.json_schema_dialect, other.json_schema_dialect);
+        merge_optional_list(&mut self.servers, other.servers);
+
+        match (&mut self.paths, other.paths) {
+            (Some(base), Some(inc)) => base.merge(inc),
+            (slot @ None, Some(inc)) => *slot = Some(inc),
+            (_, None) => {}
+        }
+        match (&mut self.webhooks, other.webhooks) {
+            (Some(base), Some(inc)) => base.merge(inc),
+            (slot @ None, Some(inc)) => *slot = Some(inc),
+            (_, None) => {}
+        }
+        match (&mut self.components, other.components) {
+            (Some(base), Some(inc)) => base.merge(inc),
+            (slot @ None, Some(inc)) => *slot = Some(inc),
+            (_, None) => {}
+        }
+
+        merge_optional_list(&mut self.security, other.security);
+        merge_named_list(&mut self.tags, other.tags, |t| t.name.as_str());
+        merge_optional(&mut self.external_docs, other.external_docs);
+        merge_named_list(&mut self.x_tag_groups, other.x_tag_groups, |g| {
+            g.name.as_str()
+        });
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
 }
 
 impl ResolveReference<Response> for Spec {
@@ -2209,6 +2260,358 @@ mod tests {
         let mut ctx = Context::new(&spec, Options::new());
         TagGroup::default().validate_with_context(&mut ctx, "#.x-tagGroups[0]".to_owned());
         assert_eq!(ctx.errors.len(), 2, "tag group errors: {:?}", ctx.errors);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // `Spec::merge` coverage.
+    // ────────────────────────────────────────────────────────────────────
+
+    fn base_spec(value: serde_json::Value) -> Spec {
+        serde_json::from_value(value).expect("base spec must parse")
+    }
+
+    #[test]
+    fn merge_paths_deep_merges_path_items_and_appends_new() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {
+                "/a": {"summary": "base-a"},
+                "/b": {"summary": "base-b"}
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "Incoming", "version": "2"},
+            "paths": {
+                "/b": {"summary": "incoming-b"},
+                "/c": {"summary": "incoming-c"}
+            }
+        })));
+        let paths = base.paths.expect("paths must be present");
+        assert_eq!(paths.paths["/a"].summary.as_deref(), Some("base-a"));
+        assert_eq!(paths.paths["/b"].summary.as_deref(), Some("incoming-b"));
+        assert_eq!(paths.paths["/c"].summary.as_deref(), Some("incoming-c"));
+        assert_eq!(base.info.title, "Base");
+    }
+
+    #[test]
+    fn merge_path_items_preserves_methods_only_present_on_one_side() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "post": {"summary": "incoming-post", "responses": {"201": {"description": "created"}}}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(json["paths"]["/pets"]["get"]["summary"], "base-get");
+        assert_eq!(json["paths"]["/pets"]["post"]["summary"], "incoming-post");
+    }
+
+    #[test]
+    fn merge_components_path_items_bag_deep_merges_on_collision() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "pathItems": {
+                    "Echo": {
+                        "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "pathItems": {
+                    "Echo": {
+                        "post": {"summary": "incoming-post", "responses": {"201": {"description": "created"}}}
+                    }
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["components"]["pathItems"]["Echo"]["get"]["summary"],
+            "base-get"
+        );
+        assert_eq!(
+            json["components"]["pathItems"]["Echo"]["post"]["summary"],
+            "incoming-post"
+        );
+    }
+
+    #[test]
+    fn merge_components_callbacks_bag_deep_merges_inline_callbacks() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                        },
+                        "{$request.body#/other}": {
+                            "post": {"summary": "base-only-cb", "responses": {"200": {"description": "ok"}}}
+                        }
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "post": {"summary": "incoming-post", "responses": {"201": {"description": "created"}}}
+                        },
+                        "{$request.body#/new}": {
+                            "get": {"summary": "incoming-only-cb", "responses": {"200": {"description": "ok"}}}
+                        }
+                    }
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        let cb = &json["components"]["callbacks"]["OnEvent"];
+        assert_eq!(cb["{$request.body#/url}"]["get"]["summary"], "base-get");
+        assert_eq!(
+            cb["{$request.body#/url}"]["post"]["summary"],
+            "incoming-post"
+        );
+        assert_eq!(
+            cb["{$request.body#/other}"]["post"]["summary"],
+            "base-only-cb"
+        );
+        assert_eq!(
+            cb["{$request.body#/new}"]["get"]["summary"],
+            "incoming-only-cb"
+        );
+    }
+
+    #[test]
+    fn merge_components_callbacks_bag_ref_replaces_wholesale() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                        }
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {"$ref": "#/components/callbacks/Other"}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["components"]["callbacks"]["OnEvent"]["$ref"],
+            "#/components/callbacks/Other"
+        );
+    }
+
+    #[test]
+    fn merge_components_each_bag_incoming_wins_per_name() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "schemas": {"Pet": {"type": "string"}, "Owner": {"type": "string"}},
+                "responses": {"NotFound": {"description": "base"}}
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "y", "version": "2"},
+            "paths": {},
+            "components": {
+                "schemas": {"Pet": {"type": "object"}, "Tag": {"type": "string"}}
+            }
+        })));
+        let comp = base.components.expect("components present");
+        let schemas = comp.schemas.expect("schemas present");
+        let pet = serde_json::to_value(&schemas["Pet"]).unwrap();
+        assert_eq!(pet["type"], "object");
+        assert!(schemas.contains_key("Owner"));
+        assert!(schemas.contains_key("Tag"));
+        assert!(
+            comp.responses
+                .as_ref()
+                .is_some_and(|m| m.contains_key("NotFound"))
+        );
+    }
+
+    #[test]
+    fn merge_tags_dedupe_by_name_and_append_new() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "base-pets"},
+                {"name": "users", "description": "base-users"}
+            ]
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "incoming-pets"},
+                {"name": "orders", "description": "new-orders"}
+            ]
+        })));
+        let tags = base.tags.unwrap();
+        assert_eq!(tags.len(), 3);
+        let pets = tags.iter().find(|t| t.name == "pets").unwrap();
+        assert_eq!(pets.description.as_deref(), Some("incoming-pets"));
+    }
+
+    #[test]
+    fn merge_servers_replaces_only_when_incoming_is_non_empty() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "servers": [{"url": "https://base.example/"}]
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {}
+        })));
+        assert_eq!(
+            base.servers.as_ref().unwrap()[0].url,
+            "https://base.example/"
+        );
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "servers": [{"url": "https://incoming.example/"}]
+        })));
+        assert_eq!(
+            base.servers.as_ref().unwrap()[0].url,
+            "https://incoming.example/"
+        );
+    }
+
+    #[test]
+    fn merge_keeps_base_info_and_openapi_version() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.2",
+            "info": {"title": "Incoming", "version": "9"},
+            "paths": {}
+        })));
+        assert_eq!(base.info.title, "Base");
+        assert_eq!(base.info.version, "1");
+    }
+
+    #[test]
+    fn merge_top_level_extensions_per_key_incoming_wins() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "base",
+            "x-base-only": "kept"
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "incoming",
+            "x-incoming-only": "added"
+        })));
+        let ext = base.extensions.unwrap();
+        assert_eq!(ext["x-shared"], serde_json::json!("incoming"));
+        assert_eq!(ext["x-base-only"], serde_json::json!("kept"));
+        assert_eq!(ext["x-incoming-only"], serde_json::json!("added"));
+    }
+
+    #[test]
+    fn merge_webhooks_per_key_incoming_wins() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "webhooks": {"petCreated": {"summary": "base-hook"}}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "webhooks": {
+                "petCreated": {"summary": "incoming-hook"},
+                "petDeleted": {"summary": "new-hook"}
+            }
+        })));
+        let webhooks = base.webhooks.unwrap();
+        assert_eq!(
+            webhooks.paths["petCreated"].summary.as_deref(),
+            Some("incoming-hook")
+        );
+        assert_eq!(
+            webhooks.paths["petDeleted"].summary.as_deref(),
+            Some("new-hook")
+        );
+    }
+
+    #[test]
+    fn merge_round_trips_through_json() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {"/a": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "components": {"schemas": {"Pet": {"type": "string"}}}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.1.0",
+            "info": {"title": "y", "version": "2"},
+            "paths": {"/b": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "components": {"schemas": {"Owner": {"type": "string"}}}
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        let _: Spec = serde_json::from_value(json).expect("merged spec must re-parse");
     }
 }
 

--- a/crates/roas/src/v3_2/callback.rs
+++ b/crates/roas/src/v3_2/callback.rs
@@ -58,6 +58,25 @@ pub struct Callback {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl Callback {
+    /// Per-expression-key merge: for every `(expr, PathItem)` in `other`,
+    /// if `self` already has that expression key the two `PathItem`s are
+    /// merged in place via [`PathItem::merge`]; otherwise the incoming
+    /// entry is inserted. Specification extensions on the Callback Object
+    /// itself are merged per-key.
+    pub fn merge(&mut self, other: Callback) {
+        for (key, item) in other.paths {
+            match self.paths.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(item);
+                }
+            }
+        }
+        crate::common::merge::merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
 impl Serialize for Callback {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/roas/src/v3_2/components.rs
+++ b/crates/roas/src/v3_2/components.rs
@@ -75,6 +75,83 @@ pub struct Components {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl Components {
+    /// Per-bag, per-key merge: every entry in each of `other`'s component
+    /// bags (`schemas`, `responses`, …) replaces `self`'s entry under the
+    /// same name; new names are inserted. Specification extensions (`^x-`)
+    /// on the Components Object are merged the same way.
+    ///
+    /// Two bags get a deeper merge so reusable definitions don't lose
+    /// base-only methods or callback expressions on collision:
+    ///
+    /// * **`path_items`**: when both sides define a `PathItem` under the
+    ///   same name, the two are merged via [`PathItem::merge`] (per-method
+    ///   incoming wins; methods only present on one side survive).
+    /// * **`callbacks`**: when both sides define a callback under the same
+    ///   name *and* both are inline `RefOr::Item`, the two `Callback`s are
+    ///   merged via [`Callback::merge`] (per-expression-key, deep). Any
+    ///   case involving `RefOr::Ref` is wholesale-replaced by incoming
+    ///   since refs can't be merged without resolving them.
+    pub fn merge(&mut self, other: Components) {
+        use crate::common::merge::merge_optional_map;
+        merge_optional_map(&mut self.schemas, other.schemas);
+        merge_optional_map(&mut self.responses, other.responses);
+        merge_optional_map(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.examples, other.examples);
+        merge_optional_map(&mut self.request_bodies, other.request_bodies);
+        merge_optional_map(&mut self.headers, other.headers);
+        merge_optional_map(&mut self.security_schemes, other.security_schemes);
+        merge_optional_map(&mut self.links, other.links);
+        merge_callbacks_bag(&mut self.callbacks, other.callbacks);
+        merge_path_items_bag(&mut self.path_items, other.path_items);
+        merge_optional_map(&mut self.media_types, other.media_types);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
+/// Per-key deep merge for `components.pathItems`: when both sides define
+/// a `PathItem` under the same name, merge in place via
+/// [`PathItem::merge`] instead of wholesale-replacing the entry.
+fn merge_path_items_bag(
+    base: &mut Option<BTreeMap<String, PathItem>>,
+    incoming: Option<BTreeMap<String, PathItem>>,
+) {
+    let Some(incoming) = incoming else { return };
+    let target = base.get_or_insert_with(Default::default);
+    for (key, item) in incoming {
+        match target.entry(key) {
+            std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(item);
+            }
+        }
+    }
+}
+
+/// Per-key deep merge for `components.callbacks`: when both sides define
+/// a callback under the same name and both are inline (`RefOr::Item`),
+/// merge in place via [`Callback::merge`]. Any case involving `RefOr::Ref`
+/// is wholesale-replaced by incoming (refs can't be merged without
+/// resolving them).
+fn merge_callbacks_bag(
+    base: &mut Option<BTreeMap<String, RefOr<Callback>>>,
+    incoming: Option<BTreeMap<String, RefOr<Callback>>>,
+) {
+    let Some(incoming) = incoming else { return };
+    let target = base.get_or_insert_with(Default::default);
+    for (key, item) in incoming {
+        match target.entry(key) {
+            std::collections::btree_map::Entry::Occupied(mut e) => match (e.get_mut(), item) {
+                (RefOr::Item(base_cb), RefOr::Item(inc_cb)) => base_cb.merge(inc_cb),
+                (slot, item) => *slot = item,
+            },
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(item);
+            }
+        }
+    }
+}
+
 impl ValidateWithContext<Spec> for Components {
     fn validate_with_context(&self, ctx: &mut Context<Spec>, path: String) {
         let re = regex!(r"^[a-zA-Z0-9.\-_]+$");

--- a/crates/roas/src/v3_2/path_item.rs
+++ b/crates/roas/src/v3_2/path_item.rs
@@ -96,6 +96,28 @@ pub struct PathItem {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+impl PathItem {
+    /// Deep-merge: every method-keyed operation in `other.operations` and
+    /// `other.additional_operations` is merged into `self`'s map under the
+    /// same key (incoming wins per method); operations only present in one
+    /// side are preserved. So merging a base with `get` and an incoming
+    /// with `post` keeps both. Scalar fields (`$ref`, `summary`,
+    /// `description`) and `parameters` / `servers` follow the spec-level
+    /// "incoming wins when present / non-empty" contract.
+    pub fn merge(&mut self, other: PathItem) {
+        use crate::common::merge::{merge_optional, merge_optional_list, merge_optional_map};
+
+        merge_optional(&mut self.reference, other.reference);
+        merge_optional(&mut self.summary, other.summary);
+        merge_optional(&mut self.description, other.description);
+        merge_optional_map(&mut self.operations, other.operations);
+        merge_optional_map(&mut self.additional_operations, other.additional_operations);
+        merge_optional_list(&mut self.servers, other.servers);
+        merge_optional_list(&mut self.parameters, other.parameters);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
+}
+
 impl Serialize for PathItem {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -432,6 +454,23 @@ impl Paths {
 
     pub fn iter(&self) -> std::collections::btree_map::Iter<'_, String, PathItem> {
         self.paths.iter()
+    }
+
+    /// Per-key merge: for every `(path, PathItem)` in `other`, if `self`
+    /// already has that path the two `PathItem`s are merged in place via
+    /// [`PathItem::merge`]; otherwise the incoming entry is inserted.
+    /// Specification extensions (`^x-`) on the Paths Object itself are
+    /// merged per-key.
+    pub fn merge(&mut self, other: Paths) {
+        for (key, item) in other.paths {
+            match self.paths.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(item),
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(item);
+                }
+            }
+        }
+        crate::common::merge::merge_optional_map(&mut self.extensions, other.extensions);
     }
 }
 

--- a/crates/roas/src/v3_2/spec.rs
+++ b/crates/roas/src/v3_2/spec.rs
@@ -621,6 +621,56 @@ impl Spec {
             ..Default::default()
         })
     }
+
+    /// Merge `other` into `self` in place. Incoming entries always win:
+    ///
+    /// * **Map-like sections** (`paths`, `webhooks`, every
+    ///   `components.<bag>`, top-level Specification Extensions): incoming
+    ///   entries replace base entries with the same key; new keys are
+    ///   appended.
+    /// * **`tags`**: deduplicated by `name`; incoming wins per name and
+    ///   new tags are appended.
+    /// * **`servers` / `security`**: replaced wholesale when incoming is
+    ///   non-empty; an absent or empty incoming list leaves the base
+    ///   alone.
+    /// * **`externalDocs`, `$self`, `jsonSchemaDialect`**: replaced when
+    ///   incoming is `Some`.
+    /// * **`info` / `openapi`**: untouched — the base keeps its identity.
+    ///
+    /// `$ref`s are not rewritten. If a base component is replaced by an
+    /// incoming one of the same name, every existing `$ref` to that name
+    /// (in either side's paths / components) resolves to the incoming
+    /// definition.
+    pub fn merge(&mut self, other: Self) {
+        use crate::common::merge::{
+            merge_named_list, merge_optional, merge_optional_list, merge_optional_map,
+        };
+
+        merge_optional(&mut self.self_uri, other.self_uri);
+        merge_optional(&mut self.json_schema_dialect, other.json_schema_dialect);
+        merge_optional_list(&mut self.servers, other.servers);
+
+        match (&mut self.paths, other.paths) {
+            (Some(base), Some(inc)) => base.merge(inc),
+            (slot @ None, Some(inc)) => *slot = Some(inc),
+            (_, None) => {}
+        }
+        match (&mut self.webhooks, other.webhooks) {
+            (Some(base), Some(inc)) => base.merge(inc),
+            (slot @ None, Some(inc)) => *slot = Some(inc),
+            (_, None) => {}
+        }
+        match (&mut self.components, other.components) {
+            (Some(base), Some(inc)) => base.merge(inc),
+            (slot @ None, Some(inc)) => *slot = Some(inc),
+            (_, None) => {}
+        }
+
+        merge_optional_list(&mut self.security, other.security);
+        merge_named_list(&mut self.tags, other.tags, |t| t.name.as_str());
+        merge_optional(&mut self.external_docs, other.external_docs);
+        merge_optional_map(&mut self.extensions, other.extensions);
+    }
 }
 
 impl ResolveReference<Response> for Spec {
@@ -2284,6 +2334,439 @@ mod tests {
             Some(&groups)
         );
         assert_eq!(serde_json::to_value(&spec).unwrap(), value);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // `Spec::merge` coverage. The merge contract is "incoming always
+    // wins": map sections merge per-key, list sections replace wholesale
+    // when non-empty, tags/x-tagGroups dedupe by `name`, `info` /
+    // `openapi` stay on the base.
+    // ────────────────────────────────────────────────────────────────────
+
+    fn base_spec(value: serde_json::Value) -> Spec {
+        serde_json::from_value(value).expect("base spec must parse")
+    }
+
+    #[test]
+    fn merge_paths_deep_merges_path_items_and_appends_new() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {
+                "/a": {"summary": "base-a"},
+                "/b": {"summary": "base-b"}
+            }
+        }));
+        let incoming = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "Incoming", "version": "2"},
+            "paths": {
+                "/b": {"summary": "incoming-b"},
+                "/c": {"summary": "incoming-c"}
+            }
+        }));
+        base.merge(incoming);
+        let paths = base.paths.expect("paths must be present");
+        assert_eq!(paths.paths["/a"].summary.as_deref(), Some("base-a"));
+        assert_eq!(paths.paths["/b"].summary.as_deref(), Some("incoming-b"));
+        assert_eq!(paths.paths["/c"].summary.as_deref(), Some("incoming-c"));
+        // `info` is untouched.
+        assert_eq!(base.info.title, "Base");
+    }
+
+    #[test]
+    fn merge_path_items_preserves_methods_only_present_on_one_side() {
+        // The key deep-merge contract: base has `/pets.get`, incoming has
+        // `/pets.post`. After merging, `/pets` must carry both methods —
+        // we don't want a wholesale PathItem replacement that drops base's
+        // `get`.
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "post": {"summary": "incoming-post", "responses": {"201": {"description": "created"}}}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["paths"]["/pets"]["get"]["summary"], "base-get",
+            "base get must survive deep merge"
+        );
+        assert_eq!(
+            json["paths"]["/pets"]["post"]["summary"], "incoming-post",
+            "incoming post must be added"
+        );
+    }
+
+    #[test]
+    fn merge_path_item_same_method_incoming_wins() {
+        // Both sides define `/pets.get`. Incoming's operation replaces
+        // base's — per-method incoming-wins inside `PathItem::operations`.
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {
+                "/pets": {
+                    "get": {"summary": "incoming-get", "responses": {"200": {"description": "ok"}}}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(json["paths"]["/pets"]["get"]["summary"], "incoming-get");
+    }
+
+    #[test]
+    fn merge_components_path_items_bag_deep_merges_on_collision() {
+        // Same name `Echo` under `components.pathItems` on both sides: base
+        // has `get`, incoming has `post` — both methods must survive.
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "pathItems": {
+                    "Echo": {
+                        "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "pathItems": {
+                    "Echo": {
+                        "post": {"summary": "incoming-post", "responses": {"201": {"description": "created"}}}
+                    }
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["components"]["pathItems"]["Echo"]["get"]["summary"],
+            "base-get"
+        );
+        assert_eq!(
+            json["components"]["pathItems"]["Echo"]["post"]["summary"],
+            "incoming-post"
+        );
+    }
+
+    #[test]
+    fn merge_components_callbacks_bag_deep_merges_inline_callbacks() {
+        // Same callback name on both sides, both inline. Each carries one
+        // expression-key with different methods. The deep merge must keep
+        // both expression keys and, within the colliding one, both methods.
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                        },
+                        "{$request.body#/other}": {
+                            "post": {"summary": "base-only-cb", "responses": {"200": {"description": "ok"}}}
+                        }
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "post": {"summary": "incoming-post", "responses": {"201": {"description": "created"}}}
+                        },
+                        "{$request.body#/new}": {
+                            "get": {"summary": "incoming-only-cb", "responses": {"200": {"description": "ok"}}}
+                        }
+                    }
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        let cb = &json["components"]["callbacks"]["OnEvent"];
+        // Colliding expression key keeps base get + incoming post.
+        assert_eq!(
+            cb["{$request.body#/url}"]["get"]["summary"], "base-get",
+            "base-only method must survive callback deep merge",
+        );
+        assert_eq!(
+            cb["{$request.body#/url}"]["post"]["summary"], "incoming-post",
+            "incoming method must be added",
+        );
+        // Base-only and incoming-only expression keys both present.
+        assert_eq!(
+            cb["{$request.body#/other}"]["post"]["summary"],
+            "base-only-cb"
+        );
+        assert_eq!(
+            cb["{$request.body#/new}"]["get"]["summary"],
+            "incoming-only-cb"
+        );
+    }
+
+    #[test]
+    fn merge_components_callbacks_bag_ref_replaces_wholesale() {
+        // Either side is a `$ref` — we can't merge across a ref boundary
+        // without resolving, so incoming wins wholesale.
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {
+                        "{$request.body#/url}": {
+                            "get": {"summary": "base-get", "responses": {"200": {"description": "ok"}}}
+                        }
+                    }
+                }
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "callbacks": {
+                    "OnEvent": {"$ref": "#/components/callbacks/Other"}
+                }
+            }
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        assert_eq!(
+            json["components"]["callbacks"]["OnEvent"]["$ref"], "#/components/callbacks/Other",
+            "incoming $ref must wholesale-replace the inline base entry",
+        );
+    }
+
+    #[test]
+    fn merge_components_each_bag_incoming_wins_per_name() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "components": {
+                "schemas": {"Pet": {"type": "string"}, "Owner": {"type": "string"}},
+                "responses": {"NotFound": {"description": "base"}}
+            }
+        }));
+        let incoming = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "y", "version": "2"},
+            "paths": {},
+            "components": {
+                "schemas": {"Pet": {"type": "object"}, "Tag": {"type": "string"}},
+                "parameters": {"Limit": {"name": "limit", "in": "query", "schema": {"type": "integer"}}}
+            }
+        }));
+        base.merge(incoming);
+        let comp = base.components.expect("components present");
+        let schemas = comp.schemas.expect("schemas present");
+        // Round-trip Pet through JSON to confirm incoming definition replaced base.
+        let pet = serde_json::to_value(&schemas["Pet"]).unwrap();
+        assert_eq!(pet["type"], "object", "incoming Pet wins");
+        assert!(schemas.contains_key("Owner"), "base-only Owner retained");
+        assert!(schemas.contains_key("Tag"), "incoming-only Tag added");
+        // Parameters bag was None on base; incoming creates it.
+        assert!(
+            comp.parameters
+                .as_ref()
+                .is_some_and(|m| m.contains_key("Limit"))
+        );
+        // Base-only bag stays.
+        assert!(
+            comp.responses
+                .as_ref()
+                .is_some_and(|m| m.contains_key("NotFound"))
+        );
+    }
+
+    #[test]
+    fn merge_tags_dedupe_by_name_and_append_new() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "base-pets"},
+                {"name": "users", "description": "base-users"}
+            ]
+        }));
+        let incoming = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "tags": [
+                {"name": "pets", "description": "incoming-pets"},
+                {"name": "orders", "description": "new-orders"}
+            ]
+        }));
+        base.merge(incoming);
+        let tags = base.tags.unwrap();
+        assert_eq!(tags.len(), 3, "deduped: pets/users/orders");
+        let pets = tags.iter().find(|t| t.name == "pets").unwrap();
+        assert_eq!(pets.description.as_deref(), Some("incoming-pets"));
+        assert!(tags.iter().any(|t| t.name == "orders"));
+        assert!(tags.iter().any(|t| t.name == "users"));
+    }
+
+    #[test]
+    fn merge_servers_replaces_only_when_incoming_is_non_empty() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "servers": [{"url": "https://base.example/"}]
+        }));
+        // None incoming servers: base stays.
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {}
+        })));
+        let urls: Vec<_> = base
+            .servers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|s| s.url.clone())
+            .collect();
+        assert_eq!(urls, vec!["https://base.example/".to_owned()]);
+
+        // Non-empty incoming: base replaced wholesale.
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "servers": [{"url": "https://incoming.example/"}]
+        })));
+        let urls: Vec<_> = base
+            .servers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|s| s.url.clone())
+            .collect();
+        assert_eq!(urls, vec!["https://incoming.example/".to_owned()]);
+    }
+
+    #[test]
+    fn merge_keeps_base_info_and_openapi_version() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "Base", "version": "1"},
+            "paths": {}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "Incoming", "version": "9"},
+            "paths": {}
+        })));
+        assert_eq!(base.info.title, "Base", "info untouched by merge");
+        assert_eq!(base.info.version, "1");
+    }
+
+    #[test]
+    fn merge_top_level_extensions_per_key_incoming_wins() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "base",
+            "x-base-only": "kept"
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "x-shared": "incoming",
+            "x-incoming-only": "added"
+        })));
+        let ext = base.extensions.unwrap();
+        assert_eq!(ext["x-shared"], serde_json::json!("incoming"));
+        assert_eq!(ext["x-base-only"], serde_json::json!("kept"));
+        assert_eq!(ext["x-incoming-only"], serde_json::json!("added"));
+    }
+
+    #[test]
+    fn merge_webhooks_per_key_incoming_wins() {
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "webhooks": {
+                "petCreated": {"summary": "base-hook"}
+            }
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {},
+            "webhooks": {
+                "petCreated": {"summary": "incoming-hook"},
+                "petDeleted": {"summary": "new-hook"}
+            }
+        })));
+        let webhooks = base.webhooks.unwrap();
+        assert_eq!(
+            webhooks.paths["petCreated"].summary.as_deref(),
+            Some("incoming-hook")
+        );
+        assert_eq!(
+            webhooks.paths["petDeleted"].summary.as_deref(),
+            Some("new-hook")
+        );
+    }
+
+    #[test]
+    fn merge_round_trips_through_json() {
+        // After merge, the resulting spec must still serialize cleanly and
+        // re-parse to the same shape — i.e. no internal invariant broken.
+        let mut base = base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "x", "version": "1"},
+            "paths": {"/a": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "components": {"schemas": {"Pet": {"type": "string"}}}
+        }));
+        base.merge(base_spec(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "y", "version": "2"},
+            "paths": {"/b": {"get": {"responses": {"200": {"description": "ok"}}}}},
+            "components": {"schemas": {"Owner": {"type": "string"}}}
+        })));
+        let json = serde_json::to_value(&base).unwrap();
+        let _: Spec = serde_json::from_value(json).expect("merged spec must re-parse");
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `Spec::merge(&mut self, other: Self)` to each of the per-version `Spec` trees in `roas`. Lets callers combine two OpenAPI documents of the same version in-place without going through JSON.

```rust
let mut base: v3_2::Spec = ...;
let incoming: v3_2::Spec = ...;
base.merge(incoming);
```

## Contract

"Incoming always wins" — no `MergeOptions`, no error path:

| Section kind | Behavior |
|---|---|
| Map-keyed bags (`paths`, `webhooks`, every `components.<bag>`, v2's `definitions` / `parameters` / `responses` / `securityDefinitions`, top-level `x-*` extensions) | Per-key incoming wins; new keys appended. |
| `tags`, `x-tagGroups` | Deduped by `name`; incoming wins per name; new names appended. |
| List fields (`servers`, `security`, v2's `schemes` / `consumes` / `produces` / `x-servers`) | Replaced wholesale **when incoming is non-empty**; an absent or empty incoming list leaves the base alone. |
| Scalar options (`externalDocs`, `host` / `basePath`, `jsonSchemaDialect`, `$self`) | Replaced when incoming is `Some`. |
| `info`, `openapi` / `swagger` version | Untouched on base — base keeps its identity. |

`$ref`s are **not** rewritten. If a base component is replaced by an incoming one of the same name, every existing `$ref` to that name now resolves to the incoming definition — exactly the "Pet stays named Pet, old refs follow the new shape" behavior requested.

## Deep merge for PathItem containers

A naive `paths.extend(other.paths)` would drop unrelated methods on collision: merging a base with `/pets.get` and an incoming with `/pets.post` would lose the base `get`. To avoid that, three deep-merge axes are wired up:

- `Paths::merge` walks each `(path, PathItem)` and calls `PathItem::merge` on collision.
- `PathItem::merge` (all four versions) does per-method incoming-wins inside `operations` (and v3.2's `additional_operations`); scalar fields and `parameters` / `servers` follow the spec-level "incoming wins when present / non-empty" contract.
- `Callback::merge` (v3.0+) per-expression-key deep merge of `PathItem`s.
- `Components::merge`'s `path_items` (v3.1+) and `callbacks` (v3.0+) bags route through those helpers. For `callbacks`, when either side is a `RefOr::Ref` the incoming entry wholesale-replaces — refs can't be merged without resolving them.

## Open questions

Filed as **Draft** because two questions are unresolved:

1. **Operation-level deep merge.** Within a single Operation, `responses`, `callbacks`, `parameters` are currently replaced wholesale when the same method exists on both sides. Should those bags get the same per-key / per-expression deep merge as their reusable counterparts? Same question for `security` overrides at the operation level.
2. **Merge options.** Today the contract is hardcoded to "incoming wins". Worth considering a `MergeOptions { on_conflict: BaseWins | IncomingWins | Error, deep: bool }` if the deeper-merge semantics turn out to be situational.

## Coverage

53 new tests across the workspace; full `cargo nextest run --workspace --all-features` passes 1021/1021. `cargo clippy --tests --all-features -- -D warnings` clean.