### PR TITLE
ci: publish roas-cli as prebuilt binaries, Docker image, and Homebrew formula

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,10 @@ jobs:
       # block — without `contents: read`, `actions/checkout` cannot fetch the repo.
       contents: read
       id-token: write
+      # `packages: write` is required for the roas-cli-only steps below that
+      # push the container image to ghcr.io. Cargo publishing itself doesn't
+      # need it, but adding it at the job level keeps the matrix uniform.
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -36,3 +40,125 @@ jobs:
       - run: cargo publish --all-features --package ${{ matrix.package }} --verbose
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      # roas-cli-only publish targets. Gated on both the matrix package and
+      # the tag prefix so that a `roas/v…` tag (which expands the matrix to
+      # include roas-cli for cargo-publish purposes) doesn't accidentally
+      # push a Docker image or commit a Homebrew formula tied to the wrong
+      # version.
+      - name: Extract roas-cli version from tag
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        id: roas-cli
+        run: |
+          version="${GITHUB_REF#refs/tags/roas-cli/v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          tag="roas-cli/v${version}"
+          # GitHub source archive URL — tarball SHA lands in the Homebrew formula.
+          echo "tarball=https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${tag}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          # The built-in token already has `packages: write` against
+          # ghcr.io/${owner-of-repo}/*. No separate secret needed.
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push roas-cli container image
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # Tag the release version and `latest`. Both point at the
+          # multi-arch index; users pulling `:latest` get the right arch
+          # automatically.
+          tags: |
+            ghcr.io/sv-tools/roas:${{ steps.roas-cli.outputs.version }}
+            ghcr.io/sv-tools/roas:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/sv-tools/roas
+            org.opencontainers.image.description=Command-line front-end for the roas OpenAPI library
+            org.opencontainers.image.licenses=MIT OR Apache-2.0
+            org.opencontainers.image.version=${{ steps.roas-cli.outputs.version }}
+
+      - name: Compute Homebrew tarball SHA256
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        id: tarball
+        run: |
+          # Use `-fL` so GitHub's redirect to the codeload tarball is followed
+          # and a non-200 fails loudly (otherwise sha256sum would hash the
+          # error page).
+          sha=$(curl -sfL "${{ steps.roas-cli.outputs.tarball }}" | sha256sum | cut -d' ' -f1)
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Homebrew tap
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: sv-tools/homebrew-apps
+          # PAT (fine-grained, Contents: read+write on sv-tools/homebrew-apps)
+          # stored as a secret in this repo. Required because the default
+          # GITHUB_TOKEN is scoped to sv-tools/roas only.
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-apps
+
+      - name: Render and commit Homebrew formula
+        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
+        working-directory: homebrew-apps
+        env:
+          VERSION: ${{ steps.roas-cli.outputs.version }}
+          URL: ${{ steps.roas-cli.outputs.tarball }}
+          SHA256: ${{ steps.tarball.outputs.sha256 }}
+        run: |
+          mkdir -p Formula
+          # The formula compiles from source via `cargo install`. Bottles
+          # (prebuilt binaries) would be faster for users but require a
+          # darwin runner matrix and an extra release-asset upload step; we
+          # can layer that on later without changing the tap layout.
+          cat > Formula/roas.rb <<EOF
+          # typed: false
+          # frozen_string_literal: true
+          #
+          # Auto-generated by sv-tools/roas .github/workflows/publish.yaml.
+          # Do not edit by hand — changes are overwritten on the next release.
+          class Roas < Formula
+            desc "Command-line front-end for the roas OpenAPI library"
+            homepage "https://github.com/sv-tools/roas"
+            url "${URL}"
+            sha256 "${SHA256}"
+            license any_of: ["MIT", "Apache-2.0"]
+            head "https://github.com/sv-tools/roas.git", branch: "main"
+
+            depends_on "rust" => :build
+
+            def install
+              system "cargo", "install", *std_cargo_args(path: "crates/roas-cli")
+            end
+
+            test do
+              assert_match "roas ${VERSION}", shell_output("#{bin}/roas --version")
+            end
+          end
+          EOF
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/roas.rb
+          if git diff --cached --quiet; then
+            echo "roas formula unchanged at ${VERSION}; nothing to commit"
+          else
+            git commit -m "roas ${VERSION}"
+            git push
+          fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,10 +28,6 @@ jobs:
       # block — without `contents: read`, `actions/checkout` cannot fetch the repo.
       contents: read
       id-token: write
