### PR TITLE
ci: narrow checks.yaml workflow-level permissions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,7 +18,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-permissions: read-all
+# Workflow-level permissions are deliberately narrow: every job here
+# just clones the repo and runs cargo. Jobs that need more (e.g.
+# `OsvScanner*` for SARIF upload) declare it per-job. Listing the
+# workflow-level scopes explicitly also keeps reusable-workflow callers
+# from having to grant more than is actually used — the GITHUB_TOKEN
+# request from `workflow_call` is the union of this block and each
+# job's own `permissions:`.
+permissions:
+  contents: read
 
 jobs:
   RustMeta:


### PR DESCRIPTION
## Summary

Follow-up to #161. The next Publish run for \`roas/v0.14.0\` still failed at startup, this time with:

> Error calling workflow 'sv-tools/roas/.github/workflows/checks.yaml@3d984ec…'. The workflow is requesting 'artifact-metadata: read, attestations: read, checks: read, code-quality: read, deployments: read, discussions: read, issues: read, models: read, vulnerability-alerts: read, packages: read, pages: read, pull-requests: read, repository-projects: read, statuses: read, id-token: read', but is only allowed 'artifa[...]'

\`checks.yaml\` declared workflow-level \`permissions: read-all\`, which is a request for read across ~15 scopes. The narrowed per-job grant from #161 (only \`actions: read\`, \`contents: read\`, \`security-events: write\`) didn't cover the rest.

Every job in \`checks.yaml\` just clones the repo and runs cargo; the \`OsvScanner*\` SARIF-upload pair self-declare what they need. So the workflow-level request was over-broad — narrowed it to \`contents: read\` and documented the contract for future callers.

## Test plan

- [ ] After merge, re-tag \`roas/v0.14.0\` and verify the Publish workflow starts (no \`startup_failure\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)