### PR TITLE
ci: grant security-events: write to the reusable Checks call

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,15 @@ permissions: read-all
 
 jobs:
   Checks:
+    # `OsvScanner` (and its PR sibling) inside the reusable workflow need
+    # `security-events: write` to upload SARIF to the Security tab.
+    # Reusable workflows can't escalate beyond what the caller grants, so
+    # the top-level `read-all` default isn't enough — pin the broader
+    # scope here at the call site.
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: ./.github/workflows/checks.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

The \`roas/v0.14.0\` Publish run failed at startup with:

> The nested job 'OsvScannerPR' is requesting 'security-events: write', but is only allowed 'security-events: read'.
> The nested job 'OsvScanner' is requesting 'security-events: write', but is only allowed 'security-events: read'.

\`publish.yaml\` calls \`checks.yaml\` as a reusable workflow. The OsvScanner jobs in \`checks.yaml\` request \`security-events: write\` so they can upload SARIF to the Security tab, but a reusable workflow can't escalate beyond what the caller grants — \`publish.yaml\`'s top-level \`permissions: read-all\` was capping it at \`read\`.

Fix: pin the broader scope on the \`Checks:\` job (\`actions: read\`, \`contents: read\`, \`security-events: write\`) so the called workflow's per-job permissions are admissible. Everything else still inherits the workflow-level \`read-all\` default.

## Test plan

- [ ] After merge, re-trigger the Publish workflow for \`roas/v0.14.0\` (delete + re-push the tag, or run via workflow_dispatch) and verify it now starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)