### PR TITLE
chore(roas-cli): bump to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Patch bump to pick up the publish-workflow fixes landed since 0.6.0 (GHCR index annotations, roas-action sed regex). No CLI source changes.