### PR TITLE
ci: drop x86_64-apple-darwin from release matrix; bump roas-cli 0.2.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,16 +54,12 @@ jobs:
             runner: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
-          # x86_64 macOS is cross-built on linux via cargo-zigbuild. GitHub's
-          # macos-13 fleet is undersized and the release run was queueing for
-          # hours; zig provides the macOS SDK headers + linker glue and
-          # produces an ad-hoc-signed mach-o binary the matrix can pack and
-          # ship like the rest. arm64 macOS stays native — Apple Silicon is
-          # the dominant target now and the macos-latest runners have
-          # capacity.
-          - target: x86_64-apple-darwin
-            runner: ubuntu-latest
-            cross: zigbuild
+          # macOS is arm64-only. macos-13 (Intel) is being phased out by
+          # GitHub and queues for hours; cross-building x86_64 via
+          # cargo-zigbuild failed at link time because notify / reqwest pull
+          # in CoreServices / CoreFoundation / Security and zig doesn't
+          # bundle those frameworks. Intel macOS users can `cargo install
+          # roas-cli` or use the Docker image.
           - target: aarch64-apple-darwin
             runner: macos-latest
     runs-on: ${{ matrix.runner }}
@@ -72,23 +68,12 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           target: ${{ matrix.target }}
-      - name: Set up Zig (cross-build to macOS)
-        if: matrix.cross == 'zigbuild'
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-      - name: Install cargo-zigbuild
-        if: matrix.cross == 'zigbuild'
-        # `--locked` requires the Cargo.lock from this repo, which is
-        # unrelated to cargo-zigbuild's own dep tree — so omit it here.
-        run: cargo install cargo-zigbuild
       - name: Extract roas-cli version from tag
         id: v
         run: echo "version=${GITHUB_REF#refs/tags/roas-cli/v}" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Build release binary
-        # Picks `cargo zigbuild` on the cross row and `cargo build` everywhere
-        # else; both produce a release binary at `target/${target}/release/roas`,
-        # so the rest of the steps are uniform.
-        run: cargo ${{ matrix.cross == 'zigbuild' && 'zigbuild' || 'build' }} --release --package roas-cli --target ${{ matrix.target }} --locked
+        run: cargo build --release --package roas-cli --target ${{ matrix.target }} --locked
       - name: Pack tarball
         id: pack
         run: |
@@ -202,7 +187,6 @@ jobs:
           }
           {
             echo "darwin_arm64=$(read_sha aarch64-apple-darwin)"
-            echo "darwin_amd64=$(read_sha x86_64-apple-darwin)"
             echo "linux_arm64=$(read_sha aarch64-unknown-linux-gnu)"
             echo "linux_amd64=$(read_sha x86_64-unknown-linux-gnu)"
           } >> "$GITHUB_OUTPUT"
@@ -224,7 +208,6 @@ jobs:
           REPO_URL: https://github.com/${{ github.repository }}
           TAG: roas-cli/v${{ steps.v.outputs.version }}
           DARWIN_ARM64_SHA: ${{ steps.sha.outputs.darwin_arm64 }}
-          DARWIN_AMD64_SHA: ${{ steps.sha.outputs.darwin_amd64 }}
           LINUX_ARM64_SHA: ${{ steps.sha.outputs.linux_arm64 }}
           LINUX_AMD64_SHA: ${{ steps.sha.outputs.linux_amd64 }}
         run: |
@@ -233,6 +216,9 @@ jobs:
           asset_url() {
             echo "${REPO_URL}/releases/download/${TAG}/roas-${VERSION}-$1.tar.gz"
           }
+          # macOS bottle is arm64-only. Intel macOS users hit Homebrew's
+          # "No available formula for this platform" error and should
+          # `cargo install roas-cli` or use the Docker image.
           cat > Formula/roas.rb <<EOF
           # typed: false
           # frozen_string_literal: true
@@ -249,10 +235,6 @@ jobs:
               on_arm do
                 url "$(asset_url aarch64-apple-darwin)"
                 sha256 "${DARWIN_ARM64_SHA}"
-              end
-              on_intel do
-                url "$(asset_url x86_64-apple-darwin)"
-                sha256 "${DARWIN_AMD64_SHA}"
               end
             end
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

The cargo-zigbuild cross-build for `x86_64-apple-darwin` (added in #149) failed at link time:

```
error: unable to find framework 'CoreServices'. searched paths:  none
error: unable to find framework 'CoreFoundation'. searched paths:  none
error: unable to find framework 'Security'. searched paths:  none
```

`notify` (used by `preview --watch`) and `reqwest`/`native-tls` pull these in on macOS; zig bundles SDK *headers* but not the framework binaries themselves, so the linker can't resolve them. The native `macos-13` runners are being phased out by GitHub and queue for hours — there's no longer a quick way to ship Intel macOS binaries from CI.

## Changes

- `RoasCliBuild` matrix loses the `x86_64-apple-darwin` row, the `mlugg/setup-zig` / `cargo install cargo-zigbuild` setup steps, and the `cross` flag + GHA-expression toggle on the build command. The build step is back to a single straightforward `cargo build`.
- `PublishRoasCli` drops the `darwin_amd64` SHA read and the `on_intel` block under `on_macos` in the Homebrew formula template.
- `roas-cli` 0.2.3 → 0.2.4 + `Cargo.lock` refresh, to cut a release that exercises the simplified pipeline.

Net `publish.yaml` diff is **-18 lines**.

## End-user impact

Intel macOS users:

- **Homebrew**: `brew install roas` hits "No available formula for this platform". Two fallbacks:
  - `cargo install roas-cli` (compiles from source, no signing concerns since it's the user's own machine).
  - `docker run ghcr.io/sv-tools/roas …` (the linux/amd64 image runs on Intel macOS via Docker Desktop's VM).
- **Crates.io**: unchanged — `cargo install roas-cli` still works.

Apple Silicon (arm64) macOS, x86_64 / arm64 Linux: unchanged, all installs paths intact.

## After merge

Tag `roas-cli/v0.2.4`. Full pipeline runs through three matrix targets (no macOS Intel) and pushes the simplified Homebrew formula.