### PR TITLE
chore(roas-cli): bump to 0.5.0, require roas >=0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ name = "roas"
 path = "src/main.rs"
 
 [dependencies]
-roas = { version = ">=0.14", path = "../roas", features = ["clap", "v2", "v3_0", "v3_1", "v3_2"] }
+roas = { version = ">=0.15", path = "../roas", features = ["clap", "v2", "v3_0", "v3_1", "v3_2"] }
 roas-file-fetcher = { version = ">=0.1", path = "../roas-file-fetcher", features = ["yaml"] }
 roas-http-fetcher = { version = ">=0.1", path = "../roas-http-fetcher", features = ["yaml"] }
 anyhow.workspace = true


### PR DESCRIPTION
Bumps roas-cli to 0.5.0 and tightens the roas dep floor to >=0.15 so the CLI is built against the current roas API surface.