### PR TITLE
roas-cli: bump 0.2.1 -> 0.2.2 (re-cut after lockfile mismatch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Patch bump on `roas-cli` to re-cut the release after the `roas-cli/v0.2.1` tag's partial run.

## What happened on 0.2.1

- ✅ `cargo publish` succeeded — `roas-cli 0.2.1` is on crates.io.
- ❌ `RoasCliBuild` failed under `cargo build --release --package roas-cli --locked` because `Cargo.lock` (just committed in #146) still pointed at `0.2.0` — the squash-merge of #145 didn't refresh it.
- ❌ As a consequence, neither the GHCR image nor the Homebrew formula was published for 0.2.1.

Force-pushing the `roas-cli/v0.2.1` tag wouldn't help: `cargo publish` would now fail (0.2.1 already on crates.io), which cascades into `PublishRoasCli` being skipped.

## What this PR does

- Bumps `crates/roas-cli/Cargo.toml`: `0.2.1` → `0.2.2`.
- Refreshes `Cargo.lock` to match (`cargo update -p roas-cli`). This also subsumes #147, which can be closed.

## After merge

Tag `roas-cli/v0.2.2`. The full pipeline runs:

- crates.io gets `roas-cli 0.2.2`.
- `ghcr.io/sv-tools/roas:0.2.2` and `:latest` go up multi-arch.
- `Formula/roas.rb` in `sv-tools/homebrew-apps` is committed with the four prebuilt-tarball URLs.

`0.2.1` remains as a crates.io-only "ghost" version with no Docker / Homebrew counterpart.