### PR TITLE
ci: grant id-token: write to the Publish job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,13 @@ jobs:
         package: ${{ fromJSON(needs.Checks.outputs.publish) }}
       fail-fast: false
     runs-on: ubuntu-latest
+    permissions:
+      # `rust-lang/crates-io-auth-action` exchanges the workflow's OIDC
+      # token for a short-lived crates.io publish token; that exchange
+      # requires `id-token: write`. The default `read-all` doesn't
+      # cover it, so grant it explicitly on the publishing job only.
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1


### PR DESCRIPTION
## Summary

After unblocking workflow validation (#162) and skipping the broken \`OsvScanner\` job (#163), the next failure was from \`rust-lang/crates-io-auth-action@v1.0.4\` in the \`Publish\` job:

> Error: Please ensure the 'id-token' permission is set to 'write' in your workflow.

The action exchanges the workflow's OIDC token for a short-lived crates.io publish token, which requires \`id-token: write\`. The workflow-level \`permissions: read-all\` default doesn't cover it.

Grants \`id-token: write\` (plus \`contents: read\` for checkout) on the \`Publish\` job only — every other job keeps the narrow \`read-all\` default.

## Test plan

- [ ] After merge (chained with #162 and #163), re-tag \`roas/v0.14.0\` and verify the Publish workflow runs to completion and publishes the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)