### PR TITLE
ci: temporarily disable OsvScanner (non-PR variant)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -129,7 +129,11 @@ jobs:
     # Flat scan of the current tree. Runs on push (post-merge to
     # main), workflow_call (publish flow), and schedule. The PR
     # variant above handles `pull_request`.
-    if: github.event_name != 'pull_request'
+    #
+    # TEMPORARILY DISABLED — same upstream unpinned-action issue as
+    # `OsvScannerPR` above. Re-enable by restoring the original
+    # `if: github.event_name != 'pull_request'`.
+    if: false
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary

\`OsvScanner\` calls \`google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml\`, whose inner job references \`actions/download-artifact@v8\` — an unpinned tag. The repo's action-pinning policy rejects unpinned actions at "Set up job", so:

- every push-to-main run of the Rust workflow fails on this job, and
- the \`workflow_call\` from \`publish.yaml\` inherits that failure, blocking the \`roas/v0.14.0\` release.

Flips the \`if:\` to a literal \`false\` so the job is skipped without losing the rest of the configuration. Re-enable once [google/osv-scanner-action#127](https://github.com/google/osv-scanner-action/pull/127) (which pins \`download-artifact\` to a SHA) lands — restore the original \`github.event_name != 'pull_request'\`.

\`OsvScannerPR\` (which calls the PR-diff reusable workflow) stays as-is — it still runs on pull requests where the comparative scan adds the most value.

Skipped jobs satisfy \`AllChecks\` (\`skipped\` is neither \`failure\` nor \`cancelled\`) and don't contribute a failed conclusion to \`workflow_call\`, so the publish pipeline is unblocked.

Stacks on top of #162 — both changes are needed:
- #162 narrows \`checks.yaml\`'s workflow-level \`permissions: read-all\` so workflow validation passes,
- this PR disables the upstream-broken \`OsvScanner\` job so the call doesn't fail at runtime.

## Test plan

- [ ] After merge (with #162 also merged), re-tag \`roas/v0.14.0\` and verify the Publish workflow completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)