### PR TITLE
feat(roas-cli): shell completions and manpages

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -32,6 +32,13 @@ component_management:
       name: roas-cli
       paths:
         - crates/roas-cli/**
+      # Tighter gate than the workspace default (`target: auto`). The
+      # CLI is small and exercised by in-file unit tests, so 95% is a
+      # comfortable floor — drops below it indicate a real regression
+      # rather than rounding noise.
+      statuses:
+        - type: project
+          target: 95%
     - component_id: roas-file-fetcher
       name: roas-file-fetcher
       paths:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -247,6 +247,12 @@ jobs:
 
             def install
               bin.install "roas"
+              # Generate shell completions + manpages from the binary we
+              # just installed — no extra tarball download required.
+              generate_completions_from_executable(bin/"roas", "completions")
+              man_dir = buildpath/"man"
+              system bin/"roas", "manpages", "--out", man_dir
+              man1.install Dir[man_dir/"*.1"]
             end
 
             test do

--- a/.github/workflows/release-stage.yaml
+++ b/.github/workflows/release-stage.yaml
@@ -169,11 +169,76 @@ jobs:
       - name: Smoke-test image (binary actually starts under distroless)
         run: docker run --rm roas:smoke --version
 
+  # ────────────────────────────────────────────────────────────────────────
+  # Shell completions + manpages. Both are derived from clap's command
+  # tree, so the artifacts are platform-independent — one ubuntu-latest
+  # build is enough. The `completions` and `manpages` subcommands on the
+  # built binary do the actual rendering; the workflow packs the outputs
+  # into two tarballs (`roas-${V}-completions.tar.gz`,
+  # `roas-${V}-manpages.tar.gz`) and uploads them alongside the per-target
+  # binary archives so `AttachRoasCliBinaries` can attach everything in
+  # one shot.
+  # ────────────────────────────────────────────────────────────────────────
+  RoasCliExtras:
+    needs: Checks
+    if: ${{ contains(fromJSON(needs.Checks.outputs.publish), 'roas-cli') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+      - name: Extract roas-cli version from tag
+        id: v
+        run: echo "version=${GITHUB_REF#refs/tags/roas-cli/v}" >> "$GITHUB_OUTPUT"
+      - name: Build roas-cli
+        run: cargo build --release --package roas-cli --locked
+      - name: Generate completions and manpages
+        env:
+          ROAS: target/release/roas
+        run: |
+          set -euo pipefail
+          mkdir -p completions manpages
+          # File-name conventions per shell: bash uses the bare bin name,
+          # zsh expects `_<name>`, fish wants `<name>.fish`, powershell
+          # uses `_<name>.ps1`, elvish wants `<name>.elv`. Match what
+          # each shell autodiscovers so users can drop the file straight
+          # into their completion directory.
+          "$ROAS" completions bash       > completions/roas.bash
+          "$ROAS" completions zsh        > completions/_roas
+          "$ROAS" completions fish       > completions/roas.fish
+          "$ROAS" completions powershell > completions/_roas.ps1
+          "$ROAS" completions elvish     > completions/roas.elv
+          "$ROAS" manpages --out manpages
+      - name: Pack tarballs
+        env:
+          V: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+          completions_archive="roas-${V}-completions.tar.gz"
+          manpages_archive="roas-${V}-manpages.tar.gz"
+          # `tar -C <dir> .` puts the files at the archive root rather
+          # than under a `completions/` or `manpages/` prefix — matches
+          # what consumers (Homebrew, ad-hoc tar -xzf) expect.
+          tar -czf "$completions_archive" -C completions .
+          tar -czf "$manpages_archive" -C manpages .
+          shasum -a 256 "$completions_archive" > "${completions_archive}.sha256"
+          shasum -a 256 "$manpages_archive" > "${manpages_archive}.sha256"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # `roas-cli-*` prefix matches the wildcard pattern
+          # `AttachRoasCliBinaries` already uses to download artifacts.
+          name: roas-cli-extras
+          path: |
+            roas-${{ steps.v.outputs.version }}-completions.tar.gz
+            roas-${{ steps.v.outputs.version }}-completions.tar.gz.sha256
+            roas-${{ steps.v.outputs.version }}-manpages.tar.gz
+            roas-${{ steps.v.outputs.version }}-manpages.tar.gz.sha256
+
   AttachRoasCliBinaries:
     needs:
       - Checks
       - DraftRelease
       - RoasCliBuild
+      - RoasCliExtras
       - DockerImageSmokeTest
     if: ${{ contains(fromJSON(needs.Checks.outputs.publish), 'roas-cli') }}
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +213,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1204,6 +1223,8 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "enumset",
  "notify",
  "notify-debouncer-mini",
@@ -1243,6 +1264,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.33"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
 dependencies = [
  "clap",
  "roff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["openapi", "swagger"]
 anyhow = "1.0.99"
 axum = "0.8"
 clap = { version = "4.6.1", features = ["derive"] }
+clap_complete = "4.6.1"
+clap_mangen = "0.2.30"
 enumset = "1.1.10"
 lazy-regex = "3.6.0"
 monostate = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.99"
 axum = "0.8"
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.1"
-clap_mangen = "0.2.30"
+clap_mangen = "0.3.0"
 enumset = "1.1.10"
 lazy-regex = "3.6.0"
 monostate = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ subcommand reference, piping examples, and the live-reload preview server.
 
 ## OpenAPI versions
 
-| Spec      | Status |
-|-----------|--------|
-| OpenAPI [v2.0](https://spec.openapis.org/oas/v2.0.html) (Swagger) | parser, description validator, schema validator, converter to v3, documentation rendering via `roas preview` |
-| OpenAPI [v3.0.x](https://spec.openapis.org/oas/v3.0.4.html)       | parser, description validator, schema validator, converter to v3.1 / v3.2, documentation rendering via `roas preview` |
-| OpenAPI [v3.1.x](https://spec.openapis.org/oas/v3.1.2.html)       | parser, description validator, schema validator, converter to v3.2, documentation rendering via `roas preview` |
+| Spec                                                              | Status                                                                                                                   |
+|-------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| OpenAPI [v2.0](https://spec.openapis.org/oas/v2.0.html) (Swagger) | parser, description validator, schema validator, converter to v3, documentation rendering via `roas preview`             |
+| OpenAPI [v3.0.x](https://spec.openapis.org/oas/v3.0.4.html)       | parser, description validator, schema validator, converter to v3.1 / v3.2, documentation rendering via `roas preview`    |
+| OpenAPI [v3.1.x](https://spec.openapis.org/oas/v3.1.2.html)       | parser, description validator, schema validator, converter to v3.2, documentation rendering via `roas preview`           |
 | OpenAPI [v3.2.x](https://spec.openapis.org/oas/v3.2.0.html)       | parser, description validator, schema validator, documentation rendering via `roas preview` (target of all upconverters) |
 
 See each crate's `README.md` for usage examples, and `AGENTS.md` at the

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -24,8 +24,8 @@ roas-http-fetcher = { version = ">=0.1", path = "../roas-http-fetcher", features
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-clap_complete = "4.6.1"
-clap_mangen = "0.2.30"
+clap_complete.workspace = true
+clap_mangen.workspace = true
 enumset.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -24,6 +24,8 @@ roas-http-fetcher = { version = ">=0.1", path = "../roas-http-fetcher", features
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
+clap_complete = "4.6.1"
+clap_mangen = "0.2.30"
 enumset.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/roas-cli/README.md
+++ b/crates/roas-cli/README.md
@@ -107,6 +107,29 @@ roas preview --no-open --from v3_1 spec.json
 
 `--watch` watches the spec file and pushes a Server-Sent-Events reload to the browser on every change; the page reloads itself and re-fetches `/spec`. If a write produces a parse error the previous good JSON is kept and the error is logged to stderr. `--watch` requires a real file — stdin input is rejected. Both renderers target OpenAPI 3.0 / 3.1 today — v3.2-specific fields are skipped silently. To preview an older spec under a v3.0+ renderer, upconvert it once with `roas convert --to v3_1 spec.json` and serve the result.
 
+### `completions`
+
+Prints a shell completion script to stdout. Supported shells: `bash`, `zsh`, `fish`, `powershell`, `elvish`. Pipe the output into the location your shell expects:
+
+```shell
+roas completions bash       > /etc/bash_completion.d/roas
+roas completions zsh        > "${fpath[1]}/_roas"
+roas completions fish       > ~/.config/fish/completions/roas.fish
+```
+
+The Homebrew formula auto-installs completions for bash/zsh/fish; the Docker image carries the same `completions` subcommand if you need to extract scripts in containerised builds.
+
+### `manpages`
+
+Generates troff manpages — top-level `roas.1` plus one per subcommand (`roas-validate.1`, `roas-convert.1`, `roas-preview.1`, …) — into an output directory:
+
+```shell
+roas manpages --out /tmp/man
+man /tmp/man/roas-validate.1
+```
+
+For a system-wide install: `roas manpages --out "$(brew --prefix)/share/man/man1"` (Homebrew), or `roas manpages --out ~/.local/share/man/man1` for a per-user install. The Homebrew formula installs these automatically.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.

--- a/crates/roas-cli/src/main.rs
+++ b/crates/roas-cli/src/main.rs
@@ -34,13 +34,13 @@
 //! stdin defaults to JSON. `--format json|yaml` overrides everything.
 
 use anyhow::{Context, Result, anyhow, bail};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use roas::loader::Loader;
 use roas::validation::Options;
 use roas_file_fetcher::FileFetcher;
 use roas_http_fetcher::HttpFetcher;
 use std::fs;
-use std::io::{IsTerminal, Read};
+use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
 // `roas::validation::Options` implements `clap::ValueEnum` under the `clap`
@@ -70,6 +70,24 @@ enum Command {
     Convert(ConvertArgs),
     /// Preview the spec in a browser, rendered with Redoc or Swagger UI.
     Preview(PreviewArgs),
+    /// Print a shell completion script to stdout.
+    ///
+    /// Source the output to enable completions; `roas completions bash >
+    /// /etc/bash_completion.d/roas` is the standard recipe. Bash, Zsh,
+    /// Fish, PowerShell, and Elvish are supported.
+    Completions {
+        /// Target shell.
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+    /// Generate troff manpages for `roas` and each subcommand into a
+    /// directory. Top-level page is `roas.1`; subcommand pages follow the
+    /// `roas-<subcommand>.1` convention (e.g. `roas-validate.1`).
+    Manpages {
+        /// Output directory (created if missing).
+        #[arg(short, long, value_name = "DIR")]
+        out: PathBuf,
+    },
 }
 
 #[derive(clap::Args)]
@@ -167,7 +185,56 @@ fn main() -> Result<()> {
         Command::Validate(args) => run_validate(args),
         Command::Convert(args) => run_convert(args),
         Command::Preview(args) => preview::run_preview(args),
+        Command::Completions { shell } => run_completions(shell),
+        Command::Manpages { out } => run_manpages(&out),
     }
+}
+
+fn run_completions(shell: clap_complete::Shell) -> Result<()> {
+    let mut cmd = Cli::command();
+    let name = cmd.get_name().to_string();
+    clap_complete::generate(shell, &mut cmd, name, &mut io::stdout());
+    Ok(())
+}
+
+fn run_manpages(out: &Path) -> Result<()> {
+    fs::create_dir_all(out).with_context(|| format!("creating {}", out.display()))?;
+    let cmd = Cli::command();
+    write_manpage(out, &cmd, cmd.get_name())?;
+    // Recurse: every subcommand (and its subcommands, if any) gets its own
+    // `roas-<sub>[-<subsub>].1`. clap_mangen doesn't follow children
+    // automatically, so we walk the tree ourselves.
+    let mut stack: Vec<(String, clap::Command)> = cmd
+        .get_subcommands()
+        .cloned()
+        .map(|sub| (cmd.get_name().to_string(), sub))
+        .collect();
+    while let Some((parent_name, sub)) = stack.pop() {
+        let full_name = format!("{parent_name}-{}", sub.get_name());
+        // Rename the subcommand to its hyphenated full path so the NAME
+        // and SYNOPSIS lines render as `roas-validate` rather than the
+        // bare `validate` clap stores internally. clap::Command::name
+        // only takes `Into<Str>`, which lacks a `From<String>` impl —
+        // leak the heap string into a 'static reference. We're about to
+        // exit; the alloc is one per subcommand and unmeasurable.
+        let leaked: &'static str = String::leak(full_name.clone());
+        let renamed = sub.clone().name(leaked);
+        write_manpage(out, &renamed, &full_name)?;
+        for nested in sub.get_subcommands().cloned() {
+            stack.push((full_name.clone(), nested));
+        }
+    }
+    Ok(())
+}
+
+fn write_manpage(out: &Path, cmd: &clap::Command, name: &str) -> Result<()> {
+    let path = out.join(format!("{name}.1"));
+    let man = clap_mangen::Man::new(cmd.clone()).title(name.to_uppercase());
+    let mut buf = Vec::new();
+    man.render(&mut buf)
+        .with_context(|| format!("rendering {}", path.display()))?;
+    fs::write(&path, buf).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
 }
 
 /// What was passed on the command line. `None` + piped stdin == read stdin;

--- a/crates/roas-cli/src/main.rs
+++ b/crates/roas-cli/src/main.rs
@@ -191,9 +191,13 @@ fn main() -> Result<()> {
 }
 
 fn run_completions(shell: clap_complete::Shell) -> Result<()> {
+    write_completions(shell, &mut io::stdout())
+}
+
+fn write_completions(shell: clap_complete::Shell, out: &mut dyn io::Write) -> Result<()> {
     let mut cmd = Cli::command();
     let name = cmd.get_name().to_string();
-    clap_complete::generate(shell, &mut cmd, name, &mut io::stdout());
+    clap_complete::generate(shell, &mut cmd, name, out);
     Ok(())
 }
 
@@ -1091,5 +1095,130 @@ mod tests {
     fn cli_rejects_unknown_preview_renderer() {
         let res = Cli::try_parse_from(["roas", "preview", "--renderer", "stoplight", "spec.json"]);
         assert!(res.is_err(), "unknown renderer must be rejected");
+    }
+
+    // ── completions / manpages ──────────────────────────────────────────
+
+    #[test]
+    fn cli_parses_completions_with_each_supported_shell() {
+        for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+            let cli = Cli::try_parse_from(["roas", "completions", shell])
+                .unwrap_or_else(|e| panic!("completions {shell} parse: {e}"));
+            assert!(
+                matches!(cli.command, Command::Completions { .. }),
+                "expected Completions for {shell}",
+            );
+        }
+    }
+
+    #[test]
+    fn cli_rejects_unknown_completions_shell() {
+        let res = Cli::try_parse_from(["roas", "completions", "tcsh"]);
+        assert!(res.is_err(), "unsupported shell must be rejected");
+    }
+
+    #[test]
+    fn cli_parses_manpages_with_short_and_long_flag() {
+        for arg in ["--out", "-o"] {
+            let cli = Cli::try_parse_from(["roas", "manpages", arg, "/tmp/x"])
+                .unwrap_or_else(|e| panic!("manpages {arg} parse: {e}"));
+            match cli.command {
+                Command::Manpages { out } => assert_eq!(out, Path::new("/tmp/x")),
+                _ => panic!("expected Manpages"),
+            }
+        }
+    }
+
+    #[test]
+    fn cli_rejects_manpages_without_out_flag() {
+        let res = Cli::try_parse_from(["roas", "manpages"]);
+        assert!(res.is_err(), "--out is required");
+    }
+
+    /// Every shell variant should produce a non-empty completion script. We
+    /// don't pin the exact contents (clap_complete's output evolves), but
+    /// every script has to mention the bin name somewhere — that's enough
+    /// to distinguish "generator ran" from "generator no-op'd".
+    #[test]
+    fn write_completions_emits_a_script_for_every_supported_shell() {
+        use clap_complete::Shell;
+        for shell in [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Elvish,
+        ] {
+            let mut buf = Vec::new();
+            write_completions(shell, &mut buf).expect("write_completions");
+            let out = String::from_utf8(buf).expect("completion script is UTF-8");
+            assert!(
+                !out.is_empty(),
+                "{shell:?} produced empty completion script"
+            );
+            assert!(
+                out.contains("roas"),
+                "{shell:?} completion script must reference the bin name",
+            );
+        }
+    }
+
+    #[test]
+    fn run_manpages_writes_top_level_and_per_subcommand_pages() {
+        let dir = temp_path("manpages-pages");
+        // run_manpages auto-creates a missing directory — assert that
+        // behaviour by handing it a path that doesn't exist yet.
+        assert!(!dir.exists());
+        run_manpages(&dir).expect("run_manpages");
+
+        // Top-level + one per subcommand (validate / convert / preview /
+        // completions / manpages). No nested subcommands today, so the
+        // tree walker stops one level deep.
+        for name in [
+            "roas.1",
+            "roas-validate.1",
+            "roas-convert.1",
+            "roas-preview.1",
+            "roas-completions.1",
+            "roas-manpages.1",
+        ] {
+            let path = dir.join(name);
+            let body = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            assert!(!body.is_empty(), "{name} is empty");
+            // troff manpages have a `.TH <NAME> <SECTION>` header — the
+            // NAME is the renamed (hyphenated) form for subpages, so a
+            // bare `.TH ROAS-VALIDATE 1` is the strongest invariant the
+            // SYNOPSIS-renaming code can be checked against.
+            let expected_th = format!(".TH {} 1", name.trim_end_matches(".1").to_uppercase());
+            assert!(
+                body.contains(&expected_th),
+                "{name} missing TH header `{expected_th}`",
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_manpages_overwrites_existing_files() {
+        let dir = temp_path("manpages-overwrite");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let target = dir.join("roas.1");
+        std::fs::write(&target, b"stale").expect("seed file");
+
+        run_manpages(&dir).expect("run_manpages");
+
+        let body = std::fs::read_to_string(&target).expect("read");
+        assert_ne!(body, "stale", "existing manpage must be overwritten");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_completions_invokes_write_completions_against_stdout() {
+        // Direct exercise of the thin `run_completions` wrapper so the
+        // dispatch shim doesn't sit uncovered. Output goes to the real
+        // stdout (the test harness will capture it); we only care that
+        // the call doesn't error.
+        run_completions(clap_complete::Shell::Bash).expect("run_completions");
     }
 }


### PR DESCRIPTION
Adds two new subcommands to the `roas` binary, both driven by clap's own command tree so they stay in sync with the CLI:

- `roas completions <shell>` — prints a bash/zsh/fish/powershell/elvish completion script to stdout (via `clap_complete`).
- `roas manpages --out <dir>` — emits troff manpages: top-level `roas.1` plus `roas-<sub>.1` per subcommand (via `clap_mangen`).

Release-stage gets a new `RoasCliExtras` job that builds once on ubuntu-latest, renders both, and uploads `roas-${V}-completions.tar.gz` + `roas-${V}-manpages.tar.gz` (with sha256 sidecars). `AttachRoasCliBinaries` waits on the new job and attaches the tarballs to the draft release alongside the per-target binaries.

The Homebrew formula's install block now wires both up automatically via `generate_completions_from_executable` and a system call to `roas manpages --out`, so `brew install sv-tools/apps/roas` installs completions and `man roas` works out of the box.

Sigstore signatures + SLSA provenance for these new tarballs (and the existing binaries) will follow in a separate PR.