### PR TITLE
feat(roas-cli): stdin input + format-preserving pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas-cli/README.md
+++ b/crates/roas-cli/README.md
@@ -15,12 +15,24 @@ The installed binary is named `roas`.
 ## Usage
 
 ```shell
-roas validate <FILE>            # parse + validate
-roas convert --to v3_2 <FILE>   # upconvert across versions
-roas preview <FILE>             # open the spec in a browser via Redoc
+roas validate [FILE]            # parse + validate
+roas convert --to v3_2 [FILE]   # upconvert across versions
+roas preview [FILE]             # open the spec in a browser via Redoc
 ```
 
-Input can be JSON or YAML; the parser is selected by file extension (`.yaml` / `.yml` → YAML, everything else → JSON).
+Input can be JSON or YAML. With a file path, the parser is selected by extension (`.yaml` / `.yml` → YAML, everything else → JSON). Pass `-` as the file path, or omit it entirely and pipe the spec, to read from stdin; stdin defaults to JSON. `--format json|yaml` overrides everything.
+
+### Piping specs
+
+Every subcommand accepts the spec on stdin, so they chain naturally. `validate` is silent on stdout by default — pass `--print` to echo the parsed spec downstream:
+
+```shell
+cat spec.json | roas validate                           # auto: piped stdin
+cat spec.yaml | roas validate --format yaml             # stdin defaults to JSON; override
+roas convert --to v3_2 spec.json | roas validate --print | roas preview
+```
+
+`preview --watch` requires a real file and is rejected for stdin input.
 
 ### `validate`
 
@@ -47,16 +59,20 @@ empty-external-documentation-url
 
 Run `roas validate --help` for descriptions of each check.
 
+Pass `--print` to echo the parsed spec on stdout (diagnostics stay on stderr), so `validate` can sit in the middle of a pipeline. The output format matches the input: YAML in → YAML out, JSON in → JSON out.
+
 ### `convert`
 
 Upconverts a spec to a target version by chaining the existing `From<v_X::Spec> for v_Y::Spec` migrations. Downconversion is not supported.
 
 ```shell
-roas convert --to v3_2 spec.json
+roas convert --to v3_2 spec.json                          # JSON in → JSON out
+roas convert --to v3_2 spec.yaml                          # YAML in → YAML out
+roas convert --to v3_2 --output-format yaml spec.json     # switch format
 roas convert --to v3_1 --from v2 spec.yaml
 ```
 
-Output is JSON on stdout.
+Output goes to stdout. The format matches the input by default (YAML in → YAML out, JSON in → JSON out); pass `--output-format json|yaml` to override.
 
 ### `preview`
 
@@ -69,7 +85,7 @@ roas preview --watch spec.yaml                       # live-reload on file chang
 roas preview --no-open --from v3_1 spec.json
 ```
 
-`--watch` watches the spec file and pushes a Server-Sent-Events reload to the browser on every change; the page reloads itself and re-fetches `/spec`. If a write produces a parse error the previous good JSON is kept and the error is logged to stderr. Both renderers target OpenAPI 3.0 / 3.1 today — v3.2-specific fields are skipped silently. To preview an older spec under a v3.0+ renderer, upconvert it once with `roas convert --to v3_1 spec.json` and serve the result.
+`--watch` watches the spec file and pushes a Server-Sent-Events reload to the browser on every change; the page reloads itself and re-fetches `/spec`. If a write produces a parse error the previous good JSON is kept and the error is logged to stderr. `--watch` requires a real file — stdin input is rejected. Both renderers target OpenAPI 3.0 / 3.1 today — v3.2-specific fields are skipped silently. To preview an older spec under a v3.0+ renderer, upconvert it once with `roas convert --to v3_1 spec.json` and serve the result.
 
 ## License
 

--- a/crates/roas-cli/src/main.rs
+++ b/crates/roas-cli/src/main.rs
@@ -2,29 +2,36 @@
 //!
 //! Three subcommands today:
 //!
-//! - `roas validate <FILE>` — parse and validate an OpenAPI spec. Version is
+//! - `roas validate [FILE]` — parse and validate an OpenAPI spec. Version is
 //!   auto-detected from the document; pass `--from` to force. External
 //!   `$ref`s are skipped by default; use `--load file` / `--load http`
-//!   (or both) to enable the loader.
+//!   (or both) to enable the loader. Pass `--print` to echo the parsed
+//!   spec to stdout on success — in the same format as the input (YAML
+//!   in → YAML out, JSON in → JSON out) — useful for pipelines.
 //!
-//! - `roas convert --to <VERSION> <FILE>` — chain the existing
+//! - `roas convert --to <VERSION> [FILE]` — chain the existing
 //!   `From<v_X::Spec> for v_Y::Spec` migrations to upconvert a spec.
 //!   Pass `--from` to force the input version. Pass `--collapse` to
 //!   run `Spec::collapse` on the (post-conversion) result, lifting
 //!   every inline component into the matching `components.<bag>` /
 //!   `definitions` / `parameters` / `responses` slot with strict
 //!   dedup. External `$ref`s are skipped by default; use
-//!   `--load file` / `--load http` to opt into the loader.
+//!   `--load file` / `--load http` to opt into the loader. Output
+//!   defaults to the input format (YAML in → YAML out, JSON in → JSON
+//!   out); pass `--output-format json|yaml` to override.
 //!
-//! - `roas preview <FILE>` — start a local HTTP server on
+//! - `roas preview [FILE]` — start a local HTTP server on
 //!   `127.0.0.1:<random>` that serves the spec rendered with
 //!   [Redoc](https://redocly.com/redoc) (default) or
 //!   [Swagger UI](https://swagger.io/tools/swagger-ui/) (`--renderer
 //!   swagger-ui`), and open the default browser at it. `--no-open` skips
