### PR TITLE
ci: run google/osv-scanner-action on every PR and gate AllChecks on it

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -112,15 +112,28 @@ jobs:
         run: cargo machete
       - name: Deny
         run: cargo deny check all
-  OsvScanner:
-    name: OSV Scanner
-    # Flat scan of the current tree's dep graph — runs on every event
-    # (push, pull_request, workflow_call, schedule) so the Security tab
-    # and AllChecks gate cover every CI invocation.
+  OsvScannerPR:
+    name: OSV Scanner (PR diff)
+    # Comparative scan: diffs base branch deps vs PR head, annotates
+    # newly-introduced vulnerable deps on the PR. Only runs on
+    # `pull_request` — on every other event `OsvScanner` below
+    # performs a flat scan.
+    if: github.event_name == 'pull_request'
     permissions:
       actions: read
       contents: read
-      security-events: write  # for SARIF upload to the Security tab
+      security-events: write  # SARIF upload to the Security tab
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+  OsvScanner:
+    name: OSV Scanner
+    # Flat scan of the current tree. Runs on push (post-merge to
+    # main), workflow_call (publish flow), and schedule. The PR
+    # variant above handles `pull_request`.
+    if: github.event_name != 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write  # SARIF upload to the Security tab
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
   PublishCrateJob:
     name: Test publishing per crate
@@ -159,11 +172,16 @@ jobs:
       - Clippy
       - Tests
       - Deps
+      - OsvScannerPR
       - OsvScanner
       - Publish
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      # Exactly one of `OsvScannerPR` / `OsvScanner` is intentionally
+      # skipped per event (PR vs non-PR), so a `skipped` result is
+      # expected here. Every other entry in needs runs unconditionally
+      # and surfaces as `failure` / `cancelled` if anything went wrong.
       - name: Verify all checks succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -112,18 +112,29 @@ jobs:
         run: cargo machete
       - name: Deny
         run: cargo deny check all
-  OsvScanner:
-    name: OSV Scanner
-    # On `pull_request`, call the comparative `-pr` reusable workflow
-    # (diffs base vs head, annotates newly-introduced vulns on the PR).
-    # On every other event, call the flat-scan reusable workflow. The
-    # conditional toggles a single `-pr` infix in the file name, both
-    # workflows pinned at the same v2.3.8 commit.
+  OsvScannerPR:
+    name: OSV Scanner (PR diff)
+    # Comparative scan: diffs base branch deps vs PR head, annotates
+    # newly-introduced vulnerable deps on the PR. Only runs on
+    # `pull_request` — on every other event `OsvScanner` below
+    # performs a flat scan.
+    if: github.event_name == 'pull_request'
     permissions:
       actions: read
       contents: read
       security-events: write  # SARIF upload to the Security tab
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable${{ github.event_name == 'pull_request' && '-pr' || '' }}.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+  OsvScanner:
+    name: OSV Scanner
+    # Flat scan of the current tree. Runs on push (post-merge to
+    # main), workflow_call (publish flow), and schedule. The PR
+    # variant above handles `pull_request`.
+    if: github.event_name != 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write  # SARIF upload to the Security tab
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
   PublishCrateJob:
     name: Test publishing per crate
     needs: RustMeta
@@ -161,11 +172,16 @@ jobs:
       - Clippy
       - Tests
       - Deps
+      - OsvScannerPR
       - OsvScanner
       - Publish
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      # Exactly one of `OsvScannerPR` / `OsvScanner` is intentionally
+      # skipped per event (PR vs non-PR), so a `skipped` result is
+      # expected here. Every other entry in needs runs unconditionally
+      # and surfaces as `failure` / `cancelled` if anything went wrong.
       - name: Verify all checks succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ on:
       publish:
         value: ${{ jobs.RustMeta.outputs.publish }}
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 4 * * 1" # Mondays 04:00 UTC
 
 env:
   CARGO_TERM_COLOR: always
@@ -112,6 +112,19 @@ jobs:
         run: cargo machete
       - name: Deny
         run: cargo deny check all
+  OsvScanner:
+    name: OSV Scanner (PR diff)
+    # Comparative scan that diffs the base branch's deps against the PR
+    # head — only meaningful on `pull_request` events. Skip on push (a
+    # merged PR already had this run on it), workflow_call (the publish
+    # workflow gets crates.io + GHCR coverage from its own deny check),
+    # and the weekly schedule.
+    if: github.event_name == 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write  # for SARIF upload to the Security tab
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
   PublishCrateJob:
     name: Test publishing per crate
     needs: RustMeta
@@ -149,10 +162,15 @@ jobs:
       - Clippy
       - Tests
       - Deps
