### PR TITLE
ci(dependabot): add 7-day cooldown to update PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
       ci:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
@@ -21,3 +23,5 @@ updates:
         patterns:
           - "*"
         update-types: [ "major", "minor", "patch" ]
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Adds `cooldown.default-days: 7` to both Dependabot update groups (GitHub Actions and Cargo). New releases will sit for a week before Dependabot opens an update PR, so just-cut versions can settle before landing here.