### PR TITLE
docs: promote roas-cli as a first-class install path

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -154,8 +154,15 @@ jobs:
           tags: |
             ghcr.io/sv-tools/roas:${{ needs.Resolve.outputs.version }}
             ghcr.io/sv-tools/roas:latest
+          # Point `source` at the roas-cli subdirectory rather than the
+          # workspace root: GHCR uses this label to pick the README it
+          # renders on the package page, and the CLI README is the right
+          # surface for someone who landed here from
+          # `ghcr.io/sv-tools/roas`. Documentation label points at the
+          # same place explicitly for clients that prefer it.
           labels: |
-            org.opencontainers.image.source=https://github.com/sv-tools/roas
+            org.opencontainers.image.source=https://github.com/sv-tools/roas/tree/main/crates/roas-cli
+            org.opencontainers.image.documentation=https://github.com/sv-tools/roas/blob/main/crates/roas-cli/README.md
             org.opencontainers.image.description=Command-line front-end for the roas OpenAPI library
             org.opencontainers.image.licenses=MIT OR Apache-2.0
             org.opencontainers.image.version=${{ needs.Resolve.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,26 @@
-# roas workspace
+# roas
 
-`roas` is a Rust **SDK** for the OpenAPI Specification — a typed Rust library that
-lets you parse, validate, convert, and round-trip OpenAPI / Swagger documents
-directly from Rust code. The SDK supports every released OpenAPI version: v2.0
-(Swagger), v3.0.x, v3.1.x, and v3.2.x.
+`roas` is a Rust **SDK and command-line tool** for the OpenAPI Specification:
+parse, validate, convert, and round-trip OpenAPI / Swagger documents from
+Rust code *or* from the shell. Every released OpenAPI version is supported:
+v2.0 (Swagger), v3.0.x, v3.1.x, and v3.2.x.
 
-## What this SDK provides
+## Use it as a CLI
+
+[`roas-cli`](crates/roas-cli) ships a `roas` binary with `validate`,
+`convert`, and `preview` subcommands. Install via Cargo, Homebrew, or
+Docker — pick whichever fits the host:
+
+```shell
+cargo install roas-cli                                                # any platform with a Rust toolchain
+brew install sv-tools/apps/roas                                       # macOS arm64, Linux
+docker run --rm -v "$PWD:/specs" -w /specs ghcr.io/sv-tools/roas:latest validate openapi.yaml
+```
+
+See the [`roas-cli` README](crates/roas-cli/README.md) for the full
+subcommand reference, piping examples, and the live-reload preview server.
+
+## Use it as a Rust SDK
 
 - **Parsers and serialisers** — deserialise OpenAPI documents from JSON or YAML
   into strongly-typed Rust structs (one type tree per spec version) and
@@ -27,16 +42,6 @@ directly from Rust code. The SDK supports every released OpenAPI version: v2.0
   for resolving external `$ref`s, with first-party fetcher crates for
   [filesystem](crates/roas-file-fetcher) and [HTTP](crates/roas-http-fetcher)
   sources (JSON or YAML bodies, optional async).
-- **Command-line interface** — [`roas-cli`](crates/roas-cli) ships a `roas`
-  binary with `validate` and `convert` subcommands for one-shot use without
-  writing Rust.
-- **Documentation viewer** — [`roas-cli`](crates/roas-cli)'s `preview`
-  subcommand starts a local HTTP server and renders the spec in a browser
-  via [Redoc](https://redocly.com/redoc) or
-  [Swagger UI](https://swagger.io/tools/swagger-ui/), so you can browse the
-  API as documentation without leaving your terminal. Pick the renderer with
-  `--renderer redoc|swagger-ui`, and pass `--watch` to live-reload the page
-  whenever the spec file changes on disk.
 
 ## Crates
 

--- a/crates/roas-cli/README.md
+++ b/crates/roas-cli/README.md
@@ -6,11 +6,31 @@ Command-line front-end for [`roas`](https://crates.io/crates/roas): validate and
 
 ## Install
 
+The installed binary is named `roas` (the crate is `roas-cli`).
+
+### Cargo
+
 ```shell
 cargo install roas-cli
 ```
 
-The installed binary is named `roas`.
+### Homebrew
+
+```shell
+brew install sv-tools/apps/roas
+```
+
+The tap is [`sv-tools/homebrew-apps`](https://github.com/sv-tools/homebrew-apps); the formula tracks the latest published release. macOS arm64 and Linux (arm64 / x86_64) only — Intel macOS users should `cargo install` or use Docker.
+
+### Docker
+
+Multi-arch image (`linux/amd64`, `linux/arm64`):
+
+```shell
+docker run --rm -v "$PWD:/specs" -w /specs ghcr.io/sv-tools/roas:latest validate openapi.yaml
+```
+
+Pinned versions: `ghcr.io/sv-tools/roas:<version>` — see the [GitHub Releases](https://github.com/sv-tools/roas/releases). The image's entrypoint is the `roas` binary, so any subcommand and flags follow `docker run ... ghcr.io/sv-tools/roas:<tag>`.
 
 ## Usage
 


### PR DESCRIPTION
Three coordinated edits to make `roas-cli` more visible to non-Rust users.

- `crates/roas-cli/README.md`: Install section now lists Cargo, Homebrew (`brew install sv-tools/apps/roas`), and Docker (`docker run … ghcr.io/sv-tools/roas:latest`).
- `README.md`: leads with a "Use it as a CLI" section showing the three install one-liners, with the SDK feature list below it (and the CLI-only bullets dropped from that list to avoid duplication).
- `.github/workflows/publish.yaml`: `org.opencontainers.image.source` now points at `tree/main/crates/roas-cli` instead of the repo root, and adds an `org.opencontainers.image.documentation` label pointing at the CLI README. This should make GHCR render the CLI README on the `ghcr.io/sv-tools/roas` package page rather than the workspace one.

Caveat on the GHCR labels: I'm not 100% sure GHCR honors a subdirectory `source` URL for the README it displays — it may still fall back to the repo-root README. If so, the workspace README has also been rewritten to be CLI-prominent, so the package page lands well either way.