### PR TITLE
chore: refresh Cargo.lock for roas-cli 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
## Summary

One-line `Cargo.lock` bump for `roas-cli` (0.2.0 → 0.2.1). PR #146 committed the lockfile before #145 bumped the manifest, and the squash-merge didn't refresh it. The release pipeline's `cargo build --locked` correctly refused to update the lock, breaking the `RoasCliBuild` matrix on the `roas-cli/v0.2.1` tag run.

## Recovery context

The 0.2.1 tag's run is partially complete:

- ✅ `cargo publish` succeeded — `roas-cli 0.2.1` is on crates.io.
- ❌ `RoasCliBuild` failed → no `ghcr.io/sv-tools/roas:0.2.1` image, no `Formula/roas.rb` update.

After this PR lands, recovery options:

1. **Bump to `roas-cli 0.2.2` and re-tag.** Cleanest: the matrix runs end-to-end. crates.io gets `0.2.2`, Docker + Homebrew get `0.2.2`. `0.2.1` stays as a "ghost" version on crates.io with no Docker / Homebrew counterpart.
2. **Force-push the `roas-cli/v0.2.1` tag.** Re-runs the workflow; `cargo publish` will fail (0.2.1 already published) and that failure cascades into `PublishRoasCli` being skipped. So this **does not** work without further workflow changes.

Recommendation: take option 1.