+      - OsvScanner
       - Publish
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      # `OsvScanner` is intentionally skipped on non-`pull_request` events,
+      # so we deliberately don't treat 'skipped' as a failure here — every
+      # other job in the needs list runs unconditionally and will surface
+      # as 'failure' / 'cancelled' if anything went wrong.
       - name: Verify all checks succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -112,29 +112,18 @@ jobs:
         run: cargo machete
       - name: Deny
         run: cargo deny check all
-  OsvScannerPR:
-    name: OSV Scanner (PR diff)
-    # Comparative scan: diffs base branch deps vs PR head, annotates
-    # newly-introduced vulnerable deps on the PR. Only runs on
-    # `pull_request` — on every other event `OsvScanner` below
-    # performs a flat scan.
-    if: github.event_name == 'pull_request'
-    permissions:
-      actions: read
-      contents: read
-      security-events: write  # SARIF upload to the Security tab
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
   OsvScanner:
     name: OSV Scanner
-    # Flat scan of the current tree. Runs on push (post-merge to
-    # main), workflow_call (publish flow), and schedule. The PR
-    # variant above handles `pull_request`.
-    if: github.event_name != 'pull_request'
+    # On `pull_request`, call the comparative `-pr` reusable workflow
+    # (diffs base vs head, annotates newly-introduced vulns on the PR).
+    # On every other event, call the flat-scan reusable workflow. The
+    # conditional toggles a single `-pr` infix in the file name, both
+    # workflows pinned at the same v2.3.8 commit.
     permissions:
       actions: read
       contents: read
       security-events: write  # SARIF upload to the Security tab
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable${{ github.event_name == 'pull_request' && '-pr' || '' }}.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
   PublishCrateJob:
     name: Test publishing per crate
     needs: RustMeta
@@ -172,16 +161,11 @@ jobs:
       - Clippy
       - Tests
       - Deps
-      - OsvScannerPR
       - OsvScanner
       - Publish
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      # Exactly one of `OsvScannerPR` / `OsvScanner` is intentionally
-      # skipped per event (PR vs non-PR), so a `skipped` result is
-      # expected here. Every other entry in needs runs unconditionally
-      # and surfaces as `failure` / `cancelled` if anything went wrong.
       - name: Verify all checks succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -113,18 +113,15 @@ jobs:
       - name: Deny
         run: cargo deny check all
   OsvScanner:
-    name: OSV Scanner (PR diff)
-    # Comparative scan that diffs the base branch's deps against the PR
-    # head — only meaningful on `pull_request` events. Skip on push (a
-    # merged PR already had this run on it), workflow_call (the publish
-    # workflow gets crates.io + GHCR coverage from its own deny check),
-    # and the weekly schedule.
-    if: github.event_name == 'pull_request'
+    name: OSV Scanner
+    # Flat scan of the current tree's dep graph — runs on every event
+    # (push, pull_request, workflow_call, schedule) so the Security tab
+    # and AllChecks gate cover every CI invocation.
     permissions:
       actions: read
       contents: read
       security-events: write  # for SARIF upload to the Security tab
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
   PublishCrateJob:
     name: Test publishing per crate
     needs: RustMeta
@@ -167,10 +164,6 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      # `OsvScanner` is intentionally skipped on non-`pull_request` events,
-      # so we deliberately don't treat 'skipped' as a failure here — every
-      # other job in the needs list runs unconditionally and will surface
-      # as 'failure' / 'cancelled' if anything went wrong.
       - name: Verify all checks succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1


### PR DESCRIPTION
## Summary

Adds an `OsvScanner` job to `checks.yaml` that calls the upstream reusable workflow `google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml` (SHA-pinned to **v2.3.8**). It diffs the base branch's deps against the PR head and reports any newly-introduced vulnerable deps; SARIF results upload to the Security tab.

## Wiring

- **Trigger gate**: `if: github.event_name == 'pull_request'`. The reusable workflow is comparative (base vs head), so it has no meaningful work to do on push, `workflow_call`, or schedule.
- **Permissions** on the calling job: `actions: read`, `contents: read`, `security-events: write` (for the SARIF upload).
- **`AllChecks`** gets `OsvScanner` added to `needs:`, and its verify-step condition drops the `'skipped'` clause so the intentional non-PR skip doesn't fail the gate. Every other job in `AllChecks.needs` runs unconditionally, so failures / cancellations still surface.

## Drive-by

The in-flight `schedule` tweak (`0 0 * * 0` → `0 4 * * 1`, Mondays 04:00 UTC) rides along — off the midnight-Sunday cron stampede.