### PR TITLE
chore(roas-cli): bump to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Patch bump to retest the publish workflow's `AS src` preservation fix (568f323) end-to-end — v0.6.1's tag predated the fix, so the old greedy `:.*` sed actually ran. No CLI source changes.