### PR TITLE
fix(publish): preserve `AS <stage>` when bumping roas-action FROM line

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -339,10 +339,14 @@ jobs:
           V: ${{ needs.Resolve.outputs.version }}
         run: |
           set -euo pipefail
-          # Match any current pin (`:<version>` or `:latest`) and rewrite
-          # it to the new version. Anchored to the `FROM` line so unrelated
-          # mentions of the image elsewhere in the file aren't touched.
-          sed -i -E "s|^FROM ghcr\.io/sv-tools/roas:.*|FROM ghcr.io/sv-tools/roas:${V}|" Dockerfile
+          # Match `roas:<tag>` only — Docker tag charset is
+          # `[A-Za-z0-9._-]+`, which deliberately excludes whitespace
+          # and `#`. The previous regex used `.*`, which greedily ate
+          # the rest of the line and stripped multi-stage markers like
+          # ` AS src` or trailing comments. Anchored to `FROM` so
+          # unrelated mentions of the image elsewhere in the file
+          # aren't touched.
+          sed -i -E "s|^(FROM ghcr\.io/sv-tools/roas):[A-Za-z0-9._-]+|\1:${V}|" Dockerfile
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git diff --quiet Dockerfile; then


### PR DESCRIPTION
Old regex was `:.*` which greedily ate everything after the tag, so multi-stage Dockerfiles like

```Dockerfile
FROM ghcr.io/sv-tools/roas:0.6.0 AS src
```

got rewritten to

```Dockerfile
FROM ghcr.io/sv-tools/roas:0.7.0
```

— silently dropping the `AS src` stage name and breaking any downstream `COPY --from=src`.

Constrain the match to a valid Docker tag charset (`[A-Za-z0-9._-]+`) using a capture group. Verified against four representative `FROM` lines locally — `AS` / `as` / trailing comments all preserved.

```
FROM ghcr.io/sv-tools/roas:0.6.0 AS src        → FROM ghcr.io/sv-tools/roas:0.7.0 AS src
FROM ghcr.io/sv-tools/roas:latest              → FROM ghcr.io/sv-tools/roas:0.7.0
FROM ghcr.io/sv-tools/roas:0.5.0  # pinned     → FROM ghcr.io/sv-tools/roas:0.7.0  # pinned
FROM ghcr.io/sv-tools/roas:0.4.0 as builder    → FROM ghcr.io/sv-tools/roas:0.7.0 as builder
```