### PR TITLE
roas: bump 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "roas"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas/Cargo.toml
+++ b/crates/roas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Bumps \`roas\` from 0.13.2 → 0.14.0 for the substantial new public API added since the last release:

- \`v3_2::Spec::collapse\` (#156, #157) — lift inline components into \`components.<bag>\` with dedup + optional loader.
- \`common::collapse\` (#158) — shared dedup/naming/\`lift_ref_or\` machinery.
- \`v3_1::Spec::collapse\`, \`v3_0::Spec::collapse\`, \`v2::Spec::collapse\` (#159) — same surface for the remaining OAS versions, plus \`pub use CollapseError\` per version module.

Sibling crates (\`roas-cli\`, \`roas-file-fetcher\`, \`roas-http-fetcher\`) already depend on \`roas = \">=0.13\"\` or \`\">=0.13.2\"\`, so they pick up the new version automatically — no sibling bumps needed.

## Test plan

- [ ] Existing CI (build / clippy / nextest / OSV) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)