-      # `packages: write` is required for the roas-cli-only steps below that
-      # push the container image to ghcr.io. Cargo publishing itself doesn't
-      # need it, but adding it at the job level keeps the matrix uniform.
-      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -41,93 +37,183 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-      # roas-cli-only publish targets. Gated on both the matrix package and
-      # the tag prefix so that a `roas/v…` tag (which expands the matrix to
-      # include roas-cli for cargo-publish purposes) doesn't accidentally
-      # push a Docker image or commit a Homebrew formula tied to the wrong
-      # version.
+  # ────────────────────────────────────────────────────────────────────────
+  # roas-cli release pipeline. Only fires when `roas-cli` is in the publish
+  # set — i.e. on a `roas-cli/v…` tag where the version bump made the matrix.
+  # Cross-cuts the standard `Publish` job because it needs a per-target build
+  # matrix on native runners (no QEMU rebuilds of the rust dep tree).
+  # ────────────────────────────────────────────────────────────────────────
+  RoasCliBuild:
+    needs: Checks
+    if: ${{ contains(fromJSON(needs.Checks.outputs.publish), 'roas-cli') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            runner: macos-13
+          - target: aarch64-apple-darwin
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          target: ${{ matrix.target }}
       - name: Extract roas-cli version from tag
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
-        id: roas-cli
+        id: v
+        run: echo "version=${GITHUB_REF#refs/tags/roas-cli/v}" >> "$GITHUB_OUTPUT"
+        shell: bash
+      - name: Build release binary
+        run: cargo build --release --package roas-cli --target ${{ matrix.target }} --locked
+      - name: Pack tarball
+        id: pack
         run: |
-          version="${GITHUB_REF#refs/tags/roas-cli/v}"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          tag="roas-cli/v${version}"
-          # GitHub source archive URL — tarball SHA lands in the Homebrew formula.
-          echo "tarball=https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${tag}.tar.gz" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          archive="roas-${{ steps.v.outputs.version }}-${{ matrix.target }}.tar.gz"
+          # `tar -C` so the archive contains just `roas`, not a path prefix —
+          # Homebrew's `bin.install "roas"` expects the binary at archive root.
+          tar -C "target/${{ matrix.target }}/release" -czf "$archive" roas
+          # `shasum -a 256` is portable across the macOS / linux runners;
+          # `sha256sum` isn't installed by default on macOS.
+          shasum -a 256 "$archive" > "${archive}.sha256"
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+        shell: bash
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: roas-cli-${{ matrix.target }}
+          path: |
+            ${{ steps.pack.outputs.archive }}
+            ${{ steps.pack.outputs.archive }}.sha256
+
+  PublishRoasCli:
+    needs:
+      - Checks
+      - Publish
+      - RoasCliBuild
+    if: ${{ contains(fromJSON(needs.Checks.outputs.publish), 'roas-cli') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the GitHub Release + upload assets
+      packages: write  # push the container image to ghcr.io
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Extract roas-cli version from tag
+        id: v
+        run: echo "version=${GITHUB_REF#refs/tags/roas-cli/v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          pattern: roas-cli-*
+          merge-multiple: true
+
+      - name: Create GitHub Release with prebuilt binaries
+        id: release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          files: |
+            artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz
+            artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz.sha256
+          # The repo carries other crates (e.g. `roas`) with their own tags;
+          # don't mark this roas-cli release as the repo-wide "Latest".
+          make_latest: "false"
+
+      # ── Container image ──────────────────────────────────────────────────
+      # Stage the linux binaries into a tiny build context so the multi-arch
+      # `docker build` just COPYs them in. No QEMU rebuild of the rust dep
+      # tree — multi-arch image lands in a couple of minutes.
+      - name: Stage linux binaries for docker build
+        run: |
+          set -euo pipefail
+          V="${{ steps.v.outputs.version }}"
+          mkdir -p ctx/linux/amd64 ctx/linux/arm64
+          tar -xzf "artifacts/roas-${V}-x86_64-unknown-linux-gnu.tar.gz" -C ctx/linux/amd64
+          tar -xzf "artifacts/roas-${V}-aarch64-unknown-linux-gnu.tar.gz" -C ctx/linux/arm64
+          chmod +x ctx/linux/amd64/roas ctx/linux/arm64/roas
+          cp Dockerfile ctx/
 
       - name: Set up QEMU
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          # The built-in token already has `packages: write` against
-          # ghcr.io/${owner-of-repo}/*. No separate secret needed.
+          # GITHUB_TOKEN already carries `packages: write` against
+          # ghcr.io/${owner-of-repo}/* — no separate secret needed.
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push roas-cli container image
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          context: .
-          file: ./Dockerfile
+          context: ctx
+          file: ctx/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          # Tag the release version and `latest`. Both point at the
-          # multi-arch index; users pulling `:latest` get the right arch
-          # automatically.
           tags: |
-            ghcr.io/sv-tools/roas:${{ steps.roas-cli.outputs.version }}
+            ghcr.io/sv-tools/roas:${{ steps.v.outputs.version }}
             ghcr.io/sv-tools/roas:latest
           labels: |
             org.opencontainers.image.source=https://github.com/sv-tools/roas
             org.opencontainers.image.description=Command-line front-end for the roas OpenAPI library
             org.opencontainers.image.licenses=MIT OR Apache-2.0
-            org.opencontainers.image.version=${{ steps.roas-cli.outputs.version }}
+            org.opencontainers.image.version=${{ steps.v.outputs.version }}
 
-      - name: Compute Homebrew tarball SHA256
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
-        id: tarball
+      # ── Homebrew formula ─────────────────────────────────────────────────
+      # Source the release-asset SHAs from the tarballs we just uploaded.
+      # `softprops/action-gh-release` published them to the canonical URL
+      # `https://github.com/${repo}/releases/download/${tag}/${asset}`.
+      - name: Collect Homebrew asset SHAs
+        id: sha
         run: |
-          # Use `-fL` so GitHub's redirect to the codeload tarball is followed
-          # and a non-200 fails loudly (otherwise sha256sum would hash the
-          # error page).
-          sha=$(curl -sfL "${{ steps.roas-cli.outputs.tarball }}" | sha256sum | cut -d' ' -f1)
-          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          read_sha() {
+            # `.tar.gz.sha256` is `<sha>  <archive>` — keep the first field.
+            awk '{print $1}' "artifacts/roas-${{ steps.v.outputs.version }}-$1.tar.gz.sha256"
+          }
+          {
+            echo "darwin_arm64=$(read_sha aarch64-apple-darwin)"
+            echo "darwin_amd64=$(read_sha x86_64-apple-darwin)"
+            echo "linux_arm64=$(read_sha aarch64-unknown-linux-gnu)"
+            echo "linux_amd64=$(read_sha x86_64-unknown-linux-gnu)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout Homebrew tap
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: sv-tools/homebrew-apps
-          # PAT (fine-grained, Contents: read+write on sv-tools/homebrew-apps)
-          # stored as a secret in this repo. Required because the default
-          # GITHUB_TOKEN is scoped to sv-tools/roas only.
+          # Fine-grained PAT (Contents: read+write on sv-tools/homebrew-apps)
+          # stored as a secret in this repo. The default GITHUB_TOKEN is
+          # scoped to sv-tools/roas only.
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-apps
 
       - name: Render and commit Homebrew formula
-        if: matrix.package == 'roas-cli' && startsWith(github.ref, 'refs/tags/roas-cli/v')
         working-directory: homebrew-apps
         env:
-          VERSION: ${{ steps.roas-cli.outputs.version }}
-          URL: ${{ steps.roas-cli.outputs.tarball }}
-          SHA256: ${{ steps.tarball.outputs.sha256 }}
+          VERSION: ${{ steps.v.outputs.version }}
+          REPO_URL: https://github.com/${{ github.repository }}
+          TAG: roas-cli/v${{ steps.v.outputs.version }}
+          DARWIN_ARM64_SHA: ${{ steps.sha.outputs.darwin_arm64 }}
+          DARWIN_AMD64_SHA: ${{ steps.sha.outputs.darwin_amd64 }}
+          LINUX_ARM64_SHA: ${{ steps.sha.outputs.linux_arm64 }}
+          LINUX_AMD64_SHA: ${{ steps.sha.outputs.linux_amd64 }}
         run: |
+          set -euo pipefail
           mkdir -p Formula
-          # The formula compiles from source via `cargo install`. Bottles
-          # (prebuilt binaries) would be faster for users but require a
-          # darwin runner matrix and an extra release-asset upload step; we
-          # can layer that on later without changing the tap layout.
+          asset_url() {
+            echo "${REPO_URL}/releases/download/${TAG}/roas-${VERSION}-$1.tar.gz"
+          }
           cat > Formula/roas.rb <<EOF
           # typed: false
           # frozen_string_literal: true
@@ -137,15 +223,33 @@ jobs:
           class Roas < Formula
             desc "Command-line front-end for the roas OpenAPI library"
             homepage "https://github.com/sv-tools/roas"
-            url "${URL}"
-            sha256 "${SHA256}"
+            version "${VERSION}"
             license any_of: ["MIT", "Apache-2.0"]
-            head "https://github.com/sv-tools/roas.git", branch: "main"
 
-            depends_on "rust" => :build
+            on_macos do
+              on_arm do
+                url "$(asset_url aarch64-apple-darwin)"
+                sha256 "${DARWIN_ARM64_SHA}"
+              end
+              on_intel do
+                url "$(asset_url x86_64-apple-darwin)"
+                sha256 "${DARWIN_AMD64_SHA}"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "$(asset_url aarch64-unknown-linux-gnu)"
+                sha256 "${LINUX_ARM64_SHA}"
+              end
+              on_intel do
+                url "$(asset_url x86_64-unknown-linux-gnu)"
+                sha256 "${LINUX_AMD64_SHA}"
+              end
+            end
 
             def install
-              system "cargo", "install", *std_cargo_args(path: "crates/roas-cli")
+              bin.install "roas"
             end
 
             test do

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
 # syntax=docker/dockerfile:1.7
+#
+# Release-pipeline Dockerfile. Expects prebuilt linux binaries staged in the
+# build context at `./linux/amd64/roas` and `./linux/arm64/roas`. Buildx
+# substitutes TARGETOS/TARGETARCH per platform when running with
+# `--platform linux/amd64,linux/arm64`, so a single Dockerfile + COPY yields
+# the right multi-arch image without QEMU rebuilds of the rust toolchain.
+#
+# To build locally (single arch matching the host):
+#   cargo build --release --package roas-cli
+#   mkdir -p ctx/linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+#   cp target/release/roas ctx/linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')/
+#   docker build -t roas:dev ctx
 
-# Multi-stage build for the `roas` CLI binary. The release pipeline drives
-# this with QEMU under the hood for linux/arm64, so the Dockerfile itself
-# stays single-arch-shaped: each platform gets its own native build inside
-# its own emulated container.
-
-FROM rust:1-bookworm AS builder
-WORKDIR /src
-COPY . .
-# `--locked` enforces the workspace `Cargo.lock` so the image build can't
-# silently pick up a dep version that hasn't been tested yet.
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    cargo build --release --package roas-cli --locked
-
-# distroless/cc has glibc + libgcc_s — enough for a default-target Rust
-# binary that doesn't pull in additional shared libraries. `nonroot` ships
-# UID 65532 by default which is the more defensible posture for a CLI image.
 FROM gcr.io/distroless/cc-debian12:nonroot
-COPY --from=builder /src/target/release/roas /usr/local/bin/roas
+ARG TARGETOS
+ARG TARGETARCH
+COPY ${TARGETOS}/${TARGETARCH}/roas /usr/local/bin/roas
 ENTRYPOINT ["/usr/local/bin/roas"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.7
+
+# Multi-stage build for the `roas` CLI binary. The release pipeline drives
+# this with QEMU under the hood for linux/arm64, so the Dockerfile itself
+# stays single-arch-shaped: each platform gets its own native build inside
+# its own emulated container.
+
+FROM rust:1-bookworm AS builder
+WORKDIR /src
+COPY . .
+# `--locked` enforces the workspace `Cargo.lock` so the image build can't
+# silently pick up a dep version that hasn't been tested yet.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    cargo build --release --package roas-cli --locked
+
+# distroless/cc has glibc + libgcc_s — enough for a default-target Rust
+# binary that doesn't pull in additional shared libraries. `nonroot` ships
+# UID 65532 by default which is the more defensible posture for a CLI image.
+FROM gcr.io/distroless/cc-debian12:nonroot
+COPY --from=builder /src/target/release/roas /usr/local/bin/roas
+ENTRYPOINT ["/usr/local/bin/roas"]


### PR DESCRIPTION
## Summary

Extends the tag-driven publish workflow with a precompile-then-ship pipeline for `roas-cli`, gated on `roas-cli` being in `needs.Checks.outputs.publish`. End-user install paths after this lands:

```sh
docker pull ghcr.io/sv-tools/roas:latest
brew tap sv-tools/apps && brew install roas
```

Both are **instant** — no rust build on the user's machine.

## Pipeline shape

Two new jobs, sibling to the existing per-package `Publish`:

- **`RoasCliBuild`** — 4-target matrix on native runners (no QEMU, no cross toolchain): `x86_64`/`aarch64` × `unknown-linux-gnu`/`apple-darwin`. Each runner produces `roas-<version>-<target>.tar.gz` + `.sha256` and uploads them as workflow artefacts.
- **`PublishRoasCli`** — downloads the artefacts, creates the GitHub Release with them as assets (`make_latest: false` so it doesn't hijack the "Latest" badge from `roas/v…` library tags), stages the linux binaries into a build context, and pushes the multi-arch container image to `ghcr.io/sv-tools/roas`. Then renders `Formula/roas.rb` with `on_macos { on_arm/on_intel … }` URL/sha pairs against the release assets and commits to `sv-tools/homebrew-apps` using `HOMEBREW_TAP_TOKEN`.

The `Dockerfile` is now a 5-line `distroless/cc-debian12:nonroot` wrapper that COPYs the prebuilt binary per `${TARGETARCH}` — no rust toolchain inside the image build.

The existing `Publish` job is back to just `cargo publish`; Docker and Homebrew steps moved into `PublishRoasCli`.

## Prereqs (already in place)

- `sv-tools/homebrew-apps` tap repo exists.
- `HOMEBREW_TAP_TOKEN` secret is set on this repo (fine-grained PAT with `Contents: read+write` on `sv-tools/homebrew-apps`).

## Notes

- glibc compat: the linux binaries are built on the runners' default glibc (ubuntu-latest → 24.04; ubuntu-24.04-arm). If users on older distros hit "version 'GLIBC_X.Y' not found", we can pin the runners to `ubuntu-22.04` / `-arm`.
- Bottle tarballs vs raw release-asset tarballs: this PR ships the latter, which Homebrew accepts via `url`/`sha256` blocks. Homebrew's bottle DSL has stricter naming and is mainly useful for homebrew-core submission later.