### PR TITLE
roas-cli: bump 0.2.4 -> 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Patch bump to retry the release pipeline. The `roas-cli/v0.2.4` run failed at the asset-upload step:

```
Error: Cannot upload asset roas-0.2.4-x86_64-unknown-linux-gnu.tar.gz to an
immutable release. GitHub only allows asset uploads before a release is
published, so upload assets to a draft release before you publish it.
```

The matrix uploads four artefacts concurrently; the first to finish creates the release as **published** (the default for `softprops/action-gh-release` is non-draft), and subsequent uploads race against GitHub's new immutable-release semantics.

Workaround (manual, this release): create a **draft** release for `roas-cli/v0.2.5` on GitHub before pushing the tag, so the workflow appends assets to an existing draft. Publish the draft once all four uploads succeed and the Docker / Homebrew steps complete.

Longer-term fix (separate PR): pass `draft: true` to the action so the workflow always creates/uses a draft; the maintainer manually publishes after CI is green.