### PR TITLE
ci: keep roas-cli GitHub Release as a draft

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -126,7 +126,8 @@ jobs:
             artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz.sha256
           # The repo carries other crates (e.g. `roas`) with their own tags;
           # don't mark this roas-cli release as the repo-wide "Latest".
-          make_latest: "false"
+          make_latest: false
+          draft: true
 
       # ── Container image ──────────────────────────────────────────────────
       # Stage the linux binaries into a tiny build context so the multi-arch


### PR DESCRIPTION
## Summary

Two-line change to `softprops/action-gh-release` inside `PublishRoasCli`:

- `draft: true` — keeps the release unpublished after the workflow finishes. Draft releases accept asset uploads even after they're created, so the matrix's per-runner asset uploads no longer race against the immutable-published-release semantics that broke `roas-cli/v0.2.4`.
- `make_latest: "false"` → `make_latest: false` (unquoted boolean for consistency with `draft: true`).

## Workflow after this lands

1. Tag `roas-cli/v<version>`.
2. CI runs end-to-end: cargo publish, build matrix, Docker push, Homebrew formula commit. All assets land on the draft release.
3. Maintainer reviews the draft release on GitHub and clicks "Publish release" once everything looks good.