-//!   the launch. Ctrl+C tears the server down.
+//!   the launch. Ctrl+C tears the server down. `--watch` requires a real
+//!   file (stdin can't be watched).
 //!
-//! Input may be JSON or YAML; the parser is selected by file extension
-//! (`.yaml` / `.yml` → YAML, otherwise JSON).
+//! Input may be JSON or YAML. With a file path, the parser is selected by
+//! extension (`.yaml` / `.yml` → YAML, otherwise JSON). Pass `-` as the
+//! file path, or omit it entirely and pipe the spec, to read from stdin;
+//! stdin defaults to JSON. `--format json|yaml` overrides everything.
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -33,7 +40,8 @@ use roas::validation::Options;
 use roas_file_fetcher::FileFetcher;
 use roas_http_fetcher::HttpFetcher;
 use std::fs;
-use std::path::PathBuf;
+use std::io::{IsTerminal, Read};
+use std::path::{Path, PathBuf};
 
 // `roas::validation::Options` implements `clap::ValueEnum` under the `clap`
 // feature (enabled on the `roas` dep in this crate's Cargo.toml), so we can
@@ -66,12 +74,18 @@ enum Command {
 
 #[derive(clap::Args)]
 struct ValidateArgs {
-    /// Path to the spec file (JSON or YAML).
-    file: PathBuf,
+    /// Path to the spec file (JSON or YAML). Pass `-`, or omit and pipe
+    /// the spec, to read from stdin.
+    file: Option<PathBuf>,
 
     /// Force the input version (auto-detected by default).
     #[arg(long, value_enum)]
     from: Option<SpecVersion>,
+
+    /// Override format detection. By default, file paths use the extension
+    /// (`.yaml`/`.yml` → YAML, otherwise JSON) and stdin defaults to JSON.
+    #[arg(long, value_enum)]
+    format: Option<InputFormat>,
 
     /// Enable external-reference loading. Pass `--load file` to allow
     /// `file://` refs, `--load http` to allow `http://` and `https://`.
@@ -84,12 +98,20 @@ struct ValidateArgs {
     /// `roas validate --help` to see the full list.
     #[arg(long, value_enum)]
     ignore: Vec<Options>,
+
+    /// On success, echo the parsed spec to stdout in the same format as
+    /// the input (YAML in → YAML out, JSON in → JSON out). Diagnostics
+    /// stay on stderr. Lets `validate` sit in the middle of a pipeline:
+    /// `roas convert ... | roas validate --print | roas preview`.
+    #[arg(long)]
+    print: bool,
 }
 
 #[derive(clap::Args)]
 struct ConvertArgs {
-    /// Path to the spec file (JSON or YAML).
-    file: PathBuf,
+    /// Path to the spec file (JSON or YAML). Pass `-`, or omit and pipe
+    /// the spec, to read from stdin.
+    file: Option<PathBuf>,
 
     /// Target spec version.
     #[arg(long, value_enum)]
@@ -98,6 +120,16 @@ struct ConvertArgs {
     /// Force the input version (auto-detected by default).
     #[arg(long, value_enum)]
     from: Option<SpecVersion>,
+
+    /// Override format detection. By default, file paths use the extension
+    /// (`.yaml`/`.yml` → YAML, otherwise JSON) and stdin defaults to JSON.
+    #[arg(long, value_enum)]
+    format: Option<InputFormat>,
+
+    /// Output format. Defaults to the input format (YAML in → YAML out,
+    /// JSON in → JSON out). Pass `--output-format json|yaml` to switch.
+    #[arg(long, value_enum)]
+    output_format: Option<InputFormat>,
 
     /// Lift every inline component into the matching root bag
     /// (`components.<bag>` for v3.x, `definitions` / `parameters` /
@@ -123,6 +155,12 @@ enum LoaderKind {
     Http,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum InputFormat {
+    Json,
+    Yaml,
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
@@ -132,9 +170,76 @@ fn main() -> Result<()> {
     }
 }
 
-pub(crate) fn read_and_parse(path: &std::path::Path) -> Result<serde_json::Value> {
-    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    parse_value(&raw, path_looks_like_yaml(path))
+/// What was passed on the command line. `None` + piped stdin == read stdin;
+/// `Some(p)` where `p == Path::new("-")` is the explicit stdin sentinel;
+/// `None` + TTY stdin is a usage error.
+///
+/// `display()` returns a label for diagnostics: the file path for files,
+/// `<stdin>` for stdin.
+#[derive(Clone, Debug)]
+pub(crate) enum InputSource {
+    File(PathBuf),
+    Stdin,
+}
+
+impl InputSource {
+    pub(crate) fn display(&self) -> String {
+        match self {
+            InputSource::File(p) => p.display().to_string(),
+            InputSource::Stdin => "<stdin>".to_string(),
+        }
+    }
+}
+
+/// Resolve the positional `file` argument into a concrete source. Honors
+/// the `-` sentinel and the "no arg + piped stdin" shortcut. Returns
+/// `Err` only when neither was provided and stdin is a TTY.
+pub(crate) fn resolve_input_source(file: Option<&Path>) -> Result<InputSource> {
+    match file {
+        Some(p) if p == Path::new("-") => Ok(InputSource::Stdin),
+        Some(p) => Ok(InputSource::File(p.to_path_buf())),
+        None => {
+            if std::io::stdin().is_terminal() {
+                bail!("no input: pass a file path, or pipe a spec to stdin");
+            }
+            Ok(InputSource::Stdin)
+        }
+    }
+}
+
+/// Read + parse a spec from the resolved source. Format selection: explicit
+/// `--format` wins; otherwise file paths use the extension, stdin defaults
+/// to JSON. Returns the parsed value plus the *resolved* format so callers
+/// that round-trip the spec back to bytes (e.g. `validate --print`) can
+/// match the output format to the input.
+pub(crate) fn read_input(
+    source: &InputSource,
+    format: Option<InputFormat>,
+) -> Result<(serde_json::Value, InputFormat)> {
+    let resolved = match source {
+        InputSource::File(p) => format.unwrap_or_else(|| {
+            if path_looks_like_yaml(p) {
+                InputFormat::Yaml
+            } else {
+                InputFormat::Json
+            }
+        }),
+        InputSource::Stdin => format.unwrap_or(InputFormat::Json),
+    };
+    let raw = match source {
+        InputSource::File(p) => {
+            fs::read_to_string(p).with_context(|| format!("reading {}", p.display()))?
+        }
+        InputSource::Stdin => {
+            let mut raw = String::new();
+            std::io::stdin()
+                .read_to_string(&mut raw)
+                .context("reading from stdin")?;
+            raw
+        }
+    };
+    let value = parse_value(&raw, resolved == InputFormat::Yaml)?;
+    Ok((value, resolved))
 }
 
 fn build_loader(kinds: &[LoaderKind]) -> Option<Loader> {
@@ -159,8 +264,34 @@ fn build_loader(kinds: &[LoaderKind]) -> Option<Loader> {
     Some(loader)
 }
 
+/// Serialize a parsed spec back to bytes. `pretty_json` selects multi-line
+/// vs. compact JSON; YAML is always multi-line. A trailing newline is
+/// appended so the output is line-oriented like YAML's.
+///
+/// Used by both `validate --print` (compact, pipeline-friendly) and
+/// `convert` (pretty, file-friendly).
+fn serialize_spec(
+    value: &serde_json::Value,
+    format: InputFormat,
+    pretty_json: bool,
+) -> Result<String> {
+    match format {
+        InputFormat::Yaml => serde_yaml_ng::to_string(value).context("serializing spec as YAML"),
+        InputFormat::Json => {
+            let mut s = if pretty_json {
+                serde_json::to_string_pretty(value).context("serializing spec as JSON")?
+            } else {
+                serde_json::to_string(value).context("serializing spec as JSON")?
+            };
+            s.push('\n');
+            Ok(s)
+        }
+    }
+}
+
 fn run_validate(args: ValidateArgs) -> Result<()> {
-    let value = read_and_parse(&args.file)?;
+    let source = resolve_input_source(args.file.as_deref())?;
+    let (value, input_format) = read_input(&source, args.format)?;
     let detected = versioned::detect_or_use(args.from, value)?;
 
     let mut loader = build_loader(&args.load);
@@ -172,7 +303,15 @@ fn run_validate(args: ValidateArgs) -> Result<()> {
     match detected.validate(options, loader.as_mut()) {
         Ok(()) => {
             // Diagnostics go to stderr so stdout stays clean for shell pipelines.
-            eprintln!("{}: valid {}", args.file.display(), detected.label());
+            eprintln!("{}: valid {}", source.display(), detected.label());
+            if args.print {
+                // Echo the parsed spec so the command can sit in the middle
+                // of a pipeline. Format matches the input: YAML in → YAML out,
+                // JSON in → JSON out. `into_value` re-serialises through the
+                // typed Spec, so the output is normalised.
+                let value = detected.into_value()?;
+                print!("{}", serialize_spec(&value, input_format, false)?);
+            }
             Ok(())
         }
         Err(err) => {
@@ -181,7 +320,7 @@ fn run_validate(args: ValidateArgs) -> Result<()> {
             }
             Err(anyhow!(
                 "{}: validation failed ({} error{})",
-                args.file.display(),
+                source.display(),
                 err.errors.len(),
                 if err.errors.len() == 1 { "" } else { "s" }
             ))
@@ -190,7 +329,8 @@ fn run_validate(args: ValidateArgs) -> Result<()> {
 }
 
 fn run_convert(args: ConvertArgs) -> Result<()> {
-    let value = read_and_parse(&args.file)?;
+    let source = resolve_input_source(args.file.as_deref())?;
+    let (value, input_format) = read_input(&source, args.format)?;
     let detected = versioned::detect_or_use(args.from, value)?;
 
     let target = args.to;
@@ -208,8 +348,9 @@ fn run_convert(args: ConvertArgs) -> Result<()> {
         converted.collapse(loader.as_mut())?;
     }
     let value = converted.into_value()?;
-    let json = serde_json::to_string_pretty(&value).context("serializing converted spec")?;
-    println!("{json}");
+    // Output format defaults to the input format; `--output-format` overrides.
+    let out_format = args.output_format.unwrap_or(input_format);
+    print!("{}", serialize_spec(&value, out_format, true)?);
     Ok(())
 }
 
@@ -254,11 +395,45 @@ mod tests {
         let cli = Cli::try_parse_from(["roas", "validate", "spec.json"]).expect("validate parse");
         match cli.command {
             Command::Validate(args) => {
-                assert_eq!(args.file.to_string_lossy(), "spec.json");
+                assert_eq!(args.file.as_ref().unwrap().to_string_lossy(), "spec.json");
                 assert!(args.from.is_none());
                 assert!(args.load.is_empty());
                 assert!(args.ignore.is_empty());
+                assert!(!args.print);
+                assert!(args.format.is_none());
             }
+            _ => panic!("expected Validate"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_validate_without_file_arg() {
+        let cli = Cli::try_parse_from(["roas", "validate"]).expect("validate parse");
+        match cli.command {
+            Command::Validate(args) => assert!(args.file.is_none()),
+            _ => panic!("expected Validate"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_validate_with_stdin_sentinel_and_format_flag() {
+        let cli = Cli::try_parse_from(["roas", "validate", "--format", "yaml", "-"])
+            .expect("validate parse");
+        match cli.command {
+            Command::Validate(args) => {
+                assert_eq!(args.file.as_deref(), Some(Path::new("-")));
+                assert_eq!(args.format, Some(InputFormat::Yaml));
+            }
+            _ => panic!("expected Validate"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_validate_print_flag() {
+        let cli = Cli::try_parse_from(["roas", "validate", "--print", "spec.json"])
+            .expect("validate parse");
+        match cli.command {
+            Command::Validate(args) => assert!(args.print),
             _ => panic!("expected Validate"),
         }
     }
@@ -349,6 +524,24 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_convert_with_output_format_flag() {
+        let cli = Cli::try_parse_from([
+            "roas",
+            "convert",
+            "--to",
+            "v3_2",
+            "--output-format",
+            "yaml",
+            "spec.json",
+        ])
+        .expect("convert parse");
+        match cli.command {
+            Command::Convert(args) => assert_eq!(args.output_format, Some(InputFormat::Yaml)),
+            _ => panic!("expected Convert"),
+        }
+    }
+
+    #[test]
     fn cli_parses_convert_with_collapse_and_load_flags() {
         let cli = Cli::try_parse_from([
             "roas",
@@ -428,23 +621,47 @@ mod tests {
     }
 
     #[test]
-    fn read_and_parse_json_file_returns_parsed_value() {
+    fn read_input_json_file_returns_parsed_value_and_json_format() {
         let f = TempFile::write("ok.json", br#"{"hello":"world"}"#);
-        let v = read_and_parse(&f.0).expect("parse ok");
+        let (v, fmt) = read_input(&InputSource::File(f.0.clone()), None).expect("parse ok");
         assert_eq!(v, serde_json::json!({"hello": "world"}));
+        assert_eq!(fmt, InputFormat::Json);
     }
 
     #[test]
-    fn read_and_parse_yaml_file_routes_through_yaml_parser() {
+    fn read_input_yaml_file_routes_through_yaml_parser_via_extension() {
         let f = TempFile::write("ok.yaml", b"name: pet\ncount: 3\n");
-        let v = read_and_parse(&f.0).expect("parse ok");
+        let (v, fmt) = read_input(&InputSource::File(f.0.clone()), None).expect("parse ok");
         assert_eq!(v, serde_json::json!({"name": "pet", "count": 3}));
+        assert_eq!(fmt, InputFormat::Yaml);
     }
 
     #[test]
-    fn read_and_parse_missing_file_errors_with_reading_context() {
+    fn read_input_format_override_forces_yaml_on_no_extension_file() {
+        // No `.yaml` extension: extension sniffing would pick JSON, but
+        // `--format yaml` must win — and the resolved format must reflect it.
+        let f = TempFile::write("ok-noext", b"name: pet\ncount: 3\n");
+        let (v, fmt) =
+            read_input(&InputSource::File(f.0.clone()), Some(InputFormat::Yaml)).expect("parse ok");
+        assert_eq!(v, serde_json::json!({"name": "pet", "count": 3}));
+        assert_eq!(fmt, InputFormat::Yaml);
+    }
+
+    #[test]
+    fn read_input_format_override_forces_json_on_yaml_extension() {
+        // File has `.yaml` extension but contents are JSON: `--format json`
+        // must override the extension heuristic.
+        let f = TempFile::write("misnamed.yaml", br#"{"hello":"world"}"#);
+        let (v, fmt) =
+            read_input(&InputSource::File(f.0.clone()), Some(InputFormat::Json)).expect("parse ok");
+        assert_eq!(v, serde_json::json!({"hello": "world"}));
+        assert_eq!(fmt, InputFormat::Json);
+    }
+
+    #[test]
+    fn read_input_missing_file_errors_with_reading_context() {
         let p = temp_path("missing.json");
-        let err = read_and_parse(&p).expect_err("missing file must error");
+        let err = read_input(&InputSource::File(p), None).expect_err("missing file must error");
         assert!(
             err.to_string().contains("reading"),
             "expected `reading` context, got: {err}",
@@ -452,9 +669,10 @@ mod tests {
     }
 
     #[test]
-    fn read_and_parse_invalid_json_surfaces_parser_error() {
+    fn read_input_invalid_json_surfaces_parser_error() {
         let f = TempFile::write("bad.json", b"@@@ not json");
-        let err = read_and_parse(&f.0).expect_err("invalid JSON must error");
+        let err =
+            read_input(&InputSource::File(f.0.clone()), None).expect_err("invalid JSON must error");
         assert!(
             err.to_string().contains("parsing JSON"),
             "expected `parsing JSON` context, got: {err}",
@@ -462,13 +680,71 @@ mod tests {
     }
 
     #[test]
-    fn read_and_parse_invalid_yaml_surfaces_parser_error() {
+    fn read_input_invalid_yaml_surfaces_parser_error() {
         let f = TempFile::write("bad.yaml", b"key:\n\tvalue: oops\n");
-        let err = read_and_parse(&f.0).expect_err("invalid YAML must error");
+        let err =
+            read_input(&InputSource::File(f.0.clone()), None).expect_err("invalid YAML must error");
         assert!(
             err.to_string().contains("parsing YAML"),
             "expected `parsing YAML` context, got: {err}",
         );
+    }
+
+    #[test]
+    fn serialize_spec_compact_json_emits_single_line_with_trailing_newline() {
+        let v = serde_json::json!({"openapi":"3.2.0","info":{"title":"x","version":"1"}});
+        let out = serialize_spec(&v, InputFormat::Json, false).expect("ok");
+        assert!(out.ends_with('\n'), "JSON must end with a newline");
+        // Compact JSON has no internal newlines.
+        assert_eq!(out.matches('\n').count(), 1, "compact JSON: got: {out}");
+        let back: serde_json::Value = serde_json::from_str(out.trim_end()).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn serialize_spec_pretty_json_emits_multi_line_with_trailing_newline() {
+        let v = serde_json::json!({"openapi":"3.2.0","info":{"title":"x","version":"1"}});
+        let out = serialize_spec(&v, InputFormat::Json, true).expect("ok");
+        assert!(out.ends_with('\n'), "JSON must end with a newline");
+        // Pretty JSON spans multiple lines for an object of this size.
+        assert!(out.matches('\n').count() > 1, "pretty JSON: got: {out}");
+        let back: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn serialize_spec_yaml_emits_yaml_for_yaml_format() {
+        let v = serde_json::json!({"openapi":"3.2.0","info":{"title":"x","version":"1"}});
+        let out = serialize_spec(&v, InputFormat::Yaml, false).expect("ok");
+        // YAML structure: no curly braces at the top level, keys are bare,
+        // and serde_yaml_ng terminates documents with a newline.
+        assert!(
+            out.contains("openapi:"),
+            "YAML output must use bare keys, got: {out}",
+        );
+        assert!(
+            !out.trim().starts_with('{'),
+            "YAML output must not be JSON, got: {out}",
+        );
+        // Round-trips back to the same value.
+        let back: serde_json::Value = serde_yaml_ng::from_str(&out).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn resolve_input_source_explicit_dash_is_stdin() {
+        let src = resolve_input_source(Some(Path::new("-"))).expect("resolve ok");
+        assert!(matches!(src, InputSource::Stdin));
+        assert_eq!(src.display(), "<stdin>");
+    }
+
+    #[test]
+    fn resolve_input_source_explicit_path_is_file() {
+        let src = resolve_input_source(Some(Path::new("spec.json"))).expect("resolve ok");
+        match src {
+            InputSource::File(p) => assert_eq!(p, Path::new("spec.json")),
+            _ => panic!("expected File"),
+        }
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -487,10 +763,12 @@ mod tests {
     fn run_validate_returns_ok_for_clean_spec() {
         let f = TempFile::write("clean.json", MINIMAL_V3_2);
         let args = ValidateArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             from: None,
+            format: None,
             load: Vec::new(),
             ignore: Vec::new(),
+            print: false,
         };
         run_validate(args).expect("clean spec must validate");
     }
@@ -501,10 +779,12 @@ mod tests {
         let body = br#"{"openapi":"3.2.0","info":{"title":"x","version":"1"},"paths":{},"tags":[{"name":"unused"}]}"#;
         let f = TempFile::write("unused-tag.json", body);
         let args = ValidateArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             from: None,
+            format: None,
             load: Vec::new(),
             ignore: Vec::new(),
+            print: false,
         };
         let err = run_validate(args).expect_err("unused tag must fail");
         assert!(err.to_string().contains("validation failed"), "got: {err}",);
@@ -515,10 +795,12 @@ mod tests {
         let body = br#"{"openapi":"3.2.0","info":{"title":"x","version":"1"},"paths":{},"tags":[{"name":"unused"}]}"#;
         let f = TempFile::write("ignored.json", body);
         let args = ValidateArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             from: None,
+            format: None,
             load: Vec::new(),
             ignore: vec![Options::IgnoreUnusedTags],
+            print: false,
         };
         run_validate(args).expect("--ignore unused-tags must suppress");
     }
@@ -527,10 +809,12 @@ mod tests {
     fn run_validate_with_load_file_builds_loader() {
         let f = TempFile::write("with-load.json", MINIMAL_V3_2);
         let args = ValidateArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             from: None,
+            format: None,
             load: vec![LoaderKind::File],
             ignore: Vec::new(),
+            print: false,
         };
         run_validate(args).expect("clean spec with file loader must validate");
     }
@@ -538,10 +822,12 @@ mod tests {
     #[test]
     fn run_validate_missing_file_errors_with_reading_context() {
         let args = ValidateArgs {
-            file: temp_path("missing.json"),
+            file: Some(temp_path("missing.json")),
             from: None,
+            format: None,
             load: Vec::new(),
             ignore: Vec::new(),
+            print: false,
         };
         let err = run_validate(args).expect_err("missing file must error");
         assert!(
@@ -554,9 +840,11 @@ mod tests {
     fn run_convert_v2_to_v3_2_succeeds() {
         let f = TempFile::write("v2.json", MINIMAL_V2);
         let args = ConvertArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             to: SpecVersion::V3_2,
             from: None,
+            format: None,
+            output_format: None,
             collapse: false,
             load: vec![],
         };
@@ -600,9 +888,11 @@ mod tests {
         );
         let f = TempFile::write("convert-collapse-spec.json", body.as_bytes());
         let args = ConvertArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             to: SpecVersion::V3_2,
             from: None,
+            format: None,
+            output_format: None,
             collapse: true,
             load: vec![LoaderKind::File],
         };
@@ -639,9 +929,11 @@ mod tests {
         }"#;
         let f = TempFile::write("collapse.json", body);
         let args = ConvertArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             to: SpecVersion::V3_2,
             from: None,
+            format: None,
+            output_format: None,
             collapse: true,
             load: vec![],
         };
@@ -652,9 +944,11 @@ mod tests {
     fn run_convert_rejects_downconversion() {
         let f = TempFile::write("v3.json", MINIMAL_V3_2);
         let args = ConvertArgs {
-            file: f.0.clone(),
+            file: Some(f.0.clone()),
             to: SpecVersion::V2,
             from: None,
+            format: None,
+            output_format: None,
             collapse: false,
             load: vec![],
         };
@@ -668,9 +962,11 @@ mod tests {
     #[test]
     fn run_convert_missing_file_errors_with_reading_context() {
         let args = ConvertArgs {
-            file: temp_path("missing.json"),
+            file: Some(temp_path("missing.json")),
             to: SpecVersion::V3_2,
             from: None,
+            format: None,
+            output_format: None,
             collapse: false,
             load: vec![],
         };
@@ -690,7 +986,7 @@ mod tests {
             .expect("preview parse");
         match cli.command {
             Command::Preview(args) => {
-                assert_eq!(args.file.to_string_lossy(), "spec.json");
+                assert_eq!(args.file.as_ref().unwrap().to_string_lossy(), "spec.json");
                 assert!(args.no_open);
                 assert!(args.from.is_none());
                 assert!(!args.watch);

--- a/crates/roas-cli/src/preview.rs
+++ b/crates/roas-cli/src/preview.rs
@@ -6,7 +6,9 @@
 //!   * `/` (and `/index.html`) — a small HTML shell that mounts the renderer
 //!     and pulls its bundle from the official CDN.
 //!   * `/spec` (and `/spec.json`) — the input spec, parsed via the existing
-//!     `read_and_parse` / `detect_or_use` pipeline and re-serialised as JSON.
+//!     `read_input` / `detect_or_use` pipeline and re-serialised as JSON.
+//!     The spec may come from a file path or from stdin (pass `-`, or omit
+//!     the path and pipe the spec). `--watch` requires a real file.
 //!   * `/reload` — when `--watch` is on, a Server-Sent-Events endpoint that
 //!     pushes one `data: reload` frame per file change. The injected
 //!     page-side `EventSource` subscriber calls `window.location.reload()` on
@@ -16,7 +18,7 @@
 //! runtime is constructed inside [`run_preview`] so the rest of the CLI
 //! stays sync.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use axum::Router;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -35,8 +37,8 @@ use tokio::sync::broadcast;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
-use crate::read_and_parse;
 use crate::versioned::{self, SpecVersion};
+use crate::{InputFormat, InputSource, read_input, resolve_input_source};
 
 /// Renderer choice for the preview page. Both load their bundle from a public
 /// CDN; the spec itself is always served from the local server.
@@ -52,12 +54,18 @@ pub(crate) enum Renderer {
 
 #[derive(clap::Args)]
 pub struct PreviewArgs {
-    /// Path to the spec file (JSON or YAML).
-    pub(crate) file: PathBuf,
+    /// Path to the spec file (JSON or YAML). Pass `-`, or omit and pipe
+    /// the spec, to read from stdin. `--watch` requires a real file.
+    pub(crate) file: Option<PathBuf>,
 
     /// Force the input version (auto-detected by default).
     #[arg(long, value_enum)]
     pub(crate) from: Option<SpecVersion>,
+
+    /// Override format detection. By default, file paths use the extension
+    /// (`.yaml`/`.yml` → YAML, otherwise JSON) and stdin defaults to JSON.
+    #[arg(long, value_enum)]
+    pub(crate) format: Option<InputFormat>,
 
     /// Don't open the browser; just print the server URL and serve.
     #[arg(long)]
@@ -65,7 +73,8 @@ pub struct PreviewArgs {
 
     /// Watch the spec file and live-reload the browser on every change.
     /// Off by default; enable to spawn a filesystem watcher and an SSE
-    /// `/reload` route the rendered HTML subscribes to.
+    /// `/reload` route the rendered HTML subscribes to. Only works with
+    /// a real file; rejected for stdin input.
     #[arg(long)]
     pub(crate) watch: bool,
 
@@ -74,32 +83,87 @@ pub struct PreviewArgs {
     pub(crate) renderer: Renderer,
 }
 
-/// The minimal slice of `PreviewArgs` the spec-reading pipeline needs.
-/// Extracted so the file-watcher thread can re-run the same pipeline on
-/// every disk change without holding a reference to the full args struct.
+/// What the preview server reads from. Files can be re-read on every
+/// filesystem-watcher tick; stdin can be read exactly once.
 #[derive(Clone, Debug)]
-struct SpecSource {
-    file: PathBuf,
-    from: Option<SpecVersion>,
+enum SpecSource {
+    File {
+        file: PathBuf,
+        from: Option<SpecVersion>,
+        format: Option<InputFormat>,
+    },
+    /// Pre-read stdin body. `--watch` is rejected before we get here.
+    Stdin {
+        raw: String,
+        from: Option<SpecVersion>,
+        format: Option<InputFormat>,
+    },
 }
 
 impl SpecSource {
-    fn from_args(args: &PreviewArgs) -> Self {
-        Self {
-            file: args.file.clone(),
-            from: args.from,
+    fn from_args(args: &PreviewArgs) -> Result<Self> {
+        let source = resolve_input_source(args.file.as_deref())?;
+        match source {
+            InputSource::File(file) => Ok(SpecSource::File {
+                file,
+                from: args.from,
+                format: args.format,
+            }),
+            InputSource::Stdin => {
+                if args.watch {
+                    bail!("--watch requires a real file path; stdin cannot be watched");
+                }
+                // Read stdin once up-front. Errors here would normally
+                // surface from `read_input`, but stdin is consumed eagerly
+                // so we can keep the body around for repeated /spec serves.
+                let mut raw = String::new();
+                use std::io::Read;
+                std::io::stdin()
+                    .read_to_string(&mut raw)
+                    .context("reading from stdin")?;
+                Ok(SpecSource::Stdin {
+                    raw,
+                    from: args.from,
+                    format: args.format,
+                })
+            }
         }
     }
 
     /// Read + parse the spec, returning the JSON string the preview server
     /// hands to the renderer. Uses `convert_to(<same version>)` as a
-    /// "serialise back as a `Value`" pass.
+    /// "serialise back as a `Value`" pass. For stdin sources, "re-read"
+    /// just re-parses the buffered body.
     fn build_spec_json(&self) -> Result<String> {
-        let value = read_and_parse(&self.file)?;
-        let detected = versioned::detect_or_use(self.from, value)?;
+        let (value, from) = match self {
+            SpecSource::File { file, from, format } => {
+                let source = InputSource::File(file.clone());
+                let (value, _input_format) = read_input(&source, *format)?;
+                (value, *from)
+            }
+            SpecSource::Stdin { raw, from, format } => {
+                let is_yaml = matches!(format, Some(InputFormat::Yaml));
+                (versioned::parse_value(raw, is_yaml)?, *from)
+            }
+        };
+        let detected = versioned::detect_or_use(from, value)?;
         let version = detected.version();
         serde_json::to_string(&detected.convert_to(version)?)
             .context("serializing spec for the viewer")
+    }
+
+    fn display(&self) -> String {
+        match self {
+            SpecSource::File { file, .. } => file.display().to_string(),
+            SpecSource::Stdin { .. } => "<stdin>".to_string(),
+        }
+    }
+
+    fn watch_path(&self) -> Option<&PathBuf> {
+        match self {
+            SpecSource::File { file, .. } => Some(file),
+            SpecSource::Stdin { .. } => None,
+        }
     }
 }
 
@@ -180,6 +244,7 @@ fn render_html(renderer: Renderer, watch: bool) -> String {
 /// place, so a half-saved file doesn't black-hole the preview.
 fn spawn_file_watcher(
     source: SpecSource,
+    watch_path: PathBuf,
     spec_json: Arc<Mutex<String>>,
     reload_tx: broadcast::Sender<()>,
 ) -> Result<Debouncer<notify::RecommendedWatcher>> {
@@ -199,10 +264,10 @@ fn spawn_file_watcher(
     .context("starting filesystem watcher")?;
     debouncer
         .watcher()
-        .watch(&source.file, RecursiveMode::NonRecursive)
-        .with_context(|| format!("watching {}", source.file.display()))?;
+        .watch(&watch_path, RecursiveMode::NonRecursive)
+        .with_context(|| format!("watching {}", watch_path.display()))?;
 
-    let display_path = source.file.display().to_string();
+    let display_path = watch_path.display().to_string();
     thread::spawn(move || {
         while event_rx.recv().is_ok() {
             match source.build_spec_json() {
@@ -244,6 +309,9 @@ struct PreparedPreview {
     listener: tokio::net::TcpListener,
     url: String,
     renderer_label: &'static str,
+    /// Display label for the input source — file path or `<stdin>`. Threaded
+    /// into the "Serving …" banner so users can see where the spec came from.
+    source_label: String,
     state: AppState,
     /// Kept alive only to hold the filesystem watch open for as long as the
     /// server is running. Dropped when `PreparedPreview` is dropped.
@@ -251,7 +319,8 @@ struct PreparedPreview {
 }
 
 async fn prepare_preview(args: &PreviewArgs) -> Result<PreparedPreview> {
-    let source = SpecSource::from_args(args);
+    let source = SpecSource::from_args(args)?;
+    let source_label = source.display();
     let initial_json = source.build_spec_json()?;
     let spec_json = Arc::new(Mutex::new(initial_json));
 
@@ -270,13 +339,15 @@ async fn prepare_preview(args: &PreviewArgs) -> Result<PreparedPreview> {
 
     // Wire up the file watcher if `--watch` was passed. The debouncer is
     // returned so the caller can keep it alive — it stops watching when
-    // dropped.
-    let (reload_tx, debouncer) = if args.watch {
-        let (tx, _initial_rx) = broadcast::channel::<()>(16);
-        let debouncer = spawn_file_watcher(source, Arc::clone(&spec_json), tx.clone())?;
-        (Some(tx), Some(debouncer))
-    } else {
-        (None, None)
+    // dropped. `--watch` against stdin is rejected by `SpecSource::from_args`
+    // so `watch_path()` here is always `Some` when `args.watch` is true.
+    let (reload_tx, debouncer) = match (args.watch, source.watch_path().cloned()) {
+        (true, Some(path)) => {
+            let (tx, _initial_rx) = broadcast::channel::<()>(16);
+            let debouncer = spawn_file_watcher(source, path, Arc::clone(&spec_json), tx.clone())?;
+            (Some(tx), Some(debouncer))
+        }
+        _ => (None, None),
     };
 
     let state = AppState {
@@ -289,6 +360,7 @@ async fn prepare_preview(args: &PreviewArgs) -> Result<PreparedPreview> {
         listener,
         url,
         renderer_label,
+        source_label,
         state,
         _debouncer: debouncer,
     })
@@ -317,12 +389,10 @@ async fn run_preview_async(args: PreviewArgs) -> Result<()> {
 async fn drive_prepared_preview(args: &PreviewArgs, prepared: PreparedPreview) -> Result<()> {
     eprintln!(
         "Serving {} via {} at {}",
-        args.file.display(),
-        prepared.renderer_label,
-        prepared.url,
+        prepared.source_label, prepared.renderer_label, prepared.url,
     );
     if args.watch {
-        eprintln!("Watching {} for changes.", args.file.display());
+        eprintln!("Watching {} for changes.", prepared.source_label);
     }
     eprintln!("Press Ctrl+C to stop.");
 
@@ -539,8 +609,9 @@ mod tests {
     #[test]
     fn run_preview_missing_file_errors_with_reading_context() {
         let args = PreviewArgs {
-            file: temp_path("missing.json"),
+            file: Some(temp_path("missing.json")),
             from: None,
+            format: None,
             no_open: true,
             renderer: Renderer::Redoc,
             watch: false,
@@ -556,8 +627,9 @@ mod tests {
     async fn prepare_preview_with_redoc_returns_bound_listener_and_redoc_assets() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             renderer: Renderer::Redoc,
             watch: false,
@@ -584,8 +656,9 @@ mod tests {
     async fn prepare_preview_with_swagger_ui_switches_renderer_fields() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             renderer: Renderer::SwaggerUi,
             watch: false,
@@ -609,8 +682,9 @@ mod tests {
         .expect("write temp spec");
 
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: Some(SpecVersion::V3_1),
+            format: None,
             no_open: true,
             renderer: Renderer::Redoc,
             watch: false,
@@ -631,8 +705,9 @@ mod tests {
     async fn axum_router_serves_html_spec_and_404s_unknown_routes() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             renderer: Renderer::Redoc,
             watch: false,
@@ -672,8 +747,9 @@ mod tests {
     async fn reload_route_returns_404_when_watch_is_off() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             renderer: Renderer::Redoc,
             watch: false,
@@ -695,8 +771,9 @@ mod tests {
     async fn reload_route_emits_sse_frame_when_broadcast_fires() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             renderer: Renderer::Redoc,
             watch: true,
@@ -766,8 +843,9 @@ mod tests {
     async fn file_watcher_broadcasts_reload_and_refreshes_spec_json_on_change() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             watch: true,
             renderer: Renderer::Redoc,
@@ -813,8 +891,9 @@ mod tests {
     async fn file_watcher_keeps_previous_json_when_reparse_fails() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             watch: true,
             renderer: Renderer::Redoc,
@@ -844,8 +923,9 @@ mod tests {
     async fn prepare_preview_with_watch_wires_up_broadcast_sender_and_html_injection() {
         let path = write_minimal_v3_2_spec();
         let args = PreviewArgs {
-            file: path.clone(),
+            file: Some(path.clone()),
             from: None,
+            format: None,
             no_open: true,
             watch: true,
             renderer: Renderer::Redoc,
@@ -862,5 +942,55 @@ mod tests {
 
         drop(prepared);
         let _ = std::fs::remove_file(&path);
+    }
+
+    /// `SpecSource::Stdin` re-parses its buffered body on every
+    /// `build_spec_json` call. This exercises the same code path the
+    /// server uses to serve `/spec` when input came from a pipe.
+    #[test]
+    fn spec_source_stdin_builds_json_from_buffered_body() {
+        let source = SpecSource::Stdin {
+            raw: r#"{"openapi":"3.2.0","info":{"title":"x","version":"1"},"paths":{}}"#.to_string(),
+            from: None,
+            format: None,
+        };
+        let json = source.build_spec_json().expect("build ok");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["openapi"], "3.2.0");
+        assert_eq!(source.display(), "<stdin>");
+        assert!(source.watch_path().is_none());
+    }
+
+    /// `--watch` against the `-` stdin sentinel must bail before any
+    /// stdin read — so we can exercise the rejection in-process without
+    /// hanging on a real TTY.
+    #[test]
+    fn spec_source_from_args_rejects_watch_with_stdin_sentinel() {
+        let args = PreviewArgs {
+            file: Some(PathBuf::from("-")),
+            from: None,
+            format: None,
+            no_open: true,
+            watch: true,
+            renderer: Renderer::Redoc,
+        };
+        let err = SpecSource::from_args(&args).expect_err("--watch + stdin must error");
+        assert!(
+            err.to_string().contains("--watch requires a real file"),
+            "got: {err}",
+        );
+    }
+
+    #[test]
+    fn spec_source_stdin_with_yaml_format_parses_yaml_body() {
+        let raw = "openapi: '3.2.0'\ninfo:\n  title: x\n  version: '1'\npaths: {}\n";
+        let source = SpecSource::Stdin {
+            raw: raw.to_string(),
+            from: None,
+            format: Some(InputFormat::Yaml),
+        };
+        let json = source.build_spec_json().expect("build ok");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["openapi"], "3.2.0");
     }
 }


### PR DESCRIPTION
Threads stdin through every roas-cli subcommand so `roas convert | roas validate | roas preview` works as a real Unix pipeline.

Adds three things:

- Stdin input via the `-` sentinel or by piping with no file arg. `--format json|yaml` overrides the default (extension for files, JSON for stdin).
- `validate --print` echoes the parsed spec to stdout on success, in the same format as the input (YAML in → YAML out, JSON in → JSON out). Diagnostics stay on stderr.
- `convert --output-format json|yaml` overrides the output format; default matches the input.

`preview --watch` is rejected for stdin (buffered body can't be re-read). Bumps roas-cli to 0.4.0. 99/99 tests, clippy clean.