### PR TITLE
ci(publish): set OCI index annotations so GHCR shows the description

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -170,6 +170,19 @@ jobs:
             org.opencontainers.image.description=Command-line front-end for the roas OpenAPI library
             org.opencontainers.image.licenses=MIT OR Apache-2.0
             org.opencontainers.image.version=${{ needs.Resolve.outputs.version }}
+          # Labels live on each per-arch manifest, but GHCR's package
+          # page reads its description (and source / documentation links)
+          # from the *index* (manifest list) for multi-arch images.
+          # Without these annotations the package page shows "No
+          # description provided". The `index:` prefix is how
+          # docker/build-push-action targets the OCI index rather than
+          # each per-platform manifest.
+          annotations: |
+            index:org.opencontainers.image.source=https://github.com/sv-tools/roas/tree/main/crates/roas-cli
+            index:org.opencontainers.image.documentation=https://github.com/sv-tools/roas/blob/main/crates/roas-cli/README.md
+            index:org.opencontainers.image.description=Command-line front-end for the roas OpenAPI library
+            index:org.opencontainers.image.licenses=MIT OR Apache-2.0
+            index:org.opencontainers.image.version=${{ needs.Resolve.outputs.version }}
 
       # ── Sigstore keyless signing + SLSA provenance ───────────────────────
       # Sign the image by digest (not by tag) so the signature is bound


### PR DESCRIPTION
GHCR's package page reads the description (and source / documentation URLs) from the **manifest-list annotations** for multi-arch images — not from the per-arch image labels. The existing `labels:` block was being applied correctly, but to each per-platform manifest, which the package page doesn't consult. Result: "No description provided" on https://github.com/sv-tools/roas/pkgs/container/roas despite the labels being right.

Mirror the same five OCI image keys into `annotations:` on `docker/build-push-action` with the `index:` prefix so they land on the OCI index rather than each per-platform manifest. `source` and `documentation` cover the README-resolution path too, so the same change should make the CLI README render on the package page if the source-subdirectory trick from #176 hadn't been picked up already.