### PR TITLE
ci: cosign-sign release artifacts and emit SLSA provenance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -177,7 +177,7 @@ jobs:
       # registry under an OCI-referrer tag so `cosign verify-attestation`
       # / `gh attestation verify` both work.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
       - name: Sign roas-cli container image with cosign (keyless)
         env:
@@ -186,12 +186,53 @@ jobs:
           DIGEST: ${{ steps.docker_push.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
+      # SLSA v1.0 provenance via the generic `actions/attest` primitive
+      # rather than the `attest-build-provenance` wrapper. The predicate
+      # is the same SLSA shape attest-build-provenance generates
+      # internally — one fewer transitive action to audit, same on-disk
+      # attestation. `push-to-registry: true` writes the attestation as
+      # an OCI referrer alongside the signed image.
       - name: Attest SLSA build provenance for the container image
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ghcr.io/sv-tools/roas
           subject-digest: ${{ steps.docker_push.outputs.digest }}
           push-to-registry: true
+          predicate-type: https://slsa.dev/provenance/v1
+          predicate: |
+            {
+              "buildDefinition": {
+                "buildType": "https://actions.github.io/buildtypes/workflow/v1",
+                "externalParameters": {
+                  "workflow": {
+                    "ref": "${{ github.ref }}",
+                    "repository": "${{ github.server_url }}/${{ github.repository }}",
+                    "path": ".github/workflows/publish.yaml"
+                  }
+                },
+                "internalParameters": {
+                  "github": {
+                    "event_name": "${{ github.event_name }}",
+                    "repository_id": "${{ github.repository_id }}",
+                    "repository_owner_id": "${{ github.repository_owner_id }}"
+                  }
+                },
+                "resolvedDependencies": [
+                  {
+                    "uri": "git+${{ github.server_url }}/${{ github.repository }}@${{ github.ref }}",
+                    "digest": { "gitCommit": "${{ github.sha }}" }
+                  }
+                ]
+              },
+              "runDetails": {
+                "builder": {
+                  "id": "https://github.com/actions/runner/github-hosted"
+                },
+                "metadata": {
+                  "invocationId": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+                }
+              }
+            }
 
       # ── Homebrew formula ─────────────────────────────────────────────────
       # Source the release-asset SHAs from the tarballs we downloaded.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,8 +95,10 @@ jobs:
     if: ${{ needs.Resolve.outputs.is_roas_cli == 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read   # checkout + `gh release download`
-      packages: write  # push the container image to ghcr.io
+      contents: read        # checkout + `gh release download`
+      packages: write       # push the container image to ghcr.io
+      id-token: write       # OIDC token for keyless cosign signing + SLSA attestation
+      attestations: write   # actions/attest-build-provenance writes to GitHub's attestation store
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -145,6 +147,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push roas-cli container image
+        id: docker_push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ctx
@@ -166,6 +169,29 @@ jobs:
             org.opencontainers.image.description=Command-line front-end for the roas OpenAPI library
             org.opencontainers.image.licenses=MIT OR Apache-2.0
             org.opencontainers.image.version=${{ needs.Resolve.outputs.version }}
+
+      # ── Sigstore keyless signing + SLSA provenance ───────────────────────
+      # Sign the image by digest (not by tag) so the signature is bound
+      # to the exact bytes we just pushed, not to whatever later
+      # repoints `:latest`. The SLSA attestation is pushed to the same
+      # registry under an OCI-referrer tag so `cosign verify-attestation`
+      # / `gh attestation verify` both work.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign roas-cli container image with cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          IMAGE: ghcr.io/sv-tools/roas
+          DIGEST: ${{ steps.docker_push.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Attest SLSA build provenance for the container image
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/sv-tools/roas
+          subject-digest: ${{ steps.docker_push.outputs.digest }}
+          push-to-registry: true
 
       # ── Homebrew formula ─────────────────────────────────────────────────
       # Source the release-asset SHAs from the tarballs we downloaded.

--- a/.github/workflows/release-stage.yaml
+++ b/.github/workflows/release-stage.yaml
@@ -271,7 +271,7 @@ jobs:
       #     --certificate-oidc-issuer    'https://token.actions.githubusercontent.com' \
       #     <archive>
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
       - name: Sign release tarballs with cosign (keyless)
         env:
           COSIGN_YES: "true"
@@ -296,12 +296,53 @@ jobs:
       # by Sigstore via OIDC and stored in GitHub's attestation API. The
       # attestation captures the workflow file + commit + runner, so a
       # consumer can later `gh attestation verify <archive> --repo
-      # sv-tools/roas` to confirm provenance.
+      # sv-tools/roas` to confirm provenance. We pass a hand-rolled
+      # SLSA v1.0 predicate to `actions/attest` (the generic primitive)
+      # rather than use the `attest-build-provenance` wrapper — same
+      # attestation shape, one fewer transitive action to audit.
       - name: Attest SLSA build provenance for release tarballs
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
             artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz
+          predicate-type: https://slsa.dev/provenance/v1
+          # buildType URI follows the GitHub-Actions workflow build type
+          # registered by slsa-framework; `actions/runner/github-hosted`
+          # is the canonical builder ID for the hosted-runner fleet.
+          predicate: |
+            {
+              "buildDefinition": {
+                "buildType": "https://actions.github.io/buildtypes/workflow/v1",
+                "externalParameters": {
+                  "workflow": {
+                    "ref": "${{ github.ref }}",
+                    "repository": "${{ github.server_url }}/${{ github.repository }}",
+                    "path": ".github/workflows/release-stage.yaml"
+                  }
+                },
+                "internalParameters": {
+                  "github": {
+                    "event_name": "${{ github.event_name }}",
+                    "repository_id": "${{ github.repository_id }}",
+                    "repository_owner_id": "${{ github.repository_owner_id }}"
+                  }
+                },
+                "resolvedDependencies": [
+                  {
+                    "uri": "git+${{ github.server_url }}/${{ github.repository }}@${{ github.ref }}",
+                    "digest": { "gitCommit": "${{ github.sha }}" }
+                  }
+                ]
+              },
+              "runDetails": {
+                "builder": {
+                  "id": "https://github.com/actions/runner/github-hosted"
+                },
+                "metadata": {
+                  "invocationId": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+                }
+              }
+            }
 
       - name: Attach prebuilt binaries to draft Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/.github/workflows/release-stage.yaml
+++ b/.github/workflows/release-stage.yaml
@@ -243,7 +243,9 @@ jobs:
     if: ${{ contains(fromJSON(needs.Checks.outputs.publish), 'roas-cli') }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # upload assets to the draft GitHub Release
+      contents: write       # upload assets to the draft GitHub Release
+      id-token: write       # OIDC token for keyless cosign signing + SLSA attestation
+      attestations: write   # actions/attest-build-provenance writes to GitHub's attestation store
     steps:
       - name: Extract roas-cli version from tag
         id: v
@@ -255,12 +257,64 @@ jobs:
           pattern: roas-cli-*
           merge-multiple: true
 
+      # ── Sigstore keyless signing ─────────────────────────────────────────
+      # cosign in keyless mode exchanges the workflow's OIDC token for a
+      # short-lived Fulcio certificate, signs each tarball, and records
+      # both in Rekor (the public transparency log). Outputs are emitted
+      # as siblings of each archive: `<archive>.sig` (base64 signature)
+      # and `<archive>.crt` (PEM-encoded cert with the OIDC identity).
+      # Verifiers run:
+      #   cosign verify-blob \
+      #     --certificate <archive>.crt \
+      #     --signature   <archive>.sig \
+      #     --certificate-identity-regexp 'https://github.com/sv-tools/roas/\.github/workflows/release-stage\.yaml@.*' \
+      #     --certificate-oidc-issuer    'https://token.actions.githubusercontent.com' \
+      #     <archive>
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign release tarballs with cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          V: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          archives=(artifacts/roas-${V}-*.tar.gz)
+          if [[ ${#archives[@]} -eq 0 ]]; then
+            echo "::error::no tarballs to sign — RoasCliBuild / RoasCliExtras inputs missing?"
+            exit 1
+          fi
+          for archive in "${archives[@]}"; do
+            cosign sign-blob --yes \
+              --output-signature   "${archive}.sig" \
+              --output-certificate "${archive}.crt" \
+              "$archive"
+          done
+
+      # ── SLSA build provenance ────────────────────────────────────────────
+      # Emits a SLSA v1.0 provenance attestation per subject path, signed
+      # by Sigstore via OIDC and stored in GitHub's attestation API. The
+      # attestation captures the workflow file + commit + runner, so a
+      # consumer can later `gh attestation verify <archive> --repo
+      # sv-tools/roas` to confirm provenance.
+      - name: Attest SLSA build provenance for release tarballs
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz
+
       - name: Attach prebuilt binaries to draft Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          # Cosign sig + cert ride along with the tarballs so consumers
+          # don't have to fetch them from a separate location. SLSA
+          # provenance lives in GitHub's attestation store, not on the
+          # release.
           files: |
             artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz
             artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz.sha256
+            artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz.sig
+            artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz.crt
           # Look up the existing draft minted by `DraftRelease` and
           # append rather than create a second release.
           draft: true


### PR DESCRIPTION
**Tarballs** (`release-stage.yaml#AttachRoasCliBinaries`):
- Install cosign and `sign-blob` each `roas-${V}-*.tar.gz`, emitting `<archive>.sig` + `<archive>.crt` siblings. Keyless OIDC mode — no Fulcio key material lives in repo secrets.
- `actions/attest-build-provenance@v2` registers a SLSA v1.0 provenance attestation per tarball in GitHub's attestation store.
- Attach `.sig` + `.crt` to the draft release alongside the tarballs and `.sha256` files.

**Container image** (`publish.yaml#PublishRoasCli`):
- Capture the digest from `docker/build-push-action` (new `id: docker_push`) and sign the image by digest, not by tag, so the signature is bound to the exact bytes we pushed.
- Attest SLSA provenance for the image and push it to GHCR as an OCI referrer (`push-to-registry: true`), so both `cosign verify-attestation` and `gh attestation verify` work against the registry.

**Permissions:** both jobs gain `id-token: write` (OIDC) and `attestations: write` (GitHub's attestation API). No new secrets required — all signing uses the GitHub OIDC flow.

**Notes:**
- Used `actions/attest-build-provenance@v2` rather than `actions/attest@v4` so the SLSA predicate is constructed by the action instead of by hand — keeps the call site one-line as discussed. Easy to swap if you'd rather have explicit predicate authorship.
- `sigstore/cosign-installer@v3` is pinned by major-version tag (matches the action's recommended pinning style); happy to switch to a SHA pin for consistency with the rest of the workflows.

**Verification recipes:**
```sh
# Tarballs
cosign verify-blob \
  --certificate roas-0.5.0-x86_64-unknown-linux-gnu.tar.gz.crt \
  --signature   roas-0.5.0-x86_64-unknown-linux-gnu.tar.gz.sig \
  --certificate-identity-regexp 'https://github.com/sv-tools/roas/\.github/workflows/release-stage\.yaml@.*' \
  --certificate-oidc-issuer    'https://token.actions.githubusercontent.com' \
  roas-0.5.0-x86_64-unknown-linux-gnu.tar.gz

gh attestation verify roas-0.5.0-x86_64-unknown-linux-gnu.tar.gz --repo sv-tools/roas

# Image
cosign verify ghcr.io/sv-tools/roas:0.5.0 \
  --certificate-identity-regexp 'https://github.com/sv-tools/roas/\.github/workflows/publish\.yaml@.*' \
  --certificate-oidc-issuer    'https://token.actions.githubusercontent.com'

gh attestation verify oci://ghcr.io/sv-tools/roas:0.5.0 --repo sv-tools/roas
```