### PR TITLE
ci: cross-build x86_64-apple-darwin via cargo-zigbuild; bump roas-cli 0.2.3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,22 +54,41 @@ jobs:
             runner: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
+          # x86_64 macOS is cross-built on linux via cargo-zigbuild. GitHub's
+          # macos-13 fleet is undersized and the release run was queueing for
+          # hours; zig provides the macOS SDK headers + linker glue and
+          # produces an ad-hoc-signed mach-o binary the matrix can pack and
+          # ship like the rest. arm64 macOS stays native — Apple Silicon is
+          # the dominant target now and the macos-latest runners have
+          # capacity.
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: ubuntu-latest
+            cross: zigbuild
           - target: aarch64-apple-darwin
-            runner: macos-14
+            runner: macos-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           target: ${{ matrix.target }}
+      - name: Set up Zig (cross-build to macOS)
+        if: matrix.cross == 'zigbuild'
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+      - name: Install cargo-zigbuild
+        if: matrix.cross == 'zigbuild'
+        # `--locked` requires the Cargo.lock from this repo, which is
+        # unrelated to cargo-zigbuild's own dep tree — so omit it here.
+        run: cargo install cargo-zigbuild
       - name: Extract roas-cli version from tag
         id: v
         run: echo "version=${GITHUB_REF#refs/tags/roas-cli/v}" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Build release binary
-        run: cargo build --release --package roas-cli --target ${{ matrix.target }} --locked
+        # Picks `cargo zigbuild` on the cross row and `cargo build` everywhere
+        # else; both produce a release binary at `target/${target}/release/roas`,
+        # so the rest of the steps are uniform.
+        run: cargo ${{ matrix.cross == 'zigbuild' && 'zigbuild' || 'build' }} --release --package roas-cli --target ${{ matrix.target }} --locked
       - name: Pack tarball
         id: pack
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

GitHub's `macos-13` Intel fleet has been undersized — the `roas-cli/v0.2.2` release run queued for hours waiting for a runner. This PR replaces the Intel macOS leg with a linux cross-build via [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild), and cuts a `0.2.3` patch bump to test the new path end-to-end.

## Matrix change

| Target | Before | After |
|---|---|---|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | (unchanged) |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` | (unchanged) |
| `x86_64-apple-darwin` | `macos-13` (native) | **`ubuntu-latest`** (zigbuild cross) |
| `aarch64-apple-darwin` | `macos-14` (native) | `macos-latest` (native; arm64 doesn't drift) |

A `cross: zigbuild` flag on the matrix entry toggles two conditional setup steps (`mlugg/setup-zig` + `cargo install cargo-zigbuild`) and one GHA expression on the build step (`cargo zigbuild` vs `cargo build`). The rest of the matrix steps (pack tarball, upload artefact) stay uniform.

## Version bump

`roas-cli` 0.2.2 → 0.2.3 + `Cargo.lock` refresh. After merge, tag `roas-cli/v0.2.3` to run the full pipeline through the new cross path. The queued 0.2.2 run can be left to drain or cancelled — its outcome is moot once 0.2.3 lands.

## Tradeoffs (recapped from earlier discussion)

- Linux cross-builds are **unsigned** for x86_64 macOS by default; cargo-zigbuild applies an ad-hoc signature, which is enough to satisfy Gatekeeper for binaries distributed without `com.apple.quarantine` (Homebrew installs in this category).
- Apple-framework deps (`CoreServices`, `Security`, `CoreFoundation`) work with cargo-zigbuild today via zig's bundled SDK headers, but a future transitive dep could expose a linker edge case the native build wouldn't.
- arm64 macOS stays native, which is the safer target to keep on real hardware (Gatekeeper is strict on Apple Silicon).