### PR TITLE
ci: let actions/attest auto-build the SLSA predicate

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,10 +95,11 @@ jobs:
     if: ${{ needs.Resolve.outputs.is_roas_cli == 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read        # checkout + `gh release download`
-      packages: write       # push the container image to ghcr.io
-      id-token: write       # OIDC token for keyless cosign signing + SLSA attestation
-      attestations: write   # actions/attest-build-provenance writes to GitHub's attestation store
+      contents: read              # checkout + `gh release download`
+      packages: write             # push the container image to ghcr.io
+      id-token: write             # OIDC token for keyless cosign signing + SLSA attestation
+      attestations: write         # actions/attest persists the attestation to the GitHub API
+      artifact-metadata: write    # required when `actions/attest` creates a storage record alongside the OCI-pushed attestation
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -186,53 +187,18 @@ jobs:
           DIGEST: ${{ steps.docker_push.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
-      # SLSA v1.0 provenance via the generic `actions/attest` primitive
-      # rather than the `attest-build-provenance` wrapper. The predicate
-      # is the same SLSA shape attest-build-provenance generates
-      # internally — one fewer transitive action to audit, same on-disk
-      # attestation. `push-to-registry: true` writes the attestation as
-      # an OCI referrer alongside the signed image.
+      # `actions/attest` defaults to "Provenance" mode — when no
+      # predicate input is supplied, it auto-generates a SLSA v1.0
+      # build-provenance predicate from the workflow context. Same
+      # shape as the deprecated `attest-build-provenance` wrapper.
+      # `push-to-registry: true` writes the attestation as an OCI
+      # referrer alongside the signed image.
       - name: Attest SLSA build provenance for the container image
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ghcr.io/sv-tools/roas
           subject-digest: ${{ steps.docker_push.outputs.digest }}
           push-to-registry: true
-          predicate-type: https://slsa.dev/provenance/v1
-          predicate: |
-            {
-              "buildDefinition": {
-                "buildType": "https://actions.github.io/buildtypes/workflow/v1",
-                "externalParameters": {
-                  "workflow": {
-                    "ref": "${{ github.ref }}",
-                    "repository": "${{ github.server_url }}/${{ github.repository }}",
-                    "path": ".github/workflows/publish.yaml"
-                  }
-                },
-                "internalParameters": {
-                  "github": {
-                    "event_name": "${{ github.event_name }}",
-                    "repository_id": "${{ github.repository_id }}",
-                    "repository_owner_id": "${{ github.repository_owner_id }}"
-                  }
-                },
-                "resolvedDependencies": [
-                  {
-                    "uri": "git+${{ github.server_url }}/${{ github.repository }}@${{ github.ref }}",
-                    "digest": { "gitCommit": "${{ github.sha }}" }
-                  }
-                ]
-              },
-              "runDetails": {
-                "builder": {
-                  "id": "https://github.com/actions/runner/github-hosted"
-                },
-                "metadata": {
-                  "invocationId": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
-                }
-              }
-            }
 
       # ── Homebrew formula ─────────────────────────────────────────────────
       # Source the release-asset SHAs from the tarballs we downloaded.

--- a/.github/workflows/release-stage.yaml
+++ b/.github/workflows/release-stage.yaml
@@ -292,57 +292,18 @@ jobs:
           done
 
       # ── SLSA build provenance ────────────────────────────────────────────
-      # Emits a SLSA v1.0 provenance attestation per subject path, signed
-      # by Sigstore via OIDC and stored in GitHub's attestation API. The
-      # attestation captures the workflow file + commit + runner, so a
-      # consumer can later `gh attestation verify <archive> --repo
-      # sv-tools/roas` to confirm provenance. We pass a hand-rolled
-      # SLSA v1.0 predicate to `actions/attest` (the generic primitive)
-      # rather than use the `attest-build-provenance` wrapper — same
-      # attestation shape, one fewer transitive action to audit.
+      # `actions/attest` runs in "Provenance" mode when no predicate
+      # input is supplied (see the README's Attestation Modes table)
+      # and auto-generates a SLSA v1.0 build-provenance predicate from
+      # the workflow context — identical shape to what the deprecated
+      # `attest-build-provenance` wrapper used to emit. Consumers
+      # verify with `gh attestation verify <archive> --repo
+      # sv-tools/roas`.
       - name: Attest SLSA build provenance for release tarballs
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
             artifacts/roas-${{ steps.v.outputs.version }}-*.tar.gz
-          predicate-type: https://slsa.dev/provenance/v1
-          # buildType URI follows the GitHub-Actions workflow build type
-          # registered by slsa-framework; `actions/runner/github-hosted`
-          # is the canonical builder ID for the hosted-runner fleet.
-          predicate: |
-            {
-              "buildDefinition": {
-                "buildType": "https://actions.github.io/buildtypes/workflow/v1",
-                "externalParameters": {
-                  "workflow": {
-                    "ref": "${{ github.ref }}",
-                    "repository": "${{ github.server_url }}/${{ github.repository }}",
-                    "path": ".github/workflows/release-stage.yaml"
-                  }
-                },
-                "internalParameters": {
-                  "github": {
-                    "event_name": "${{ github.event_name }}",
-                    "repository_id": "${{ github.repository_id }}",
-                    "repository_owner_id": "${{ github.repository_owner_id }}"
-                  }
-                },
-                "resolvedDependencies": [
-                  {
-                    "uri": "git+${{ github.server_url }}/${{ github.repository }}@${{ github.ref }}",
-                    "digest": { "gitCommit": "${{ github.sha }}" }
-                  }
-                ]
-              },
-              "runDetails": {
-                "builder": {
-                  "id": "https://github.com/actions/runner/github-hosted"
-                },
-                "metadata": {
-                  "invocationId": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
-                }
-              }
-            }
 
       - name: Attach prebuilt binaries to draft Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0


### PR DESCRIPTION
Per [the action README](https://github.com/actions/attest#attestation-modes), `actions/attest` runs in **Provenance** mode by default — when no predicate input is supplied, it auto-generates the SLSA v1.0 build-provenance predicate from the workflow context. Passing `predicate-type` + `predicate` switched it into **Custom** mode, which is what the failing log was reporting (`Attestation type: Custom`) before the API rejected the payload with `required predicate value is unset` — the JSON-in-YAML wasn't reaching the action cleanly.

Drop both inputs in both call sites (`release-stage.yaml#AttachRoasCliBinaries` for tarballs, `publish.yaml#PublishRoasCli` for the image). Resulting attestation is the same SLSA v1.0 shape the deprecated `attest-build-provenance` wrapper produced — same `buildType`, same builder ID, same metadata — but generated by `actions/attest` itself rather than by inline YAML JSON.

Also adds `artifact-metadata: write` to `PublishRoasCli` — the image attestation uses `push-to-registry: true`, which defaults `create-storage-record` to true and per the README requires that scope.

Diff is `+18 / -91`: most of the change is dropping the hand-rolled predicate JSON.