### PR TITLE
feat(roas): recursive Spec::merge for v3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "roas"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas/Cargo.toml
+++ b/crates/roas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas/src/common.rs
+++ b/crates/roas/src/common.rs
@@ -5,4 +5,5 @@ pub(crate) mod collapse;
 pub mod extensions;
 pub mod formats;
 pub(crate) mod helpers;
+pub(crate) mod merge;
 pub mod reference;

--- a/crates/roas/src/common/bool_or.rs
+++ b/crates/roas/src/common/bool_or.rs
@@ -122,4 +122,106 @@ mod tests {
             "deserialize true",
         );
     }
+
+    // ---- Merge coverage ----
+
+    use crate::merge::{ConflictKind, MergeContext, MergeOptions, MergeWithContext, Resolution};
+
+    impl MergeWithContext<()> for Foo {
+        fn merge_with_context(
+            &mut self,
+            other: Self,
+            ctx: &mut MergeContext<()>,
+            path: &mut String,
+        ) {
+            if self.foo != other.foo
+                && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden)
+            {
+                self.foo = other.foo;
+            }
+        }
+    }
+
+    fn ctx_with(opts: enumset::EnumSet<MergeOptions>) -> MergeContext<'static, ()> {
+        MergeContext::new(&(), opts)
+    }
+
+    #[test]
+    fn bool_or_item_item_recurses_into_inner() {
+        let mut base: BoolOr<Foo> = BoolOr::Item(Foo { foo: "a".into() });
+        let mut ctx = ctx_with(MergeOptions::new());
+        let mut path = "#".to_owned();
+        base.merge_with_context(BoolOr::Item(Foo { foo: "b".into() }), &mut ctx, &mut path);
+        match base {
+            BoolOr::Item(f) => assert_eq!(f.foo, "b"),
+            _ => panic!("expected Item"),
+        }
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::ScalarOverridden);
+    }
+
+    #[test]
+    fn bool_or_bool_bool_same_value_no_conflict() {
+        let mut base: BoolOr<Foo> = BoolOr::Bool(true);
+        let mut ctx = ctx_with(MergeOptions::new());
+        let mut path = "#".to_owned();
+        base.merge_with_context(BoolOr::Bool(true), &mut ctx, &mut path);
+        assert!(matches!(base, BoolOr::Bool(true)));
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn bool_or_bool_bool_different_takes_incoming_by_default() {
+        let mut base: BoolOr<Foo> = BoolOr::Bool(true);
+        let mut ctx = ctx_with(MergeOptions::new());
+        let mut path = "#".to_owned();
+        base.merge_with_context(BoolOr::Bool(false), &mut ctx, &mut path);
+        assert!(matches!(base, BoolOr::Bool(false)));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::ScalarOverridden);
+    }
+
+    #[test]
+    fn bool_or_bool_bool_different_base_wins() {
+        let mut base: BoolOr<Foo> = BoolOr::Bool(true);
+        let mut ctx = ctx_with(MergeOptions::BaseWins.only());
+        let mut path = "#".to_owned();
+        base.merge_with_context(BoolOr::Bool(false), &mut ctx, &mut path);
+        assert!(matches!(base, BoolOr::Bool(true)));
+        assert_eq!(ctx.conflicts[0].resolution, Resolution::Base);
+    }
+
+    #[test]
+    fn bool_or_bool_vs_item_replaces_with_ref_vs_value_kind() {
+        let mut base: BoolOr<Foo> = BoolOr::Bool(true);
+        let mut ctx = ctx_with(MergeOptions::new());
+        let mut path = "#".to_owned();
+        base.merge_with_context(BoolOr::Item(Foo { foo: "x".into() }), &mut ctx, &mut path);
+        assert!(matches!(base, BoolOr::Item(_)));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::RefVsValue);
+    }
+
+    #[test]
+    fn bool_or_item_vs_bool_replaces_with_ref_vs_value_kind() {
+        let mut base: BoolOr<Foo> = BoolOr::Item(Foo { foo: "x".into() });
+        let mut ctx = ctx_with(MergeOptions::new());
+        let mut path = "#".to_owned();
+        base.merge_with_context(BoolOr::Bool(false), &mut ctx, &mut path);
+        assert!(matches!(base, BoolOr::Bool(false)));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::RefVsValue);
+    }
+
+    #[test]
+    fn bool_or_errored_entry_short_circuits() {
+        let mut base: BoolOr<Foo> = BoolOr::Bool(true);
+        let mut ctx = ctx_with(MergeOptions::new());
+        ctx.errored = true;
+        let mut path = "#".to_owned();
+        base.merge_with_context(BoolOr::Bool(false), &mut ctx, &mut path);
+        // Errored entry → no-op; base unchanged, no new conflict.
+        assert!(matches!(base, BoolOr::Bool(true)));
+        assert!(ctx.conflicts.is_empty());
+    }
 }

--- a/crates/roas/src/common/bool_or.rs
+++ b/crates/roas/src/common/bool_or.rs
@@ -25,6 +25,40 @@ impl<D> BoolOr<RefOr<D>> {
     }
 }
 
+impl<D, T> crate::merge::MergeWithContext<T> for BoolOr<D>
+where
+    D: crate::merge::MergeWithContext<T>,
+{
+    fn merge_with_context(
+        &mut self,
+        other: Self,
+        ctx: &mut crate::merge::MergeContext<T>,
+        path: String,
+    ) {
+        use crate::merge::ConflictKind;
+        match (self, other) {
+            (BoolOr::Item(base), BoolOr::Item(incoming)) => {
+                base.merge_with_context(incoming, ctx, path);
+            }
+            (slot @ BoolOr::Bool(_), BoolOr::Bool(incoming_bool)) => {
+                let BoolOr::Bool(base_bool) = slot else {
+                    unreachable!()
+                };
+                if *base_bool != incoming_bool
+                    && ctx.should_take_incoming(&path, ConflictKind::ScalarOverridden)
+                {
+                    *base_bool = incoming_bool;
+                }
+            }
+            (slot, incoming) => {
+                if ctx.should_take_incoming(&path, ConflictKind::RefVsValue) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/roas/src/common/bool_or.rs
+++ b/crates/roas/src/common/bool_or.rs
@@ -33,8 +33,11 @@ where
         &mut self,
         other: Self,
         ctx: &mut crate::merge::MergeContext<T>,
-        path: String,
+        path: &mut String,
     ) {
+        if ctx.errored {
+            return;
+        }
         use crate::merge::ConflictKind;
         match (self, other) {
             (BoolOr::Item(base), BoolOr::Item(incoming)) => {
@@ -45,13 +48,13 @@ where
                     unreachable!()
                 };
                 if *base_bool != incoming_bool
-                    && ctx.should_take_incoming(&path, ConflictKind::ScalarOverridden)
+                    && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden)
                 {
                     *base_bool = incoming_bool;
                 }
             }
             (slot, incoming) => {
-                if ctx.should_take_incoming(&path, ConflictKind::RefVsValue) {
+                if ctx.should_take_incoming(path, ConflictKind::RefVsValue) {
                     *slot = incoming;
                 }
             }

--- a/crates/roas/src/common/merge.rs
+++ b/crates/roas/src/common/merge.rs
@@ -1,0 +1,358 @@
+//! Structural merge helpers shared across versions.
+//!
+//! These don't force per-version components to share *types* — they're
+//! generic over `V` and `T`, so each per-version impl block calls into
+//! them with its own `V`. The dedup-policy decision (per-version files
+//! stay duplicated except `reference.rs`) is preserved.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::merge::{ConflictKind, MergeContext, MergeWithContext};
+
+/// Merge two bare `BTreeMap`s by key. Used by `Paths`, `Callback`,
+/// `Components.<bag>` (each bag is `Option<BTreeMap<...>>` — wrap with
+/// [`merge_opt_map`] for those).
+pub(crate) fn merge_map<T, K, V>(
+    base: &mut BTreeMap<K, V>,
+    other: BTreeMap<K, V>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
+    fmt_key: impl Fn(&K) -> String,
+) where
+    K: Ord,
+{
+    for (k, incoming) in other {
+        if let Some(base_v) = base.get_mut(&k) {
+            let child_path = format!("{path}.{}", fmt_key(&k));
+            recurse(base_v, incoming, ctx, child_path);
+            if ctx.errored {
+                return;
+            }
+        } else {
+            base.insert(k, incoming);
+        }
+    }
+}
+
+/// Merge two `Option<BTreeMap<K, V>>` (the common shape for
+/// `Components.<bag>` and the dozens of optional-map sub-fields).
+pub(crate) fn merge_opt_map<T, K, V>(
+    base: &mut Option<BTreeMap<K, V>>,
+    other: Option<BTreeMap<K, V>>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
+    fmt_key: impl Fn(&K) -> String,
+) where
+    K: Ord,
+{
+    let Some(other) = other else { return };
+    match base {
+        Some(base_map) => merge_map(base_map, other, ctx, path, recurse, fmt_key),
+        None => *base = Some(other),
+    }
+}
+
+/// Merge an identity-keyed `Vec` (e.g. `tags` by name, `parameters` by
+/// `(name, in)`). On collision the recursion callback decides what
+/// happens; new keys are appended in incoming order.
+pub(crate) fn merge_vec_by_key<T, V, K>(
+    base: &mut Vec<V>,
+    other: Vec<V>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+    key_of: impl Fn(&V) -> K,
+    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
+    fmt_key: impl Fn(&K) -> String,
+) where
+    K: Ord + Clone,
+{
+    use std::collections::BTreeMap as Map;
+    let mut index: Map<K, usize> = Map::new();
+    for (i, v) in base.iter().enumerate() {
+        index.insert(key_of(v), i);
+    }
+    for incoming in other {
+        let k = key_of(&incoming);
+        if let Some(&i) = index.get(&k) {
+            let child = format!("{path}[{}]", fmt_key(&k));
+            recurse(&mut base[i], incoming, ctx, child);
+            if ctx.errored {
+                return;
+            }
+        } else {
+            index.insert(k, base.len());
+            base.push(incoming);
+        }
+    }
+}
+
+/// Merge an optional identity-keyed vec, treating `None` like an
+/// empty list on either side.
+pub(crate) fn merge_opt_vec_by_key<T, V, K>(
+    base: &mut Option<Vec<V>>,
+    other: Option<Vec<V>>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+    key_of: impl Fn(&V) -> K,
+    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
+    fmt_key: impl Fn(&K) -> String,
+) where
+    K: Ord + Clone,
+{
+    let Some(other) = other else { return };
+    match base {
+        Some(base_v) => merge_vec_by_key(base_v, other, ctx, path, key_of, recurse, fmt_key),
+        None => *base = Some(other),
+    }
+}
+
+/// Set-union an `Option<Vec<V: Ord + Eq>>` while preserving the base
+/// order (incoming-only entries appended in incoming order). No
+/// conflict is recorded — adding more tags / `required` entries is
+/// purely additive.
+pub(crate) fn merge_opt_vec_set_union<T, V>(
+    base: &mut Option<Vec<V>>,
+    other: Option<Vec<V>>,
+    _ctx: &mut MergeContext<T>,
+    _path: &str,
+) where
+    V: Ord + Clone,
+{
+    let Some(other) = other else { return };
+    match base {
+        Some(base_v) => {
+            let mut seen: BTreeSet<V> = base_v.iter().cloned().collect();
+            for v in other {
+                if seen.insert(v.clone()) {
+                    base_v.push(v);
+                }
+            }
+        }
+        None => *base = Some(other),
+    }
+}
+
+/// Merge an optional scalar. `None × x` keeps `x`. `Some(a) × Some(b)`
+/// where `a == b` is a no-op. Mismatching values run through the
+/// three-mode policy.
+pub(crate) fn merge_opt_scalar<T, V>(
+    base: &mut Option<V>,
+    other: Option<V>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+    kind: ConflictKind,
+) where
+    V: PartialEq,
+{
+    match (base.as_mut(), other) {
+        (_, None) => {}
+        (None, Some(v)) => *base = Some(v),
+        (Some(a), Some(b)) => {
+            if *a != b && ctx.should_take_incoming(path, kind) {
+                *a = b;
+            }
+        }
+    }
+}
+
+/// Merge a required scalar (one that's always present, like
+/// `info.title`). Same policy as [`merge_opt_scalar`] for the
+/// `Some × Some` arm.
+pub(crate) fn merge_required_scalar<T, V>(
+    base: &mut V,
+    other: V,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+    kind: ConflictKind,
+) where
+    V: PartialEq,
+{
+    if *base != other && ctx.should_take_incoming(path, kind) {
+        *base = other;
+    }
+}
+
+/// Replace `base` with `other` only when `other` is non-empty.
+/// Records [`ConflictKind::ListReplaced`] when an actual replacement
+/// occurs. Used for `servers`, `security`, etc.
+pub(crate) fn merge_replace_list_when_nonempty<T, V>(
+    base: &mut Option<Vec<V>>,
+    other: Option<Vec<V>>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+) {
+    use crate::merge::MergeOptions;
+    let replace_when_empty = ctx.is_option(MergeOptions::ReplaceListsWhenEmpty);
+    let Some(other) = other else { return };
+    if other.is_empty() && !replace_when_empty {
+        return;
+    }
+    match base {
+        Some(b) if !b.is_empty() => {
+            if ctx.should_take_incoming(path, ConflictKind::ListReplaced) {
+                *b = other;
+            }
+        }
+        _ => *base = Some(other),
+    }
+}
+
+/// Merge `Option<BTreeMap<String, serde_json::Value>>` extensions
+/// per-key. Identical JSON values are no-ops; differing values go
+/// through the policy.
+pub(crate) fn merge_extensions<T>(
+    base: &mut Option<BTreeMap<String, serde_json::Value>>,
+    other: Option<BTreeMap<String, serde_json::Value>>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+) {
+    let Some(other) = other else { return };
+    let base_map = base.get_or_insert_with(BTreeMap::new);
+    for (k, incoming) in other {
+        match base_map.get_mut(&k) {
+            None => {
+                base_map.insert(k, incoming);
+            }
+            Some(existing) => {
+                if *existing != incoming {
+                    let child = format!("{path}.{k}");
+                    if ctx.should_take_incoming(&child, ConflictKind::ScalarOverridden) {
+                        *existing = incoming;
+                    }
+                }
+            }
+        }
+        if ctx.errored {
+            return;
+        }
+    }
+}
+
+/// Merge two `Option<S>` where `S: MergeWithContext<T>`. Mirrors the
+/// scalar shape but recurses on `Some × Some`.
+pub(crate) fn merge_opt_struct<T, S>(
+    base: &mut Option<S>,
+    other: Option<S>,
+    ctx: &mut MergeContext<T>,
+    path: &str,
+) where
+    S: MergeWithContext<T>,
+{
+    match (base.as_mut(), other) {
+        (_, None) => {}
+        (None, Some(v)) => *base = Some(v),
+        (Some(a), Some(b)) => a.merge_with_context(b, ctx, path.to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merge::{ConflictKind, MergeOptions};
+
+    #[test]
+    fn merge_opt_scalar_none_incoming_no_op() {
+        let mut base: Option<String> = Some("a".into());
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_opt_scalar(
+            &mut base,
+            None,
+            &mut ctx,
+            "#.x",
+            ConflictKind::ScalarOverridden,
+        );
+        assert_eq!(base.as_deref(), Some("a"));
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn merge_opt_scalar_none_base_takes_incoming() {
+        let mut base: Option<String> = None;
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_opt_scalar(
+            &mut base,
+            Some("b".into()),
+            &mut ctx,
+            "#.x",
+            ConflictKind::ScalarOverridden,
+        );
+        assert_eq!(base.as_deref(), Some("b"));
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn merge_opt_scalar_same_value_no_conflict() {
+        let mut base: Option<String> = Some("a".into());
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_opt_scalar(
+            &mut base,
+            Some("a".into()),
+            &mut ctx,
+            "#.x",
+            ConflictKind::ScalarOverridden,
+        );
+        assert_eq!(base.as_deref(), Some("a"));
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn merge_opt_scalar_differing_takes_incoming_by_default() {
+        let mut base: Option<String> = Some("a".into());
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_opt_scalar(
+            &mut base,
+            Some("b".into()),
+            &mut ctx,
+            "#.x",
+            ConflictKind::ScalarOverridden,
+        );
+        assert_eq!(base.as_deref(), Some("b"));
+        assert_eq!(ctx.conflicts.len(), 1);
+    }
+
+    #[test]
+    fn merge_opt_vec_set_union_dedupes_and_preserves_base_order() {
+        let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_opt_vec_set_union(&mut base, Some(vec![2, 3]), &mut ctx, "#.x");
+        assert_eq!(base.unwrap(), vec![1, 2, 3]);
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn merge_extensions_new_key_inserts() {
+        let mut base: Option<BTreeMap<String, serde_json::Value>> = Some({
+            let mut m = BTreeMap::new();
+            m.insert("x-a".into(), serde_json::json!(1));
+            m
+        });
+        let mut other = BTreeMap::new();
+        other.insert("x-b".into(), serde_json::json!(2));
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_extensions(&mut base, Some(other), &mut ctx, "#.x");
+        let b = base.unwrap();
+        assert_eq!(b.get("x-a"), Some(&serde_json::json!(1)));
+        assert_eq!(b.get("x-b"), Some(&serde_json::json!(2)));
+    }
+
+    #[test]
+    fn merge_replace_list_keeps_populated_base_when_incoming_empty() {
+        let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_replace_list_when_nonempty(&mut base, Some(vec![]), &mut ctx, "#.x");
+        assert_eq!(base, Some(vec![1, 2]));
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn merge_replace_list_replaces_when_both_non_empty() {
+        let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        merge_replace_list_when_nonempty(&mut base, Some(vec![9, 10]), &mut ctx, "#.x");
+        assert_eq!(base, Some(vec![9, 10]));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::ListReplaced);
+    }
+}

--- a/crates/roas/src/common/merge.rs
+++ b/crates/roas/src/common/merge.rs
@@ -38,11 +38,6 @@ impl<'a> PathGuard<'a> {
         PathGuard { path, original_len }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn as_str(&self) -> &str {
-        self.path
-    }
-
     pub(crate) fn path_mut(&mut self) -> &mut String {
         self.path
     }
@@ -85,11 +80,15 @@ pub(crate) fn merge_map<T, K, V>(
     }
     for (k, incoming) in other {
         if let Some(base_v) = base.get_mut(&k) {
-            let original_len = path.len();
-            path.push('.');
-            fmt_key(&k, path);
-            recurse(base_v, incoming, ctx, path);
-            path.truncate(original_len);
+            // Use the PathGuard so a panic inside `recurse` still
+            // restores the buffer on unwind. Merge runs against owned
+            // data and doesn't itself panic, but a buggy user-supplied
+            // recurse callback could — and dropped guards keep the
+            // module invariant ("path balanced at every return") intact.
+            let mut guard = PathGuard::new(path, ".");
+            fmt_key(&k, guard.path_mut());
+            recurse(base_v, incoming, ctx, guard.path_mut());
+            drop(guard);
             if ctx.errored {
                 return;
             }
@@ -151,12 +150,13 @@ pub(crate) fn merge_vec_by_key<T, V, K>(
     for incoming in other {
         let k = key_of(&incoming);
         if let Some(&i) = index.get(&k) {
-            let original_len = path.len();
-            path.push('[');
-            fmt_key(&k, path);
-            path.push(']');
-            recurse(&mut base[i], incoming, ctx, path);
-            path.truncate(original_len);
+            // PathGuard restores the buffer even if `recurse` panics
+            // — same panic-safety reasoning as `merge_map`.
+            let mut guard = PathGuard::new(path, "[");
+            fmt_key(&k, guard.path_mut());
+            guard.path_mut().push(']');
+            recurse(&mut base[i], incoming, ctx, guard.path_mut());
+            drop(guard);
             if ctx.errored {
                 return;
             }
@@ -526,8 +526,8 @@ mod tests {
     fn path_guard_restores_path_on_drop() {
         let mut path = "#.foo".to_owned();
         {
-            let guard = PathGuard::new(&mut path, ".bar");
-            assert_eq!(guard.as_str(), "#.foo.bar");
+            let mut guard = PathGuard::new(&mut path, ".bar");
+            assert_eq!(guard.path_mut(), "#.foo.bar");
         }
         assert_eq!(path, "#.foo");
     }
@@ -538,10 +538,10 @@ mod tests {
         {
             let mut g1 = PathGuard::new(&mut path, ".a");
             {
-                let g2 = PathGuard::new(g1.path_mut(), ".b");
-                assert_eq!(g2.as_str(), "#.a.b");
+                let mut g2 = PathGuard::new(g1.path_mut(), ".b");
+                assert_eq!(g2.path_mut(), "#.a.b");
             }
-            assert_eq!(g1.as_str(), "#.a");
+            assert_eq!(g1.path_mut(), "#.a");
         }
         assert_eq!(path, "#");
     }

--- a/crates/roas/src/common/merge.rs
+++ b/crates/roas/src/common/merge.rs
@@ -1,30 +1,82 @@
 //! Structural merge helpers shared across versions.
 //!
-//! These don't force per-version components to share *types* — they're
-//! generic over `V` and `T`, so each per-version impl block calls into
+//! Generic over `V` and `T`, so each per-version impl block calls into
 //! them with its own `V`. The dedup-policy decision (per-version files
 //! stay duplicated except `reference.rs`) is preserved.
+//!
+//! All helpers in this module no-op when `ctx.errored` is already set,
+//! so callers do not need to interleave `if ctx.errored { return; }`
+//! checks between successive calls. The first helper to record a
+//! `Resolution::Errored` flips the flag and every subsequent helper
+//! returns early.
+//!
+//! Path traversal uses a `&mut String` stack: each helper pushes its
+//! own segment before recording a conflict and truncates back when
+//! it returns. The non-conflict path therefore performs zero String
+//! allocations (the original implementation `format!`'d a fresh
+//! `String` for every field of every node, conflict or not). The
+//! [`push_segment`] / [`PathGuard`] pair encapsulates the RAII
+//! push/truncate dance so call sites stay readable.
 
 use std::collections::BTreeMap;
 
 use crate::merge::{ConflictKind, MergeContext, MergeWithContext};
 
+/// RAII guard that pushes a segment onto `path` on construction and
+/// truncates it back to the original length on drop. Holding the
+/// guard for the duration of a child call keeps the path valid for
+/// any conflict recording that happens inside.
+pub(crate) struct PathGuard<'a> {
+    path: &'a mut String,
+    original_len: usize,
+}
+
+impl<'a> PathGuard<'a> {
+    pub(crate) fn new(path: &'a mut String, segment: &str) -> Self {
+        let original_len = path.len();
+        path.push_str(segment);
+        PathGuard { path, original_len }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn as_str(&self) -> &str {
+        self.path
+    }
+
+    pub(crate) fn path_mut(&mut self) -> &mut String {
+        self.path
+    }
+}
+
+impl Drop for PathGuard<'_> {
+    fn drop(&mut self) {
+        self.path.truncate(self.original_len);
+    }
+}
+
+/// Convenience for ad-hoc pushes that don't immediately go into a
+/// helper that already does its own push (e.g. when recording a
+/// conflict directly from a component impl).
+#[inline]
+pub(crate) fn with_segment<R>(
+    path: &mut String,
+    segment: &str,
+    f: impl FnOnce(&mut String) -> R,
+) -> R {
+    let mut guard = PathGuard::new(path, segment);
+    f(guard.path_mut())
+}
+
 /// Merge two bare `BTreeMap`s by key. Used by `Paths`, `Callback`,
 /// `Components.<bag>` (each bag is `Option<BTreeMap<...>>` — wrap with
 /// [`merge_opt_map`] for those).
-///
-/// All helpers in this module no-op when `ctx.errored` is already
-/// set, so callers do not need to interleave `if ctx.errored { return; }`
-/// checks between successive calls. The first helper to record a
-/// `Resolution::Errored` flips the flag and every subsequent helper
-/// returns early.
 pub(crate) fn merge_map<T, K, V>(
     base: &mut BTreeMap<K, V>,
     other: BTreeMap<K, V>,
     ctx: &mut MergeContext<T>,
-    path: &str,
-    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
-    fmt_key: impl Fn(&K) -> String,
+    path: &mut String,
+    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord,
 {
@@ -33,8 +85,11 @@ pub(crate) fn merge_map<T, K, V>(
     }
     for (k, incoming) in other {
         if let Some(base_v) = base.get_mut(&k) {
-            let child_path = format!("{path}.{}", fmt_key(&k));
-            recurse(base_v, incoming, ctx, child_path);
+            let original_len = path.len();
+            path.push('.');
+            fmt_key(&k, path);
+            recurse(base_v, incoming, ctx, path);
+            path.truncate(original_len);
             if ctx.errored {
                 return;
             }
@@ -46,13 +101,15 @@ pub(crate) fn merge_map<T, K, V>(
 
 /// Merge two `Option<BTreeMap<K, V>>` (the common shape for
 /// `Components.<bag>` and the dozens of optional-map sub-fields).
+/// Pushes `segment` onto `path` only when there's something to do.
 pub(crate) fn merge_opt_map<T, K, V>(
     base: &mut Option<BTreeMap<K, V>>,
     other: Option<BTreeMap<K, V>>,
     ctx: &mut MergeContext<T>,
-    path: &str,
-    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
-    fmt_key: impl Fn(&K) -> String,
+    path: &mut String,
+    segment: &str,
+    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord,
 {
@@ -61,7 +118,10 @@ pub(crate) fn merge_opt_map<T, K, V>(
     }
     let Some(other) = other else { return };
     match base {
-        Some(base_map) => merge_map(base_map, other, ctx, path, recurse, fmt_key),
+        Some(base_map) => {
+            let mut guard = PathGuard::new(path, segment);
+            merge_map(base_map, other, ctx, guard.path_mut(), recurse, fmt_key);
+        }
         None => *base = Some(other),
     }
 }
@@ -73,10 +133,10 @@ pub(crate) fn merge_vec_by_key<T, V, K>(
     base: &mut Vec<V>,
     other: Vec<V>,
     ctx: &mut MergeContext<T>,
-    path: &str,
+    path: &mut String,
     key_of: impl Fn(&V) -> K,
-    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
-    fmt_key: impl Fn(&K) -> String,
+    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord + Clone,
 {
@@ -91,8 +151,12 @@ pub(crate) fn merge_vec_by_key<T, V, K>(
     for incoming in other {
         let k = key_of(&incoming);
         if let Some(&i) = index.get(&k) {
-            let child = format!("{path}[{}]", fmt_key(&k));
-            recurse(&mut base[i], incoming, ctx, child);
+            let original_len = path.len();
+            path.push('[');
+            fmt_key(&k, path);
+            path.push(']');
+            recurse(&mut base[i], incoming, ctx, path);
+            path.truncate(original_len);
             if ctx.errored {
                 return;
             }
@@ -105,14 +169,16 @@ pub(crate) fn merge_vec_by_key<T, V, K>(
 
 /// Merge an optional identity-keyed vec, treating `None` like an
 /// empty list on either side.
+#[allow(clippy::too_many_arguments)] // 8 args; this is a structural plumbing helper.
 pub(crate) fn merge_opt_vec_by_key<T, V, K>(
     base: &mut Option<Vec<V>>,
     other: Option<Vec<V>>,
     ctx: &mut MergeContext<T>,
-    path: &str,
+    path: &mut String,
+    segment: &str,
     key_of: impl Fn(&V) -> K,
-    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, String),
-    fmt_key: impl Fn(&K) -> String,
+    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord + Clone,
 {
@@ -121,7 +187,18 @@ pub(crate) fn merge_opt_vec_by_key<T, V, K>(
     }
     let Some(other) = other else { return };
     match base {
-        Some(base_v) => merge_vec_by_key(base_v, other, ctx, path, key_of, recurse, fmt_key),
+        Some(base_v) => {
+            let mut guard = PathGuard::new(path, segment);
+            merge_vec_by_key(
+                base_v,
+                other,
+                ctx,
+                guard.path_mut(),
+                key_of,
+                recurse,
+                fmt_key,
+            );
+        }
         None => *base = Some(other),
     }
 }
@@ -131,17 +208,13 @@ pub(crate) fn merge_opt_vec_by_key<T, V, K>(
 /// is recorded — adding more tags / `required` entries is purely
 /// additive.
 ///
-/// Linear-scan dedup: `Vec::contains` against the grown base. Zero
-/// allocations beyond the `Vec::push` itself — the previous
-/// implementation built a `BTreeSet<V>` by cloning every base
-/// element, then `insert`-cloned every incoming probe, paying
-/// `2·|base| + |incoming|` clones. For the typical `tags` / `required`
-/// list (handful of entries) the linear scan is faster anyway.
+/// Linear-scan dedup: `Vec::contains` against the grown base.
 pub(crate) fn merge_opt_vec_set_union<T, V>(
     base: &mut Option<Vec<V>>,
     other: Option<Vec<V>>,
     ctx: &mut MergeContext<T>,
-    _path: &str,
+    _path: &mut String,
+    _segment: &str,
 ) where
     V: Eq,
 {
@@ -164,11 +237,15 @@ pub(crate) fn merge_opt_vec_set_union<T, V>(
 /// Merge an optional scalar. `None × x` keeps `x`. `Some(a) × Some(b)`
 /// where `a == b` is a no-op. Mismatching values run through the
 /// three-mode policy.
+///
+/// `segment` is appended onto `path` only when a real conflict is
+/// recorded — the non-conflict path never grows `path`.
 pub(crate) fn merge_opt_scalar<T, V>(
     base: &mut Option<V>,
     other: Option<V>,
     ctx: &mut MergeContext<T>,
-    path: &str,
+    path: &mut String,
+    segment: &str,
     kind: ConflictKind,
 ) where
     V: PartialEq,
@@ -180,8 +257,11 @@ pub(crate) fn merge_opt_scalar<T, V>(
         (_, None) => {}
         (None, Some(v)) => *base = Some(v),
         (Some(a), Some(b)) => {
-            if *a != b && ctx.should_take_incoming(path, kind) {
-                *a = b;
+            if *a != b {
+                let take = with_segment(path, segment, |p| ctx.should_take_incoming(p, kind));
+                if take {
+                    *a = b;
+                }
             }
         }
     }
@@ -194,7 +274,8 @@ pub(crate) fn merge_required_scalar<T, V>(
     base: &mut V,
     other: V,
     ctx: &mut MergeContext<T>,
-    path: &str,
+    path: &mut String,
+    segment: &str,
     kind: ConflictKind,
 ) where
     V: PartialEq,
@@ -202,8 +283,11 @@ pub(crate) fn merge_required_scalar<T, V>(
     if ctx.errored {
         return;
     }
-    if *base != other && ctx.should_take_incoming(path, kind) {
-        *base = other;
+    if *base != other {
+        let take = with_segment(path, segment, |p| ctx.should_take_incoming(p, kind));
+        if take {
+            *base = other;
+        }
     }
 }
 
@@ -214,7 +298,8 @@ pub(crate) fn merge_replace_list_when_nonempty<T, V>(
     base: &mut Option<Vec<V>>,
     other: Option<Vec<V>>,
     ctx: &mut MergeContext<T>,
-    path: &str,
+    path: &mut String,
+    segment: &str,
 ) {
     if ctx.errored {
         return;
@@ -227,7 +312,10 @@ pub(crate) fn merge_replace_list_when_nonempty<T, V>(
     }
     match base {
         Some(b) if !b.is_empty() => {
-            if ctx.should_take_incoming(path, ConflictKind::ListReplaced) {
+            let take = with_segment(path, segment, |p| {
+                ctx.should_take_incoming(p, ConflictKind::ListReplaced)
+            });
+            if take {
                 *b = other;
             }
         }
@@ -242,13 +330,15 @@ pub(crate) fn merge_extensions<T>(
     base: &mut Option<BTreeMap<String, serde_json::Value>>,
     other: Option<BTreeMap<String, serde_json::Value>>,
     ctx: &mut MergeContext<T>,
-    path: &str,
+    path: &mut String,
+    segment: &str,
 ) {
     if ctx.errored {
         return;
     }
     let Some(other) = other else { return };
     let base_map = base.get_or_insert_with(BTreeMap::new);
+    let mut guard = PathGuard::new(path, segment);
     for (k, incoming) in other {
         match base_map.get_mut(&k) {
             None => {
@@ -256,8 +346,11 @@ pub(crate) fn merge_extensions<T>(
             }
             Some(existing) => {
                 if *existing != incoming {
-                    let child = format!("{path}.{k}");
-                    if ctx.should_take_incoming(&child, ConflictKind::ScalarOverridden) {
+                    let take = with_segment(guard.path_mut(), ".", |p| {
+                        p.push_str(&k);
+                        ctx.should_take_incoming(p, ConflictKind::ScalarOverridden)
+                    });
+                    if take {
                         *existing = incoming;
                     }
                 }
@@ -275,7 +368,8 @@ pub(crate) fn merge_opt_struct<T, S>(
     base: &mut Option<S>,
     other: Option<S>,
     ctx: &mut MergeContext<T>,
-    path: &str,
+    path: &mut String,
+    segment: &str,
 ) where
     S: MergeWithContext<T>,
 {
@@ -285,7 +379,10 @@ pub(crate) fn merge_opt_struct<T, S>(
     match (base.as_mut(), other) {
         (_, None) => {}
         (None, Some(v)) => *base = Some(v),
-        (Some(a), Some(b)) => a.merge_with_context(b, ctx, path.to_owned()),
+        (Some(a), Some(b)) => {
+            let mut guard = PathGuard::new(path, segment);
+            a.merge_with_context(b, ctx, guard.path_mut());
+        }
     }
 }
 
@@ -294,30 +391,39 @@ mod tests {
     use super::*;
     use crate::merge::{ConflictKind, MergeOptions};
 
+    fn root_path() -> String {
+        "#".to_owned()
+    }
+
     #[test]
     fn merge_opt_scalar_none_incoming_no_op() {
         let mut base: Option<String> = Some("a".into());
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
         merge_opt_scalar(
             &mut base,
             None,
             &mut ctx,
-            "#.x",
+            &mut path,
+            ".x",
             ConflictKind::ScalarOverridden,
         );
         assert_eq!(base.as_deref(), Some("a"));
         assert!(ctx.conflicts.is_empty());
+        assert_eq!(path, "#", "path stack must be balanced");
     }
 
     #[test]
     fn merge_opt_scalar_none_base_takes_incoming() {
         let mut base: Option<String> = None;
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
         merge_opt_scalar(
             &mut base,
             Some("b".into()),
             &mut ctx,
-            "#.x",
+            &mut path,
+            ".x",
             ConflictKind::ScalarOverridden,
         );
         assert_eq!(base.as_deref(), Some("b"));
@@ -328,11 +434,13 @@ mod tests {
     fn merge_opt_scalar_same_value_no_conflict() {
         let mut base: Option<String> = Some("a".into());
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
         merge_opt_scalar(
             &mut base,
             Some("a".into()),
             &mut ctx,
-            "#.x",
+            &mut path,
+            ".x",
             ConflictKind::ScalarOverridden,
         );
         assert_eq!(base.as_deref(), Some("a"));
@@ -343,22 +451,27 @@ mod tests {
     fn merge_opt_scalar_differing_takes_incoming_by_default() {
         let mut base: Option<String> = Some("a".into());
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
         merge_opt_scalar(
             &mut base,
             Some("b".into()),
             &mut ctx,
-            "#.x",
+            &mut path,
+            ".x",
             ConflictKind::ScalarOverridden,
         );
         assert_eq!(base.as_deref(), Some("b"));
         assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].path, "#.x", "conflict path materialised");
+        assert_eq!(path, "#", "path stack balanced after conflict");
     }
 
     #[test]
     fn merge_opt_vec_set_union_dedupes_and_preserves_base_order() {
         let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        merge_opt_vec_set_union(&mut base, Some(vec![2, 3]), &mut ctx, "#.x");
+        let mut path = root_path();
+        merge_opt_vec_set_union(&mut base, Some(vec![2, 3]), &mut ctx, &mut path, ".x");
         assert_eq!(base.unwrap(), vec![1, 2, 3]);
         assert!(ctx.conflicts.is_empty());
     }
@@ -373,17 +486,20 @@ mod tests {
         let mut other = BTreeMap::new();
         other.insert("x-b".into(), serde_json::json!(2));
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        merge_extensions(&mut base, Some(other), &mut ctx, "#.x");
+        let mut path = root_path();
+        merge_extensions(&mut base, Some(other), &mut ctx, &mut path, ".ext");
         let b = base.unwrap();
         assert_eq!(b.get("x-a"), Some(&serde_json::json!(1)));
         assert_eq!(b.get("x-b"), Some(&serde_json::json!(2)));
+        assert_eq!(path, "#", "path balanced");
     }
 
     #[test]
     fn merge_replace_list_keeps_populated_base_when_incoming_empty() {
         let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        merge_replace_list_when_nonempty(&mut base, Some(vec![]), &mut ctx, "#.x");
+        let mut path = root_path();
+        merge_replace_list_when_nonempty(&mut base, Some(vec![]), &mut ctx, &mut path, ".servers");
         assert_eq!(base, Some(vec![1, 2]));
         assert!(ctx.conflicts.is_empty());
     }
@@ -392,9 +508,41 @@ mod tests {
     fn merge_replace_list_replaces_when_both_non_empty() {
         let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        merge_replace_list_when_nonempty(&mut base, Some(vec![9, 10]), &mut ctx, "#.x");
+        let mut path = root_path();
+        merge_replace_list_when_nonempty(
+            &mut base,
+            Some(vec![9, 10]),
+            &mut ctx,
+            &mut path,
+            ".servers",
+        );
         assert_eq!(base, Some(vec![9, 10]));
         assert_eq!(ctx.conflicts.len(), 1);
         assert_eq!(ctx.conflicts[0].kind, ConflictKind::ListReplaced);
+        assert_eq!(ctx.conflicts[0].path, "#.servers");
+    }
+
+    #[test]
+    fn path_guard_restores_path_on_drop() {
+        let mut path = "#.foo".to_owned();
+        {
+            let guard = PathGuard::new(&mut path, ".bar");
+            assert_eq!(guard.as_str(), "#.foo.bar");
+        }
+        assert_eq!(path, "#.foo");
+    }
+
+    #[test]
+    fn path_guard_restores_path_on_drop_with_nested_guards() {
+        let mut path = "#".to_owned();
+        {
+            let mut g1 = PathGuard::new(&mut path, ".a");
+            {
+                let g2 = PathGuard::new(g1.path_mut(), ".b");
+                assert_eq!(g2.as_str(), "#.a.b");
+            }
+            assert_eq!(g1.as_str(), "#.a");
+        }
+        assert_eq!(path, "#");
     }
 }

--- a/crates/roas/src/common/merge.rs
+++ b/crates/roas/src/common/merge.rs
@@ -5,13 +5,19 @@
 //! them with its own `V`. The dedup-policy decision (per-version files
 //! stay duplicated except `reference.rs`) is preserved.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use crate::merge::{ConflictKind, MergeContext, MergeWithContext};
 
 /// Merge two bare `BTreeMap`s by key. Used by `Paths`, `Callback`,
 /// `Components.<bag>` (each bag is `Option<BTreeMap<...>>` — wrap with
 /// [`merge_opt_map`] for those).
+///
+/// All helpers in this module no-op when `ctx.errored` is already
+/// set, so callers do not need to interleave `if ctx.errored { return; }`
+/// checks between successive calls. The first helper to record a
+/// `Resolution::Errored` flips the flag and every subsequent helper
+/// returns early.
 pub(crate) fn merge_map<T, K, V>(
     base: &mut BTreeMap<K, V>,
     other: BTreeMap<K, V>,
@@ -22,6 +28,9 @@ pub(crate) fn merge_map<T, K, V>(
 ) where
     K: Ord,
 {
+    if ctx.errored {
+        return;
+    }
     for (k, incoming) in other {
         if let Some(base_v) = base.get_mut(&k) {
             let child_path = format!("{path}.{}", fmt_key(&k));
@@ -47,6 +56,9 @@ pub(crate) fn merge_opt_map<T, K, V>(
 ) where
     K: Ord,
 {
+    if ctx.errored {
+        return;
+    }
     let Some(other) = other else { return };
     match base {
         Some(base_map) => merge_map(base_map, other, ctx, path, recurse, fmt_key),
@@ -68,6 +80,9 @@ pub(crate) fn merge_vec_by_key<T, V, K>(
 ) where
     K: Ord + Clone,
 {
+    if ctx.errored {
+        return;
+    }
     use std::collections::BTreeMap as Map;
     let mut index: Map<K, usize> = Map::new();
     for (i, v) in base.iter().enumerate() {
@@ -101,6 +116,9 @@ pub(crate) fn merge_opt_vec_by_key<T, V, K>(
 ) where
     K: Ord + Clone,
 {
+    if ctx.errored {
+        return;
+    }
     let Some(other) = other else { return };
     match base {
         Some(base_v) => merge_vec_by_key(base_v, other, ctx, path, key_of, recurse, fmt_key),
@@ -108,24 +126,33 @@ pub(crate) fn merge_opt_vec_by_key<T, V, K>(
     }
 }
 
-/// Set-union an `Option<Vec<V: Ord + Eq>>` while preserving the base
-/// order (incoming-only entries appended in incoming order). No
-/// conflict is recorded — adding more tags / `required` entries is
-/// purely additive.
+/// Set-union an `Option<Vec<V>>` while preserving the base order
+/// (incoming-only entries appended in incoming order). No conflict
+/// is recorded — adding more tags / `required` entries is purely
+/// additive.
+///
+/// Linear-scan dedup: `Vec::contains` against the grown base. Zero
+/// allocations beyond the `Vec::push` itself — the previous
+/// implementation built a `BTreeSet<V>` by cloning every base
+/// element, then `insert`-cloned every incoming probe, paying
+/// `2·|base| + |incoming|` clones. For the typical `tags` / `required`
+/// list (handful of entries) the linear scan is faster anyway.
 pub(crate) fn merge_opt_vec_set_union<T, V>(
     base: &mut Option<Vec<V>>,
     other: Option<Vec<V>>,
-    _ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext<T>,
     _path: &str,
 ) where
-    V: Ord + Clone,
+    V: Eq,
 {
+    if ctx.errored {
+        return;
+    }
     let Some(other) = other else { return };
     match base {
         Some(base_v) => {
-            let mut seen: BTreeSet<V> = base_v.iter().cloned().collect();
             for v in other {
-                if seen.insert(v.clone()) {
+                if !base_v.contains(&v) {
                     base_v.push(v);
                 }
             }
@@ -146,6 +173,9 @@ pub(crate) fn merge_opt_scalar<T, V>(
 ) where
     V: PartialEq,
 {
+    if ctx.errored {
+        return;
+    }
     match (base.as_mut(), other) {
         (_, None) => {}
         (None, Some(v)) => *base = Some(v),
@@ -169,6 +199,9 @@ pub(crate) fn merge_required_scalar<T, V>(
 ) where
     V: PartialEq,
 {
+    if ctx.errored {
+        return;
+    }
     if *base != other && ctx.should_take_incoming(path, kind) {
         *base = other;
     }
@@ -183,6 +216,9 @@ pub(crate) fn merge_replace_list_when_nonempty<T, V>(
     ctx: &mut MergeContext<T>,
     path: &str,
 ) {
+    if ctx.errored {
+        return;
+    }
     use crate::merge::MergeOptions;
     let replace_when_empty = ctx.is_option(MergeOptions::ReplaceListsWhenEmpty);
     let Some(other) = other else { return };
@@ -208,6 +244,9 @@ pub(crate) fn merge_extensions<T>(
     ctx: &mut MergeContext<T>,
     path: &str,
 ) {
+    if ctx.errored {
+        return;
+    }
     let Some(other) = other else { return };
     let base_map = base.get_or_insert_with(BTreeMap::new);
     for (k, incoming) in other {
@@ -240,6 +279,9 @@ pub(crate) fn merge_opt_struct<T, S>(
 ) where
     S: MergeWithContext<T>,
 {
+    if ctx.errored {
+        return;
+    }
     match (base.as_mut(), other) {
         (_, None) => {}
         (None, Some(v)) => *base = Some(v),

--- a/crates/roas/src/common/reference.rs
+++ b/crates/roas/src/common/reference.rs
@@ -1160,4 +1160,113 @@ mod tests {
         let src = std::error::Error::source(&e).expect("External must have a source");
         assert!(src.to_string().contains("no fetcher"));
     }
+
+    // ---- Merge coverage ----
+
+    use crate::merge::{ConflictKind, MergeContext, MergeOptions, MergeWithContext, Resolution};
+
+    impl MergeWithContext<()> for Foo {
+        fn merge_with_context(
+            &mut self,
+            other: Self,
+            ctx: &mut MergeContext<()>,
+            path: &mut String,
+        ) {
+            if self.foo != other.foo
+                && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden)
+            {
+                self.foo = other.foo;
+            }
+        }
+    }
+
+    fn merge_ctx(opts: enumset::EnumSet<MergeOptions>) -> MergeContext<'static, ()> {
+        MergeContext::new(&(), opts)
+    }
+
+    #[test]
+    fn refor_item_vs_ref_replaces_with_ref_vs_value_kind() {
+        // Opposite direction from the existing refor_ref_vs_item test.
+        let mut base: RefOr<Foo> = RefOr::new_item(Foo { foo: "x".into() });
+        let mut ctx = merge_ctx(MergeOptions::new());
+        let mut path = "#".to_owned();
+        base.merge_with_context(RefOr::new_ref("#/foo/A".to_owned()), &mut ctx, &mut path);
+        assert!(matches!(base, RefOr::Ref(_)));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::RefVsValue);
+    }
+
+    #[test]
+    fn ref_summary_description_merge_independently() {
+        let mut base = Ref {
+            reference: "#/c/A".into(),
+            summary: Some("base sum".into()),
+            description: None,
+        };
+        let incoming = Ref {
+            reference: "#/c/A".into(),
+            summary: None,
+            description: Some("inc desc".into()),
+        };
+        let mut ctx = merge_ctx(MergeOptions::new());
+        let mut path = "#.ref".to_owned();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        assert_eq!(base.summary.as_deref(), Some("base sum"));
+        assert_eq!(base.description.as_deref(), Some("inc desc"));
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn ref_summary_collision_records_conflict() {
+        let mut base = Ref {
+            reference: "#/c/A".into(),
+            summary: Some("a".into()),
+            description: None,
+        };
+        let mut ctx = merge_ctx(MergeOptions::new());
+        let mut path = "#.ref".to_owned();
+        base.merge_with_context(
+            Ref {
+                reference: "#/c/A".into(),
+                summary: Some("b".into()),
+                description: None,
+            },
+            &mut ctx,
+            &mut path,
+        );
+        assert_eq!(base.summary.as_deref(), Some("b"));
+        assert_eq!(ctx.conflicts.len(), 1);
+    }
+
+    #[test]
+    fn ref_or_base_wins_records_resolution_base() {
+        let mut base: RefOr<Foo> = RefOr::new_ref("#/A");
+        let mut ctx = merge_ctx(MergeOptions::BaseWins.only());
+        let mut path = "#".to_owned();
+        base.merge_with_context(RefOr::new_ref("#/B".to_owned()), &mut ctx, &mut path);
+        match base {
+            RefOr::Ref(r) => assert_eq!(r.reference, "#/A"),
+            _ => panic!("expected Ref"),
+        }
+        assert_eq!(ctx.conflicts[0].resolution, Resolution::Base);
+    }
+
+    #[test]
+    fn ref_or_errored_entry_short_circuits() {
+        let mut base: RefOr<Foo> = RefOr::new_item(Foo { foo: "x".into() });
+        let mut ctx = merge_ctx(MergeOptions::new());
+        ctx.errored = true;
+        let mut path = "#".to_owned();
+        base.merge_with_context(
+            RefOr::new_item(Foo { foo: "y".into() }),
+            &mut ctx,
+            &mut path,
+        );
+        // Errored entry → no-op; base unchanged, no new conflict.
+        match base {
+            RefOr::Item(f) => assert_eq!(f.foo, "x"),
+            _ => panic!(),
+        }
+        assert!(ctx.conflicts.is_empty());
+    }
 }

--- a/crates/roas/src/common/reference.rs
+++ b/crates/roas/src/common/reference.rs
@@ -452,8 +452,11 @@ where
         &mut self,
         other: Self,
         ctx: &mut crate::merge::MergeContext<T>,
-        path: String,
+        path: &mut String,
     ) {
+        if ctx.errored {
+            return;
+        }
         use crate::merge::ConflictKind;
         match (self, other) {
             (RefOr::Item(base), RefOr::Item(incoming)) => {
@@ -465,12 +468,12 @@ where
                 };
                 if base_ref.reference == incoming_ref.reference {
                     base_ref.merge_with_context(*incoming_ref, ctx, path);
-                } else if ctx.should_take_incoming(&path, ConflictKind::RefReplaced) {
+                } else if ctx.should_take_incoming(path, ConflictKind::RefReplaced) {
                     *slot = RefOr::Ref(incoming_ref);
                 }
             }
             (slot, incoming) => {
-                if ctx.should_take_incoming(&path, ConflictKind::RefVsValue) {
+                if ctx.should_take_incoming(path, ConflictKind::RefVsValue) {
                     *slot = incoming;
                 }
             }
@@ -483,7 +486,7 @@ impl<T> crate::merge::MergeWithContext<T> for Ref {
         &mut self,
         other: Self,
         ctx: &mut crate::merge::MergeContext<T>,
-        path: String,
+        path: &mut String,
     ) {
         use crate::common::merge::merge_opt_scalar;
         use crate::merge::ConflictKind;
@@ -491,17 +494,16 @@ impl<T> crate::merge::MergeWithContext<T> for Ref {
             &mut self.summary,
             other.summary,
             ctx,
-            &format!("{path}.summary"),
+            path,
+            ".summary",
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
     }

--- a/crates/roas/src/common/reference.rs
+++ b/crates/roas/src/common/reference.rs
@@ -442,6 +442,71 @@ impl Ref {
     }
 }
 
+// ---- merge ----
+
+impl<D, T> crate::merge::MergeWithContext<T> for RefOr<D>
+where
+    D: crate::merge::MergeWithContext<T>,
+{
+    fn merge_with_context(
+        &mut self,
+        other: Self,
+        ctx: &mut crate::merge::MergeContext<T>,
+        path: String,
+    ) {
+        use crate::merge::ConflictKind;
+        match (self, other) {
+            (RefOr::Item(base), RefOr::Item(incoming)) => {
+                base.merge_with_context(incoming, ctx, path);
+            }
+            (slot @ RefOr::Ref(_), RefOr::Ref(incoming_ref)) => {
+                let RefOr::Ref(base_ref) = slot else {
+                    unreachable!()
+                };
+                if base_ref.reference == incoming_ref.reference {
+                    base_ref.merge_with_context(*incoming_ref, ctx, path);
+                } else if ctx.should_take_incoming(&path, ConflictKind::RefReplaced) {
+                    *slot = RefOr::Ref(incoming_ref);
+                }
+            }
+            (slot, incoming) => {
+                if ctx.should_take_incoming(&path, ConflictKind::RefVsValue) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+impl<T> crate::merge::MergeWithContext<T> for Ref {
+    fn merge_with_context(
+        &mut self,
+        other: Self,
+        ctx: &mut crate::merge::MergeContext<T>,
+        path: String,
+    ) {
+        use crate::common::merge::merge_opt_scalar;
+        use crate::merge::ConflictKind;
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            &format!("{path}.summary"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+    }
+}
+
 /// Resolve a `$ref` against a `Components`-style map, following alias
 /// chains iteratively with cycle detection.
 ///

--- a/crates/roas/src/lib.rs
+++ b/crates/roas/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod common;
 pub mod loader;
+pub mod merge;
 pub mod validation;
 
 #[cfg(feature = "v2")]

--- a/crates/roas/src/merge.rs
+++ b/crates/roas/src/merge.rs
@@ -1,0 +1,379 @@
+//! Public merge API and crate-internal recursion machinery.
+//!
+//! Sits parallel to [`crate::validation`]:
+//!
+//! * The public [`Merge`] trait is what callers reach for — `base.merge(incoming, opts)`.
+//! * [`MergeWithContext<T>`] is the crate-internal recursive trait every
+//!   component type implements. Implementors mutate `self` in place,
+//!   record [`MergeConflict`]s into [`MergeContext::conflicts`], and
+//!   recurse into children via each child's `merge_with_context`. The
+//!   shape mirrors [`crate::validation::ValidateWithContext`] one-for-one.
+//! * [`MergeOptions`] is an `EnumSet`-compatible flag enum. The default
+//!   set is `EnumSet::empty()` (incoming wins, refs replace silently,
+//!   schemas are leaves, info is preserved from base).
+
+use enumset::{EnumSet, EnumSetType};
+use std::collections::HashSet;
+use std::fmt::{self, Display};
+use thiserror::Error as ThisError;
+
+/// Per-call flags toggling merge behavior.
+///
+/// All flags are *off* by default. The defaults are:
+///
+/// * **Conflict policy** — incoming wins.
+/// * **Refs** — `Ref × Ref` with the same target merges metadata; with
+///   different targets, incoming replaces. `Ref × Item` (in either
+///   order) — incoming replaces. Every replacement is recorded as a
+///   [`MergeConflict`] regardless.
+/// * **Schemas** — treated as leaves (incoming replaces, recorded as
+///   [`ConflictKind::SchemaLeafReplaced`]).
+/// * **`info` / `openapi`** — kept from the base spec (the document
+///   keeps its identity).
+/// * **Lists like `servers` / `security`** — incoming replaces only
+///   when non-empty.
+#[derive(EnumSetType, Debug)]
+pub enum MergeOptions {
+    /// Reverse the default "incoming wins" policy: when both sides
+    /// have a value at the same path, the base value is kept and the
+    /// incoming value is dropped (still recorded as a conflict with
+    /// [`Resolution::Base`]).
+    ///
+    /// Has no effect when only one side has a value, or for additive
+    /// operations (new map keys, list-by-key new entries).
+    BaseWins,
+
+    /// Convert the first real collision into an early `Err`. The
+    /// returned [`MergeError`] carries the conflicts collected up to
+    /// that point (including the one that tripped the error).
+    ///
+    /// "Real" excludes additive merges: new map keys, identity-keyed
+    /// list entries, and `Some` replacing `None`. Same-value
+    /// collisions (where base and incoming compare equal) are also
+    /// considered no-ops and do not trip this flag.
+    ErrorOnConflict,
+
+    /// Opt into deep-merging two object schemas. Without this flag,
+    /// `Schema` collisions are always replace-incoming-wins (recorded
+    /// as [`ConflictKind::SchemaLeafReplaced`]).
+    ///
+    /// When set, two `Schema::Single(SingleSchema::Object(_))` values
+    /// merge their `properties`, `pattern_properties`, `required`
+    /// (set-union), `additional_properties`, `property_names`, and
+    /// scalar fields recursively. Other schema-variant pairings
+    /// (`AllOf`, `OneOf`, `Bool`, `Multi`, `String`, etc.) still
+    /// replace.
+    DeepMergeObjectSchemas,
+
+    /// Drop the "keep base `info` / `openapi`" guarantee and merge
+    /// those fields like any other component. Off by default because
+    /// the document's identity (title, version, OpenAPI version)
+    /// usually belongs to the base.
+    MergeInfo,
+
+    /// Allow an empty incoming list to clear a populated base list.
+    /// Off by default because most callers want a missing or empty
+    /// list in the incoming document to mean "I have nothing to say
+    /// about this," not "delete what's there."
+    ///
+    /// Applies to `Spec.servers`, `Spec.security`, `Operation.servers`,
+    /// `Operation.security`, `PathItem.servers`.
+    ReplaceListsWhenEmpty,
+}
+
+impl MergeOptions {
+    /// Empty option set — the default behavior described in the
+    /// [enum's doc comment](MergeOptions).
+    pub fn new() -> EnumSet<MergeOptions> {
+        EnumSet::empty()
+    }
+
+    /// Set containing only `self`.
+    pub fn only(&self) -> EnumSet<MergeOptions> {
+        EnumSet::only(*self)
+    }
+}
+
+/// Resolution applied to a single collision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Resolution {
+    /// Incoming value was taken — the default policy.
+    Incoming,
+    /// Base value was kept — under [`MergeOptions::BaseWins`].
+    Base,
+    /// [`MergeOptions::ErrorOnConflict`] tripped on this collision.
+    /// The conflict is the last entry in the returned
+    /// [`MergeError::conflicts`].
+    Errored,
+}
+
+/// What kind of collision was resolved at a given path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ConflictKind {
+    /// An optional scalar was set on both sides with different values.
+    ScalarOverridden,
+
+    /// A required scalar (e.g. `info.title`) was set on both sides
+    /// with different values, and the merge policy kept one of them.
+    RequiredScalarOverridden,
+
+    /// `Ref × Ref` with different target strings.
+    RefReplaced,
+
+    /// `Ref × Item` (in either direction). The replacement is silent
+    /// — neither side knows whether the ref resolves to a structurally
+    /// compatible value.
+    RefVsValue,
+
+    /// Two `Schema` values collided and the leaf-replace policy was
+    /// applied (default behavior, or applied because the variants
+    /// don't match the [`MergeOptions::DeepMergeObjectSchemas`] gate).
+    SchemaLeafReplaced,
+
+    /// A whole `Option<Vec<T>>` was replaced wholesale (non-keyed
+    /// lists like `servers` / `security`).
+    ListReplaced,
+
+    /// A `Parameter` of one location collided with one of a different
+    /// location (e.g. `InPath` × `InQuery`). The location is the
+    /// identity, so the merge is a replace; deep-merge would not make
+    /// sense.
+    ParameterVariantMismatch,
+}
+
+impl Display for ConflictKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ConflictKind::ScalarOverridden => "scalar overridden",
+            ConflictKind::RequiredScalarOverridden => "required scalar overridden",
+            ConflictKind::RefReplaced => "ref replaced",
+            ConflictKind::RefVsValue => "ref/value mismatch",
+            ConflictKind::SchemaLeafReplaced => "schema leaf replaced",
+            ConflictKind::ListReplaced => "list replaced",
+            ConflictKind::ParameterVariantMismatch => "parameter variant mismatch",
+        })
+    }
+}
+
+/// One recorded resolution. Built by [`MergeContext::should_take_incoming`]
+/// and the helpers in [`crate::common::merge`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MergeConflict {
+    pub path: String,
+    pub kind: ConflictKind,
+    pub resolution: Resolution,
+}
+
+impl Display for MergeConflict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {} ({:?})", self.path, self.kind, self.resolution)
+    }
+}
+
+/// The successful return value of [`Merge::merge`]. Carries every
+/// collision that the merge resolved, including same-value collisions
+/// the caller might want to verify.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct MergeReport {
+    pub conflicts: Vec<MergeConflict>,
+}
+
+impl MergeReport {
+    pub fn is_empty(&self) -> bool {
+        self.conflicts.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.conflicts.len()
+    }
+}
+
+impl Display for MergeReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{} merge conflicts:", self.conflicts.len())?;
+        for c in &self.conflicts {
+            writeln!(f, "- {c}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Returned when [`MergeOptions::ErrorOnConflict`] is set and a real
+/// collision is hit. Carries every conflict collected up to and
+/// including the one that tripped the error.
+#[derive(Debug, Clone, PartialEq, ThisError)]
+#[error("merge aborted on conflict")]
+pub struct MergeError {
+    pub conflicts: Vec<MergeConflict>,
+}
+
+/// Public entry point for merging. Implemented for each per-version
+/// `Spec` type; v3.2 ships first, v2 / v3.0 / v3.1 follow.
+pub trait Merge: Sized {
+    /// Merge `other` into `self` in place, following the rules
+    /// determined by `options`.
+    ///
+    /// Returns a [`MergeReport`] listing every collision (even ones
+    /// resolved silently). Returns [`MergeError`] only when
+    /// [`MergeOptions::ErrorOnConflict`] is set and a real collision
+    /// was hit.
+    fn merge(
+        &mut self,
+        other: Self,
+        options: EnumSet<MergeOptions>,
+    ) -> Result<MergeReport, MergeError>;
+}
+
+/// Crate-internal recursive merge trait. Mirrors
+/// [`crate::validation::ValidateWithContext`].
+pub(crate) trait MergeWithContext<T> {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<T>, path: String);
+}
+
+/// Merge context — carries the spec being merged into, the options,
+/// accumulated conflicts, and a `visited` set for cycle safety
+/// during nested-ref / nested-schema recursion.
+pub(crate) struct MergeContext<'a, T> {
+    pub spec: &'a T,
+    pub options: EnumSet<MergeOptions>,
+    pub visited: HashSet<String>,
+    pub conflicts: Vec<MergeConflict>,
+    /// Set by [`Self::should_take_incoming`] when
+    /// [`MergeOptions::ErrorOnConflict`] is engaged and a real
+    /// collision has been recorded. Implementors check this after
+    /// each potentially-conflicting step and short-circuit further
+    /// merging.
+    pub errored: bool,
+}
+
+impl<T> MergeContext<'_, T> {
+    pub fn is_option(&self, o: MergeOptions) -> bool {
+        self.options.contains(o)
+    }
+
+    #[allow(dead_code)]
+    pub fn visit(&mut self, path: String) -> bool {
+        self.visited.insert(path)
+    }
+
+    pub fn record(&mut self, path: String, kind: ConflictKind, resolution: Resolution) {
+        self.conflicts.push(MergeConflict {
+            path,
+            kind,
+            resolution,
+        });
+    }
+
+    /// Apply the three-mode policy to a single collision. Records the
+    /// conflict and returns `true` when the caller should overwrite
+    /// `base` with `incoming`, `false` when the caller should keep
+    /// `base`.
+    ///
+    /// Under `ErrorOnConflict` this sets [`Self::errored`] and returns
+    /// `false` so the caller leaves `base` alone — the top-level
+    /// `Spec::merge` checks `errored` and converts the report into a
+    /// [`MergeError`] before returning.
+    pub fn should_take_incoming(&mut self, path: &str, kind: ConflictKind) -> bool {
+        if self.is_option(MergeOptions::ErrorOnConflict) {
+            self.record(path.to_owned(), kind, Resolution::Errored);
+            self.errored = true;
+            false
+        } else if self.is_option(MergeOptions::BaseWins) {
+            self.record(path.to_owned(), kind, Resolution::Base);
+            false
+        } else {
+            self.record(path.to_owned(), kind, Resolution::Incoming);
+            true
+        }
+    }
+}
+
+impl<T> MergeContext<'_, T> {
+    pub(crate) fn new<'a>(spec: &'a T, options: EnumSet<MergeOptions>) -> MergeContext<'a, T> {
+        MergeContext {
+            spec,
+            options,
+            visited: HashSet::new(),
+            conflicts: Vec::new(),
+            errored: false,
+        }
+    }
+}
+
+impl<'a, T> From<MergeContext<'a, T>> for Result<MergeReport, MergeError> {
+    fn from(ctx: MergeContext<'a, T>) -> Self {
+        if ctx.errored {
+            Err(MergeError {
+                conflicts: ctx.conflicts,
+            })
+        } else {
+            Ok(MergeReport {
+                conflicts: ctx.conflicts,
+            })
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for MergeContext<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MergeContext")
+            .field("spec", &self.spec)
+            .field("options", &self.options)
+            .field("visited", &self.visited)
+            .field("conflicts", &self.conflicts)
+            .field("errored", &self.errored)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_take_incoming_default_takes_incoming_and_records() {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let took = ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
+        assert!(took);
+        assert!(!ctx.errored);
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].resolution, Resolution::Incoming);
+    }
+
+    #[test]
+    fn should_take_incoming_base_wins_keeps_base() {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::BaseWins.only());
+        let took = ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
+        assert!(!took);
+        assert!(!ctx.errored);
+        assert_eq!(ctx.conflicts[0].resolution, Resolution::Base);
+    }
+
+    #[test]
+    fn should_take_incoming_error_mode_marks_errored() {
+        let mut ctx: MergeContext<()> =
+            MergeContext::new(&(), MergeOptions::ErrorOnConflict.only());
+        let took = ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
+        assert!(!took);
+        assert!(ctx.errored);
+        assert_eq!(ctx.conflicts[0].resolution, Resolution::Errored);
+    }
+
+    #[test]
+    fn context_into_result_returns_err_when_errored() {
+        let mut ctx: MergeContext<()> =
+            MergeContext::new(&(), MergeOptions::ErrorOnConflict.only());
+        ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
+        let res: Result<MergeReport, MergeError> = ctx.into();
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn context_into_result_returns_ok_with_report() {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
+        let res: Result<MergeReport, MergeError> = ctx.into();
+        let report = res.expect("ok");
+        assert_eq!(report.len(), 1);
+    }
+}

--- a/crates/roas/src/merge.rs
+++ b/crates/roas/src/merge.rs
@@ -40,6 +40,14 @@ pub enum MergeOptions {
     ///
     /// Has no effect when only one side has a value, or for additive
     /// operations (new map keys, list-by-key new entries).
+    ///
+    /// **Caveat:** unlike [`Self::ErrorOnConflict`], `BaseWins` does
+    /// **not** roll back additive mutations. If the caller inspects
+    /// `self` after a `BaseWins` merge, new map keys / new tags / new
+    /// status codes from the incoming spec will be present — only the
+    /// overwrite-of-existing path is suppressed. Pair with
+    /// [`Self::ErrorOnConflict`] (which dominates — see below) if you
+    /// need atomicity.
     BaseWins,
 
     /// Convert the first real collision into an early `Err`. The
@@ -50,6 +58,13 @@ pub enum MergeOptions {
     /// list entries, and `Some` replacing `None`. Same-value
     /// collisions (where base and incoming compare equal) are also
     /// considered no-ops and do not trip this flag.
+    ///
+    /// **Dominates [`Self::BaseWins`]:** when both are set, the first
+    /// real mismatch returns `Err` rather than silently keeping base.
+    /// The base spec is left untouched on error
+    /// ([`Merge::merge`] clones internally before mutating in this
+    /// mode), so `BaseWins`-style "keep what I have" is implicitly
+    /// upheld by the rollback.
     ErrorOnConflict,
 
     /// Opt into deep-merging two object schemas. Without this flag,

--- a/crates/roas/src/merge.rs
+++ b/crates/roas/src/merge.rs
@@ -405,4 +405,114 @@ mod tests {
         let report = res.expect("ok");
         assert_eq!(report.len(), 1);
     }
+
+    #[test]
+    fn merge_options_only_helper_returns_single_set() {
+        let only = MergeOptions::BaseWins.only();
+        assert!(only.contains(MergeOptions::BaseWins));
+        assert!(!only.contains(MergeOptions::ErrorOnConflict));
+        assert_eq!(only.len(), 1);
+    }
+
+    #[test]
+    fn merge_options_new_is_empty() {
+        assert!(MergeOptions::new().is_empty());
+    }
+
+    #[test]
+    fn merge_report_default_is_empty_and_len_zero() {
+        let r = MergeReport::default();
+        assert!(r.is_empty());
+        assert_eq!(r.len(), 0);
+    }
+
+    #[test]
+    fn merge_report_display_renders_count_and_bullets() {
+        let r = MergeReport {
+            conflicts: vec![
+                MergeConflict {
+                    path: "#.a".into(),
+                    kind: ConflictKind::ScalarOverridden,
+                    resolution: Resolution::Incoming,
+                },
+                MergeConflict {
+                    path: "#.b".into(),
+                    kind: ConflictKind::RefReplaced,
+                    resolution: Resolution::Base,
+                },
+            ],
+        };
+        let s = r.to_string();
+        assert!(s.starts_with("2 merge conflicts:"));
+        assert!(s.contains("- #.a: scalar overridden (Incoming)"));
+        assert!(s.contains("- #.b: ref replaced (Base)"));
+    }
+
+    #[test]
+    fn merge_report_display_empty_still_renders_header() {
+        let s = MergeReport::default().to_string();
+        assert!(s.starts_with("0 merge conflicts:"));
+    }
+
+    #[test]
+    fn merge_conflict_display_renders_path_kind_resolution() {
+        let c = MergeConflict {
+            path: "#.foo".into(),
+            kind: ConflictKind::ListReplaced,
+            resolution: Resolution::Errored,
+        };
+        assert_eq!(c.to_string(), "#.foo: list replaced (Errored)");
+    }
+
+    #[test]
+    fn conflict_kind_display_covers_every_variant() {
+        for (k, expected) in [
+            (ConflictKind::ScalarOverridden, "scalar overridden"),
+            (
+                ConflictKind::RequiredScalarOverridden,
+                "required scalar overridden",
+            ),
+            (ConflictKind::RefReplaced, "ref replaced"),
+            (ConflictKind::RefVsValue, "ref/value mismatch"),
+            (ConflictKind::SchemaLeafReplaced, "schema leaf replaced"),
+            (ConflictKind::ListReplaced, "list replaced"),
+            (
+                ConflictKind::ParameterVariantMismatch,
+                "parameter variant mismatch",
+            ),
+        ] {
+            assert_eq!(k.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn merge_error_display_shows_message() {
+        let err = MergeError {
+            conflicts: vec![MergeConflict {
+                path: "#".into(),
+                kind: ConflictKind::ScalarOverridden,
+                resolution: Resolution::Errored,
+            }],
+        };
+        assert_eq!(err.to_string(), "merge aborted on conflict");
+    }
+
+    #[test]
+    fn merge_context_debug_includes_state() {
+        let ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let s = format!("{ctx:?}");
+        assert!(s.contains("MergeContext"));
+        assert!(s.contains("conflicts: []"));
+        assert!(s.contains("errored: false"));
+    }
+
+    #[test]
+    fn merge_context_visit_inserts_path() {
+        // (`visit` was removed; the visited HashSet is gone too.)
+        // This test confirms the public surface no longer carries
+        // either by reaching into Debug — defensive against accidental
+        // re-introduction.
+        let ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        assert!(!format!("{ctx:?}").contains("visited"));
+    }
 }

--- a/crates/roas/src/merge.rs
+++ b/crates/roas/src/merge.rs
@@ -224,9 +224,25 @@ pub trait Merge: Sized {
 }
 
 /// Crate-internal recursive merge trait. Mirrors
-/// [`crate::validation::ValidateWithContext`].
+/// [`crate::validation::ValidateWithContext`], except the JSONPath
+/// locator is a `&mut String` push/truncate stack rather than an
+/// owned `String` rebuilt at every recursion level. Implementors
+/// push their child segments before recursing and truncate back
+/// when they return — concretely:
+///
+/// ```ignore
+/// let len = path.len();
+/// path.push_str(".myField");
+/// inner.merge_with_context(other, ctx, path);
+/// path.truncate(len);
+/// ```
+///
+/// The helpers in [`crate::common::merge`] do this internally so
+/// most call sites don't have to. This turns the previous
+/// O(nodes × fields) `format!` allocations into O(conflicts) —
+/// only the conflict-recording path materialises an owned `String`.
 pub(crate) trait MergeWithContext<T> {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<T>, path: String);
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<T>, path: &mut String);
 }
 
 /// Merge context — carries the spec being merged into, the options,

--- a/crates/roas/src/merge.rs
+++ b/crates/roas/src/merge.rs
@@ -13,7 +13,6 @@
 //!   schemas are leaves, info is preserved from base).
 
 use enumset::{EnumSet, EnumSetType};
-use std::collections::HashSet;
 use std::fmt::{self, Display};
 use thiserror::Error as ThisError;
 
@@ -231,12 +230,18 @@ pub(crate) trait MergeWithContext<T> {
 }
 
 /// Merge context — carries the spec being merged into, the options,
-/// accumulated conflicts, and a `visited` set for cycle safety
-/// during nested-ref / nested-schema recursion.
+/// and accumulated conflicts.
+///
+/// The `spec` back-reference is currently unused by every concrete
+/// `MergeWithContext` impl (merge recurses through owned subtrees, so
+/// there's nothing to resolve against the parent spec). It's kept on
+/// the type for symmetry with `validation::Context<T>` and so v2 /
+/// v3.0 / v3.1 ports can introduce ref-following merge later without
+/// reshaping every signature. If it stays unused once all four
+/// versions land, drop `T` / `spec` in a follow-up.
 pub(crate) struct MergeContext<'a, T> {
     pub spec: &'a T,
     pub options: EnumSet<MergeOptions>,
-    pub visited: HashSet<String>,
     pub conflicts: Vec<MergeConflict>,
     /// Set by [`Self::should_take_incoming`] when
     /// [`MergeOptions::ErrorOnConflict`] is engaged and a real
@@ -249,11 +254,6 @@ pub(crate) struct MergeContext<'a, T> {
 impl<T> MergeContext<'_, T> {
     pub fn is_option(&self, o: MergeOptions) -> bool {
         self.options.contains(o)
-    }
-
-    #[allow(dead_code)]
-    pub fn visit(&mut self, path: String) -> bool {
-        self.visited.insert(path)
     }
 
     pub fn record(&mut self, path: String, kind: ConflictKind, resolution: Resolution) {
@@ -293,7 +293,6 @@ impl<T> MergeContext<'_, T> {
         MergeContext {
             spec,
             options,
-            visited: HashSet::new(),
             conflicts: Vec::new(),
             errored: false,
         }
@@ -319,7 +318,6 @@ impl<T: fmt::Debug> fmt::Debug for MergeContext<'_, T> {
         f.debug_struct("MergeContext")
             .field("spec", &self.spec)
             .field("options", &self.options)
-            .field("visited", &self.visited)
             .field("conflicts", &self.conflicts)
             .field("errored", &self.errored)
             .finish()

--- a/crates/roas/src/v3_2.rs
+++ b/crates/roas/src/v3_2.rs
@@ -13,6 +13,7 @@ pub mod header;
 pub mod info;
 pub mod link;
 pub mod media_type;
+pub mod merge;
 pub mod operation;
 pub mod parameter;
 pub mod path_item;

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -42,11 +42,7 @@ use crate::v3_2::parameter::{InCookie, InHeader, InPath, InQuery, InQuerystring,
 use crate::v3_2::path_item::{PathItem, Paths};
 use crate::v3_2::request_body::RequestBody;
 use crate::v3_2::response::{Response, Responses};
-use crate::v3_2::schema::{
-    AllOfSchema, AnyOfSchema, ArraySchema, BooleanSchema, EmptySchema, IntegerSchema, MultiSchema,
-    NotSchema, NullSchema, NumberSchema, ObjectSchema, OneOfSchema, Schema, SingleSchema,
-    StringSchema,
-};
+use crate::v3_2::schema::{ObjectSchema, Schema, SingleSchema};
 use crate::v3_2::security_scheme::{
     ApiKeySecurityScheme, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow,
     DeviceAuthorizationOAuth2Flow, HttpSecurityScheme, ImplicitOAuth2Flow, MutualTLSSecurityScheme,
@@ -2540,47 +2536,13 @@ impl MergeWithContext<()> for ObjectSchema {
     }
 }
 
-// Schema sub-types that aren't recursively deep-merged still need a
-// `MergeWithContext<()>` impl so the generic `RefOr<X>::merge_with_context`
-// compiles when `X` is one of them. They land here as opaque leaves
-// (replace incoming-wins, recorded as `SchemaLeafReplaced`).
-macro_rules! leaf_schema_merge {
-    ($($t:ty),* $(,)?) => {
-        $(
-            impl MergeWithContext<()> for $t {
-                fn merge_with_context(
-                    &mut self,
-                    other: Self,
-                    ctx: &mut MergeContext<()>,
-                    path: &mut String,
-                ) {
-                    if ctx.errored { return; }
-                    if *self != other
-                        && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced)
-                    {
-                        *self = other;
-                    }
-                }
-            }
-        )*
-    };
-}
-
-leaf_schema_merge!(
-    EmptySchema,
-    StringSchema,
-    IntegerSchema,
-    NumberSchema,
-    BooleanSchema,
-    ArraySchema,
-    NullSchema,
-    AllOfSchema,
-    AnyOfSchema,
-    OneOfSchema,
-    NotSchema,
-    MultiSchema,
-    SingleSchema,
-);
+// Schema sub-types (StringSchema, IntegerSchema, …, SingleSchema)
+// don't need their own `MergeWithContext<()>` impls — `Schema`'s impl
+// handles the entire enum at the top level via `leaf_replace_schema`
+// for any pairing other than `Single(Object(_))` × `Single(Object(_))`.
+// Nothing in the codebase holds a `RefOr<StringSchema>` or
+// `&mut SingleSchema` directly, so the per-variant impls would be
+// dead code.
 
 #[cfg(test)]
 mod tests {
@@ -3363,5 +3325,1944 @@ mod tests {
                 .iter()
                 .any(|c| c.kind == ConflictKind::SchemaLeafReplaced)
         );
+    }
+
+    // ============================================================
+    // Coverage tests — one collision per component impl. Each builds
+    // two instances differing on a single field, merges, and asserts
+    // either a conflict was recorded or a merge happened. Keeps each
+    // case small; the structural correctness is already covered by
+    // the targeted tests above.
+    // ============================================================
+
+    fn root_path() -> String {
+        "#".to_owned()
+    }
+
+    fn run<S: MergeWithContext<()>>(mut base: S, incoming: S, opts: EnumSet<MergeOptions>) -> S {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut path = root_path();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        base
+    }
+
+    fn report<S: MergeWithContext<()>>(
+        base: &mut S,
+        incoming: S,
+        opts: EnumSet<MergeOptions>,
+    ) -> Vec<crate::merge::MergeConflict> {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut path = root_path();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        ctx.conflicts
+    }
+
+    fn mk_encoding(content_type: Option<&str>) -> crate::v3_2::media_type::Encoding {
+        crate::v3_2::media_type::Encoding {
+            content_type: content_type.map(str::to_owned),
+            headers: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            encoding: None,
+            prefix_encoding: None,
+            item_encoding: None,
+            extensions: None,
+        }
+    }
+
+    // ---- ExternalDocumentation ----
+
+    #[test]
+    fn external_documentation_field_merges() {
+        let mut base = ExternalDocumentation {
+            url: "https://a".into(),
+            description: Some("old".into()),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            ExternalDocumentation {
+                url: "https://b".into(),
+                description: Some("new".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.url, "https://b");
+        assert_eq!(base.description.as_deref(), Some("new"));
+        assert_eq!(conflicts.len(), 2);
+    }
+
+    // ---- Info / Contact / License ----
+
+    #[test]
+    fn contact_field_merges() {
+        let mut base = Contact {
+            name: Some("Alice".into()),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Contact {
+                name: Some("Bob".into()),
+                url: Some("https://b".into()),
+                email: Some("b@x".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.name.as_deref(), Some("Bob"));
+        assert_eq!(base.url.as_deref(), Some("https://b"));
+        assert_eq!(base.email.as_deref(), Some("b@x"));
+        assert_eq!(conflicts.len(), 1); // only `name` collided
+    }
+
+    #[test]
+    fn license_required_name_with_optional_fields() {
+        let mut base = License {
+            name: "MIT".into(),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            License {
+                name: "Apache-2.0".into(),
+                identifier: Some("Apache-2.0".into()),
+                url: Some("https://apache.org".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.name, "Apache-2.0");
+        assert_eq!(base.identifier.as_deref(), Some("Apache-2.0"));
+        assert_eq!(base.url.as_deref(), Some("https://apache.org"));
+        assert_eq!(conflicts.len(), 1); // name required-scalar collision
+        assert_eq!(conflicts[0].kind, ConflictKind::RequiredScalarOverridden);
+    }
+
+    #[test]
+    fn info_terms_of_service_and_extensions() {
+        use crate::v3_2::info::Info;
+        let mut base = Info {
+            title: "Base".into(),
+            version: "1.0.0".into(),
+            terms_of_service: Some("base tos".into()),
+            extensions: Some(BTreeMap::from([("x-a".into(), serde_json::json!(1))])),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Info {
+                title: "Base".into(),
+                version: "1.0.0".into(),
+                terms_of_service: Some("incoming tos".into()),
+                extensions: Some(BTreeMap::from([("x-b".into(), serde_json::json!(2))])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.terms_of_service.as_deref(), Some("incoming tos"));
+        let ext = base.extensions.unwrap();
+        assert!(ext.contains_key("x-a"));
+        assert!(ext.contains_key("x-b"));
+        assert!(!conflicts.is_empty());
+    }
+
+    // ---- Discriminator ----
+
+    #[test]
+    fn discriminator_default_mapping_merges() {
+        use crate::v3_2::discriminator::Discriminator;
+        let mut base = Discriminator {
+            property_name: "kind".into(),
+            default_mapping: Some("a".into()),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Discriminator {
+                property_name: "kind".into(),
+                mapping: Some(BTreeMap::from([("a".into(), "#/c/A".into())])),
+                default_mapping: Some("b".into()),
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.default_mapping.as_deref(), Some("b"));
+        assert!(base.mapping.is_some());
+        assert_eq!(conflicts.len(), 1);
+    }
+
+    #[test]
+    fn discriminator_mapping_initially_none_takes_incoming() {
+        use crate::v3_2::discriminator::Discriminator;
+        let mut base = Discriminator {
+            property_name: "kind".into(),
+            mapping: None,
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Discriminator {
+                property_name: "kind".into(),
+                mapping: Some(BTreeMap::from([("a".into(), "#/c/A".into())])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert!(base.mapping.is_some());
+        assert!(conflicts.is_empty());
+    }
+
+    // ---- XML ----
+
+    #[test]
+    fn xml_full_field_merge() {
+        use crate::v3_2::xml::XML;
+        let mut base = XML {
+            name: Some("xa".into()),
+            namespace: Some("ns".into()),
+            ..Default::default()
+        };
+        let merged = run(
+            base.clone(),
+            XML {
+                name: Some("xb".into()),
+                prefix: Some("p".into()),
+                attribute: Some(true),
+                wrapped: Some(false),
+                node_type: Some("element".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(merged.name.as_deref(), Some("xb"));
+        assert_eq!(merged.namespace.as_deref(), Some("ns"));
+        assert_eq!(merged.prefix.as_deref(), Some("p"));
+        assert_eq!(merged.attribute, Some(true));
+        let _ = &mut base;
+    }
+
+    // ---- Server / ServerVariable ----
+
+    #[test]
+    fn server_full_field_merge() {
+        use crate::v3_2::server::Server;
+        let mut base = Server {
+            url: "https://api1".into(),
+            name: Some("primary".into()),
+            description: Some("old".into()),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Server {
+                url: "https://api2".into(),
+                name: Some("secondary".into()),
+                description: Some("new".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.url, "https://api2");
+        assert_eq!(base.name.as_deref(), Some("secondary"));
+        assert_eq!(base.description.as_deref(), Some("new"));
+        // url required-scalar + name + description optional-scalar
+        assert!(conflicts.len() >= 3);
+    }
+
+    // ---- Tag with all optional fields ----
+
+    #[test]
+    fn tag_full_field_merge() {
+        let mut base = Tag {
+            name: "pets".into(),
+            summary: Some("base sum".into()),
+            description: Some("base desc".into()),
+            external_docs: Some(ExternalDocumentation {
+                url: "https://docs.a".into(),
+                ..Default::default()
+            }),
+            parent: Some("animals".into()),
+            kind: Some("entity".into()),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Tag {
+                name: "pets".into(),
+                summary: Some("inc sum".into()),
+                description: Some("inc desc".into()),
+                external_docs: Some(ExternalDocumentation {
+                    url: "https://docs.b".into(),
+                    ..Default::default()
+                }),
+                parent: Some("creatures".into()),
+                kind: Some("group".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.summary.as_deref(), Some("inc sum"));
+        assert_eq!(base.parent.as_deref(), Some("creatures"));
+        assert_eq!(base.kind.as_deref(), Some("group"));
+        assert!(!conflicts.is_empty());
+    }
+
+    // ---- MediaType + Encoding ----
+
+    #[test]
+    fn media_type_examples_and_encoding_merge() {
+        use crate::v3_2::media_type::MediaType;
+        let mut base = MediaType {
+            description: Some("base".into()),
+            example: Some(serde_json::json!({"a": 1})),
+            encoding: Some(BTreeMap::from([(
+                "field".to_owned(),
+                mk_encoding(Some("application/json")),
+            )])),
+            prefix_encoding: Some(vec![mk_encoding(Some("text/csv"))]),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            MediaType {
+                description: Some("incoming".into()),
+                example: Some(serde_json::json!({"a": 2})),
+                encoding: Some(BTreeMap::from([(
+                    "field".to_owned(),
+                    mk_encoding(Some("application/xml")),
+                )])),
+                prefix_encoding: Some(vec![mk_encoding(Some("text/plain"))]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.description.as_deref(), Some("incoming"));
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn media_type_item_encoding_merges_when_both_some() {
+        use crate::v3_2::media_type::MediaType;
+        let mut base = MediaType {
+            item_encoding: Some(mk_encoding(Some("a"))),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            MediaType {
+                item_encoding: Some(mk_encoding(Some("b"))),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(
+            base.item_encoding.unwrap().content_type.as_deref(),
+            Some("b")
+        );
+        assert_eq!(conflicts.len(), 1);
+    }
+
+    #[test]
+    fn encoding_full_field_merge() {
+        let mut base = mk_encoding(Some("a/b"));
+        base.explode = Some(false);
+        base.allow_reserved = Some(false);
+        let mut incoming = mk_encoding(Some("c/d"));
+        incoming.explode = Some(true);
+        incoming.allow_reserved = Some(true);
+        let conflicts = report(&mut base, incoming, MergeOptions::new());
+        assert_eq!(base.content_type.as_deref(), Some("c/d"));
+        assert_eq!(base.explode, Some(true));
+        assert_eq!(base.allow_reserved, Some(true));
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn encoding_item_encoding_merges_when_both_some() {
+        let mut base = mk_encoding(None);
+        base.item_encoding = Some(Box::new(mk_encoding(Some("a"))));
+        let mut incoming = mk_encoding(None);
+        incoming.item_encoding = Some(Box::new(mk_encoding(Some("b"))));
+        let _ = report(&mut base, incoming, MergeOptions::new());
+        assert_eq!(
+            base.item_encoding.unwrap().content_type.as_deref(),
+            Some("b")
+        );
+    }
+
+    // ---- Header ----
+
+    #[test]
+    fn header_full_field_merge() {
+        use crate::v3_2::header::Header;
+        let mut base = Header {
+            description: Some("base".into()),
+            required: Some(false),
+            deprecated: Some(false),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Header {
+                description: Some("incoming".into()),
+                required: Some(true),
+                deprecated: Some(true),
+                explode: Some(true),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.description.as_deref(), Some("incoming"));
+        assert_eq!(base.required, Some(true));
+        assert!(!conflicts.is_empty());
+    }
+
+    // ---- Response ----
+
+    #[test]
+    fn response_full_field_merge() {
+        use crate::v3_2::response::Response;
+        let mut base = Response {
+            summary: Some("base".into()),
+            description: Some("d-base".into()),
+            headers: Some(BTreeMap::from([(
+                "X-Base".into(),
+                RefOr::new_item(crate::v3_2::header::Header::default()),
+            )])),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Response {
+                summary: Some("incoming".into()),
+                description: Some("d-incoming".into()),
+                headers: Some(BTreeMap::from([(
+                    "X-Inc".into(),
+                    RefOr::new_item(crate::v3_2::header::Header::default()),
+                )])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.summary.as_deref(), Some("incoming"));
+        let h = base.headers.unwrap();
+        assert!(h.contains_key("X-Base"));
+        assert!(h.contains_key("X-Inc"));
+        assert!(!conflicts.is_empty());
+    }
+
+    // ---- RequestBody ----
+
+    #[test]
+    fn request_body_content_and_required_merges() {
+        use crate::v3_2::media_type::MediaType;
+        use crate::v3_2::request_body::RequestBody;
+        let mut base = RequestBody {
+            description: Some("base".into()),
+            content: BTreeMap::from([(
+                "application/json".to_owned(),
+                RefOr::new_item(MediaType {
+                    description: Some("media-base".into()),
+                    ..Default::default()
+                }),
+            )]),
+            required: Some(false),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            RequestBody {
+                description: Some("incoming".into()),
+                content: BTreeMap::from([
+                    (
+                        "application/json".to_owned(),
+                        RefOr::new_item(MediaType {
+                            description: Some("media-inc".into()),
+                            ..Default::default()
+                        }),
+                    ),
+                    (
+                        "application/xml".to_owned(),
+                        RefOr::new_item(MediaType::default()),
+                    ),
+                ]),
+                required: Some(true),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.description.as_deref(), Some("incoming"));
+        assert_eq!(base.required, Some(true));
+        assert!(base.content.contains_key("application/json"));
+        assert!(base.content.contains_key("application/xml"));
+        assert!(!conflicts.is_empty());
+    }
+
+    // ---- Example ----
+
+    #[test]
+    fn example_full_field_merge() {
+        use crate::v3_2::example::Example;
+        let mut base = Example {
+            summary: Some("a".into()),
+            description: Some("d-a".into()),
+            value: Some(serde_json::json!(1)),
+            serialized_value: Some("a-ser".into()),
+            data_value: Some(serde_json::json!("d-a")),
+            external_value: Some("https://a".into()),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Example {
+                summary: Some("b".into()),
+                description: Some("d-b".into()),
+                value: Some(serde_json::json!(2)),
+                serialized_value: Some("b-ser".into()),
+                data_value: Some(serde_json::json!("d-b")),
+                external_value: Some("https://b".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.summary.as_deref(), Some("b"));
+        assert_eq!(base.external_value.as_deref(), Some("https://b"));
+        assert!(!conflicts.is_empty());
+    }
+
+    // ---- Link ----
+
+    #[test]
+    fn link_full_field_merge() {
+        use crate::v3_2::link::Link;
+        let mut base = Link {
+            operation_ref: Some("#/a".into()),
+            description: Some("base".into()),
+            request_body: Some(serde_json::json!({"r": 1})),
+            parameters: Some(BTreeMap::from([("p1".into(), serde_json::json!("v1"))])),
+            server: Some(Server {
+                url: "https://srv1".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            Link {
+                operation_id: Some("op2".into()),
+                description: Some("incoming".into()),
+                request_body: Some(serde_json::json!({"r": 2})),
+                parameters: Some(BTreeMap::from([("p2".into(), serde_json::json!("v2"))])),
+                server: Some(Server {
+                    url: "https://srv1".into(),
+                    description: Some("srv-desc".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.description.as_deref(), Some("incoming"));
+        assert_eq!(base.operation_id.as_deref(), Some("op2"));
+        let p = base.parameters.unwrap();
+        assert!(p.contains_key("p1"));
+        assert!(p.contains_key("p2"));
+        assert!(!conflicts.is_empty());
+    }
+
+    // ---- SecurityScheme variants ----
+
+    #[test]
+    fn security_scheme_api_key_merges() {
+        use crate::v3_2::security_scheme::{ApiKeyLocation, ApiKeySecurityScheme, SecurityScheme};
+        let mut base = SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
+            name: "api-key".into(),
+            location: ApiKeyLocation::Header,
+            description: Some("base".into()),
+            ..Default::default()
+        }));
+        let _ = report(
+            &mut base,
+            SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
+                name: "api-key".into(),
+                location: ApiKeyLocation::Query,
+                description: Some("incoming".into()),
+                deprecated: Some(true),
+                ..Default::default()
+            })),
+            MergeOptions::new(),
+        );
+        if let SecurityScheme::ApiKey(a) = base {
+            assert_eq!(a.description.as_deref(), Some("incoming"));
+            assert!(matches!(a.location, ApiKeyLocation::Query));
+        } else {
+            panic!("expected ApiKey");
+        }
+    }
+
+    #[test]
+    fn security_scheme_http_merges() {
+        use crate::v3_2::security_scheme::{HttpSecurityScheme, SecurityScheme};
+        let mut base = SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
+            scheme: "basic".into(),
+            description: Some("base".into()),
+            ..Default::default()
+        }));
+        let _ = report(
+            &mut base,
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
+                scheme: "bearer".into(),
+                bearer_format: Some("JWT".into()),
+                description: Some("incoming".into()),
+                deprecated: Some(true),
+                ..Default::default()
+            })),
+            MergeOptions::new(),
+        );
+        if let SecurityScheme::HTTP(h) = base {
+            assert_eq!(h.scheme, "bearer");
+            assert_eq!(h.bearer_format.as_deref(), Some("JWT"));
+        } else {
+            panic!("expected HTTP");
+        }
+    }
+
+    #[test]
+    fn security_scheme_mutual_tls_merges() {
+        use crate::v3_2::security_scheme::{MutualTLSSecurityScheme, SecurityScheme};
+        let mut base = SecurityScheme::MutualTLS(Box::new(MutualTLSSecurityScheme {
+            description: Some("base".into()),
+            ..Default::default()
+        }));
+        let conflicts = report(
+            &mut base,
+            SecurityScheme::MutualTLS(Box::new(MutualTLSSecurityScheme {
+                description: Some("incoming".into()),
+                deprecated: Some(true),
+                ..Default::default()
+            })),
+            MergeOptions::new(),
+        );
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn security_scheme_openid_connect_merges() {
+        use crate::v3_2::security_scheme::{OpenIdConnectSecurityScheme, SecurityScheme};
+        let mut base = SecurityScheme::OpenIdConnect(Box::new(OpenIdConnectSecurityScheme {
+            open_id_connect_url: "https://a/.well-known".into(),
+            description: Some("base".into()),
+            ..Default::default()
+        }));
+        let conflicts = report(
+            &mut base,
+            SecurityScheme::OpenIdConnect(Box::new(OpenIdConnectSecurityScheme {
+                open_id_connect_url: "https://b/.well-known".into(),
+                description: Some("incoming".into()),
+                deprecated: Some(true),
+                ..Default::default()
+            })),
+            MergeOptions::new(),
+        );
+        if let SecurityScheme::OpenIdConnect(o) = base {
+            assert_eq!(o.open_id_connect_url, "https://b/.well-known");
+        } else {
+            panic!("expected OpenIdConnect");
+        }
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn security_scheme_variant_mismatch_replaces() {
+        use crate::v3_2::security_scheme::{
+            ApiKeyLocation, ApiKeySecurityScheme, HttpSecurityScheme, SecurityScheme,
+        };
+        let mut base = SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
+            name: "k".into(),
+            location: ApiKeyLocation::Header,
+            ..Default::default()
+        }));
+        let conflicts = report(
+            &mut base,
+            SecurityScheme::HTTP(Box::new(HttpSecurityScheme {
+                scheme: "basic".into(),
+                ..Default::default()
+            })),
+            MergeOptions::new(),
+        );
+        assert!(matches!(base, SecurityScheme::HTTP(_)));
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].kind, ConflictKind::ParameterVariantMismatch);
+    }
+
+    // ---- OAuth flows ----
+
+    #[test]
+    fn oauth2_flows_and_implicit_flow_merge() {
+        use crate::v3_2::security_scheme::{
+            ImplicitOAuth2Flow, OAuth2Flows, OAuth2SecurityScheme, SecurityScheme,
+        };
+        let mut flows = OAuth2Flows {
+            implicit: Some(ImplicitOAuth2Flow {
+                authorization_url: "https://auth/a".into(),
+                refresh_url: Some("https://refresh/a".into()),
+                scopes: BTreeMap::from([("read".into(), "Read".into())]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut base = SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
+            flows: flows.clone(),
+            description: Some("base".into()),
+            ..Default::default()
+        }));
+        flows.implicit = Some(ImplicitOAuth2Flow {
+            authorization_url: "https://auth/b".into(),
+            refresh_url: Some("https://refresh/b".into()),
+            scopes: BTreeMap::from([
+                ("read".into(), "Updated Read".into()),
+                ("write".into(), "Write".into()),
+            ]),
+            ..Default::default()
+        });
+        let conflicts = report(
+            &mut base,
+            SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
+                flows,
+                description: Some("incoming".into()),
+                oauth2_metadata_url: Some("https://meta".into()),
+                ..Default::default()
+            })),
+            MergeOptions::new(),
+        );
+        if let SecurityScheme::OAuth2(o) = &base {
+            let i = o.flows.implicit.as_ref().unwrap();
+            assert_eq!(i.authorization_url, "https://auth/b");
+            assert!(i.scopes.contains_key("write"));
+            assert_eq!(o.description.as_deref(), Some("incoming"));
+            assert_eq!(o.oauth2_metadata_url.as_deref(), Some("https://meta"));
+        } else {
+            panic!("expected OAuth2");
+        }
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn oauth2_password_flow_merges() {
+        use crate::v3_2::security_scheme::PasswordOAuth2Flow;
+        let mut base = PasswordOAuth2Flow {
+            token_url: "https://a/token".into(),
+            scopes: BTreeMap::from([("s1".into(), "S1".into())]),
+            ..Default::default()
+        };
+        let conflicts = report(
+            &mut base,
+            PasswordOAuth2Flow {
+                token_url: "https://b/token".into(),
+                refresh_url: Some("https://b/refresh".into()),
+                scopes: BTreeMap::from([
+                    ("s1".into(), "S1-updated".into()),
+                    ("s2".into(), "S2".into()),
+                ]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.token_url, "https://b/token");
+        assert!(base.scopes.contains_key("s2"));
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn oauth2_client_credentials_flow_merges() {
+        use crate::v3_2::security_scheme::ClientCredentialsOAuth2Flow;
+        let mut base = ClientCredentialsOAuth2Flow {
+            token_url: "https://a".into(),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            ClientCredentialsOAuth2Flow {
+                token_url: "https://b".into(),
+                refresh_url: Some("https://b/r".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.token_url, "https://b");
+    }
+
+    #[test]
+    fn oauth2_authorization_code_flow_merges() {
+        use crate::v3_2::security_scheme::AuthorizationCodeOAuth2Flow;
+        let mut base = AuthorizationCodeOAuth2Flow {
+            authorization_url: "https://a/auth".into(),
+            token_url: "https://a/token".into(),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            AuthorizationCodeOAuth2Flow {
+                authorization_url: "https://b/auth".into(),
+                token_url: "https://b/token".into(),
+                refresh_url: Some("https://b/r".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.authorization_url, "https://b/auth");
+        assert_eq!(base.token_url, "https://b/token");
+    }
+
+    #[test]
+    fn oauth2_device_authorization_flow_merges() {
+        use crate::v3_2::security_scheme::DeviceAuthorizationOAuth2Flow;
+        let mut base = DeviceAuthorizationOAuth2Flow {
+            device_authorization_url: "https://a/da".into(),
+            token_url: "https://a/token".into(),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            DeviceAuthorizationOAuth2Flow {
+                device_authorization_url: "https://b/da".into(),
+                token_url: "https://b/token".into(),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.device_authorization_url, "https://b/da");
+    }
+
+    // ---- Parameter variant mismatches ----
+
+    #[test]
+    fn parameter_variant_mismatch_replaces() {
+        let mut base = Parameter::Path(Box::new(InPath {
+            name: "id".into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }));
+        let conflicts = report(
+            &mut base,
+            Parameter::Query(Box::new(InQuery {
+                name: "id".into(),
+                description: None,
+                required: None,
+                deprecated: None,
+                allow_empty_value: None,
+                style: None,
+                explode: None,
+                allow_reserved: None,
+                schema: None,
+                example: None,
+                examples: None,
+                content: None,
+                extensions: None,
+            })),
+            MergeOptions::new(),
+        );
+        assert!(matches!(base, Parameter::Query(_)));
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].kind, ConflictKind::ParameterVariantMismatch);
+    }
+
+    // ---- Schema enum non-Single variants ----
+
+    #[test]
+    fn schema_all_of_leaf_replaces_under_deep_merge_option() {
+        use crate::v3_2::schema::AllOfSchema;
+        let mut base = Schema::AllOf(Box::new(AllOfSchema {
+            all_of: vec![],
+            ..Default::default()
+        }));
+        let conflicts = report(
+            &mut base,
+            Schema::AllOf(Box::new(AllOfSchema {
+                all_of: vec![RefOr::new_item(Schema::Single(Box::new(
+                    SingleSchema::Object(ObjectSchema::default()),
+                )))],
+                ..Default::default()
+            })),
+            MergeOptions::DeepMergeObjectSchemas.only(),
+        );
+        // AllOf doesn't deep-merge — falls back to leaf replace.
+        if let Schema::AllOf(a) = &base {
+            assert_eq!(a.all_of.len(), 1);
+        }
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].kind, ConflictKind::SchemaLeafReplaced);
+    }
+
+    #[test]
+    fn schema_single_string_replaces_under_deep_merge_object_only() {
+        use crate::v3_2::schema::StringSchema;
+        let mut base = Schema::Single(Box::new(SingleSchema::String(StringSchema {
+            description: Some("base".into()),
+            ..Default::default()
+        })));
+        let conflicts = report(
+            &mut base,
+            Schema::Single(Box::new(SingleSchema::String(StringSchema {
+                description: Some("incoming".into()),
+                ..Default::default()
+            }))),
+            MergeOptions::DeepMergeObjectSchemas.only(),
+        );
+        // StringSchema isn't ObjectSchema → leaf-replace.
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].kind, ConflictKind::SchemaLeafReplaced);
+    }
+
+    // ---- ObjectSchema deep merge — broader field coverage ----
+
+    #[test]
+    fn object_schema_deep_merge_full_fields() {
+        use crate::common::bool_or::BoolOr;
+        let mk_obj = |required: Vec<&str>, title: &str| {
+            Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+                title: Some(title.into()),
+                description: Some(format!("{title} desc")),
+                required: Some(required.iter().map(|s| s.to_string()).collect()),
+                pattern_properties: Some(BTreeMap::from([(
+                    "^pat$".into(),
+                    RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                        ObjectSchema::default(),
+                    )))),
+                )])),
+                additional_properties: Some(BoolOr::Bool(true)),
+                read_only: Some(false),
+                write_only: Some(false),
+                deprecated: Some(false),
+                max_properties: Some(10),
+                min_properties: Some(0),
+                ..Default::default()
+            })))
+        };
+        let mut base = mk_obj(vec!["a"], "Base");
+        let incoming = mk_obj(vec!["b"], "Incoming");
+        let _ = report(
+            &mut base,
+            incoming,
+            MergeOptions::DeepMergeObjectSchemas.only(),
+        );
+        let Schema::Single(s) = &base else { panic!() };
+        let SingleSchema::Object(o) = &**s else {
+            panic!()
+        };
+        assert_eq!(o.title.as_deref(), Some("Incoming"));
+        let req = o.required.as_ref().unwrap();
+        assert!(req.contains(&"a".to_owned()) && req.contains(&"b".to_owned()));
+    }
+
+    #[test]
+    fn object_schema_additional_properties_none_some_takes_incoming() {
+        use crate::common::bool_or::BoolOr;
+        let mut base = ObjectSchema::default();
+        let incoming = ObjectSchema {
+            additional_properties: Some(BoolOr::Bool(false)),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        assert!(matches!(
+            base.additional_properties,
+            Some(BoolOr::Bool(false))
+        ));
+    }
+
+    #[test]
+    fn object_schema_unevaluated_properties_merges() {
+        use crate::common::bool_or::BoolOr;
+        let mut base = ObjectSchema {
+            unevaluated_properties: Some(BoolOr::Bool(true)),
+            ..Default::default()
+        };
+        let incoming = ObjectSchema {
+            unevaluated_properties: Some(BoolOr::Bool(false)),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        assert!(matches!(
+            base.unevaluated_properties,
+            Some(BoolOr::Bool(false))
+        ));
+    }
+
+    // ---- Operation: callbacks, security, servers ----
+
+    #[test]
+    fn operation_callbacks_security_servers_merge() {
+        use crate::v3_2::callback::Callback;
+        let mut base = Operation {
+            callbacks: Some(BTreeMap::from([(
+                "cb1".to_owned(),
+                RefOr::new_item(Callback::default()),
+            )])),
+            security: Some(vec![BTreeMap::from([("a".into(), vec!["read".into()])])]),
+            servers: Some(vec![Server {
+                url: "https://srv1".into(),
+                ..Default::default()
+            }]),
+            deprecated: Some(false),
+            extensions: Some(BTreeMap::from([("x-a".into(), serde_json::json!(1))])),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                callbacks: Some(BTreeMap::from([(
+                    "cb2".to_owned(),
+                    RefOr::new_item(Callback::default()),
+                )])),
+                security: Some(vec![BTreeMap::from([("b".into(), vec!["write".into()])])]),
+                servers: Some(vec![Server {
+                    url: "https://srv2".into(),
+                    ..Default::default()
+                }]),
+                deprecated: Some(true),
+                extensions: Some(BTreeMap::from([("x-b".into(), serde_json::json!(2))])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        // callbacks: new key appended → both present.
+        let cb = base.callbacks.unwrap();
+        assert!(cb.contains_key("cb1") && cb.contains_key("cb2"));
+        // security: replace-when-non-empty.
+        assert_eq!(base.security.unwrap().len(), 1);
+        // deprecated overridden.
+        assert_eq!(base.deprecated, Some(true));
+    }
+
+    // ---- PathItem: additional_operations + parameters dedup ----
+
+    #[test]
+    fn path_item_additional_operations_and_param_dedup() {
+        let mut base = PathItem {
+            additional_operations: Some(BTreeMap::from([(
+                "trace".to_owned(),
+                Operation::default(),
+            )])),
+            parameters: Some(vec![param_path("id")]),
+            extensions: Some(BTreeMap::from([("x-a".into(), serde_json::json!(1))])),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            PathItem {
+                additional_operations: Some(BTreeMap::from([(
+                    "link".to_owned(),
+                    Operation::default(),
+                )])),
+                parameters: Some(vec![param_path("id"), param_query("limit")]),
+                extensions: Some(BTreeMap::from([("x-b".into(), serde_json::json!(2))])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let ao = base.additional_operations.unwrap();
+        assert!(ao.contains_key("trace") && ao.contains_key("link"));
+        // Param dedup: id should not be duplicated.
+        assert_eq!(base.parameters.unwrap().len(), 2);
+        let ext = base.extensions.unwrap();
+        assert!(ext.contains_key("x-a") && ext.contains_key("x-b"));
+    }
+
+    // ---- Components: every bag exercised ----
+
+    #[test]
+    fn components_every_bag_merges() {
+        use crate::v3_2::callback::Callback;
+        use crate::v3_2::components::Components;
+        use crate::v3_2::example::Example;
+        use crate::v3_2::header::Header;
+        use crate::v3_2::link::Link;
+        use crate::v3_2::media_type::MediaType;
+        use crate::v3_2::request_body::RequestBody;
+        use crate::v3_2::response::Response;
+        use crate::v3_2::security_scheme::{ApiKeyLocation, ApiKeySecurityScheme, SecurityScheme};
+
+        let make_components = |suffix: &str| Components {
+            schemas: Some(BTreeMap::from([(
+                format!("S{suffix}"),
+                RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                    ObjectSchema::default(),
+                )))),
+            )])),
+            responses: Some(BTreeMap::from([(
+                format!("R{suffix}"),
+                RefOr::new_item(Response::default()),
+            )])),
+            parameters: Some(BTreeMap::from([(
+                format!("P{suffix}"),
+                param_path(&format!("p{suffix}")),
+            )])),
+            examples: Some(BTreeMap::from([(
+                format!("E{suffix}"),
+                RefOr::new_item(Example::default()),
+            )])),
+            request_bodies: Some(BTreeMap::from([(
+                format!("RB{suffix}"),
+                RefOr::new_item(RequestBody::default()),
+            )])),
+            headers: Some(BTreeMap::from([(
+                format!("H{suffix}"),
+                RefOr::new_item(Header::default()),
+            )])),
+            security_schemes: Some(BTreeMap::from([(
+                format!("SS{suffix}"),
+                RefOr::new_item(SecurityScheme::ApiKey(Box::new(ApiKeySecurityScheme {
+                    name: "k".into(),
+                    location: ApiKeyLocation::Header,
+                    ..Default::default()
+                }))),
+            )])),
+            links: Some(BTreeMap::from([(
+                format!("L{suffix}"),
+                RefOr::new_item(Link::default()),
+            )])),
+            callbacks: Some(BTreeMap::from([(
+                format!("CB{suffix}"),
+                RefOr::new_item(Callback::default()),
+            )])),
+            path_items: Some(BTreeMap::from([(
+                format!("PI{suffix}"),
+                PathItem::default(),
+            )])),
+            media_types: Some(BTreeMap::from([(
+                format!("MT{suffix}"),
+                RefOr::new_item(MediaType::default()),
+            )])),
+            extensions: Some(BTreeMap::from([(
+                format!("x-{suffix}"),
+                serde_json::json!(1),
+            )])),
+        };
+        let mut base = make_components("a");
+        let _ = report(&mut base, make_components("b"), MergeOptions::new());
+        // Every bag should now have both entries.
+        assert_eq!(base.schemas.unwrap().len(), 2);
+        assert_eq!(base.responses.unwrap().len(), 2);
+        assert_eq!(base.parameters.unwrap().len(), 2);
+        assert_eq!(base.examples.unwrap().len(), 2);
+        assert_eq!(base.request_bodies.unwrap().len(), 2);
+        assert_eq!(base.headers.unwrap().len(), 2);
+        assert_eq!(base.security_schemes.unwrap().len(), 2);
+        assert_eq!(base.links.unwrap().len(), 2);
+        assert_eq!(base.callbacks.unwrap().len(), 2);
+        assert_eq!(base.path_items.unwrap().len(), 2);
+        assert_eq!(base.media_types.unwrap().len(), 2);
+        assert_eq!(base.extensions.unwrap().len(), 2);
+    }
+
+    // ---- Spec: webhooks, security, external_docs ----
+
+    #[test]
+    fn spec_webhooks_security_external_docs() {
+        let mut base = Spec {
+            webhooks: Some(Paths {
+                paths: BTreeMap::from([(
+                    "/wh1".to_owned(),
+                    PathItem {
+                        summary: Some("wh1".into()),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }),
+            security: Some(vec![BTreeMap::from([("base".into(), vec![])])]),
+            external_docs: Some(ExternalDocumentation {
+                url: "https://docs/a".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let incoming = Spec {
+            webhooks: Some(Paths {
+                paths: BTreeMap::from([(
+                    "/wh2".to_owned(),
+                    PathItem {
+                        summary: Some("wh2".into()),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }),
+            security: Some(vec![BTreeMap::from([("incoming".into(), vec![])])]),
+            external_docs: Some(ExternalDocumentation {
+                url: "https://docs/b".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        base.merge(incoming, MergeOptions::new()).unwrap();
+        // webhooks merge per-key
+        let wh = base.webhooks.unwrap().paths;
+        assert!(wh.contains_key("/wh1") && wh.contains_key("/wh2"));
+        // security: replace-when-non-empty
+        assert_eq!(base.security.unwrap().len(), 1);
+        // external_docs: deep merge
+        assert_eq!(base.external_docs.unwrap().url, "https://docs/b");
+    }
+
+    // ---- None × Some additive paths for nested Option<RefOr<_>>s ----
+
+    #[test]
+    fn responses_default_none_takes_incoming() {
+        use crate::v3_2::response::Responses;
+        let mut base = Responses {
+            default: None,
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Responses {
+                default: Some(response_with("default")),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert!(base.default.is_some());
+    }
+
+    #[test]
+    fn operation_request_body_none_takes_incoming() {
+        use crate::v3_2::request_body::RequestBody;
+        let mut base = Operation {
+            request_body: None,
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                request_body: Some(RefOr::new_item(RequestBody::default())),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert!(base.request_body.is_some());
+    }
+
+    // ---- parameter_ref_key for non-Path variants (used in dedup) ----
+
+    fn param_header(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Header(Box::new(InHeader {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn param_cookie(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Cookie(Box::new(InCookie {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn param_querystring(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Querystring(Box::new(InQuerystring {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            content: BTreeMap::new(),
+            example: None,
+            examples: None,
+            extensions: None,
+        })))
+    }
+
+    #[test]
+    fn parameter_dedup_covers_all_locations() {
+        // Run a merge with each Parameter variant on both sides so
+        // parameter_ref_key sees Header / Cookie / Querystring (and
+        // ref) — covers the non-Path arms.
+        let mut base = Operation {
+            parameters: Some(vec![
+                param_header("X-A"),
+                param_cookie("c"),
+                param_querystring("q"),
+                RefOr::new_ref("#/components/parameters/P"),
+            ]),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                parameters: Some(vec![
+                    // Same keys — should dedup.
+                    param_header("X-A"),
+                    param_cookie("c"),
+                    param_querystring("q"),
+                    RefOr::new_ref("#/components/parameters/P"),
+                ]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.parameters.unwrap().len(), 4, "no duplicates");
+    }
+
+    #[test]
+    fn parameter_enum_each_same_variant_recurses() {
+        // Cover each (Variant × Variant) match arm in Parameter.
+        for (name, base, incoming) in [
+            (
+                "path",
+                Parameter::Path(Box::new(mk_inpath("id", Some("a"), true))),
+                Parameter::Path(Box::new(mk_inpath("id", Some("b"), true))),
+            ),
+            (
+                "query",
+                Parameter::Query(Box::new(InQuery {
+                    name: "q".into(),
+                    description: Some("a".into()),
+                    required: None,
+                    deprecated: None,
+                    allow_empty_value: None,
+                    style: None,
+                    explode: None,
+                    allow_reserved: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                })),
+                Parameter::Query(Box::new(InQuery {
+                    name: "q".into(),
+                    description: Some("b".into()),
+                    required: None,
+                    deprecated: None,
+                    allow_empty_value: None,
+                    style: None,
+                    explode: None,
+                    allow_reserved: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                })),
+            ),
+            (
+                "header",
+                Parameter::Header(Box::new(InHeader {
+                    name: "X-A".into(),
+                    description: Some("a".into()),
+                    required: None,
+                    deprecated: None,
+                    style: None,
+                    explode: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                })),
+                Parameter::Header(Box::new(InHeader {
+                    name: "X-A".into(),
+                    description: Some("b".into()),
+                    required: None,
+                    deprecated: None,
+                    style: None,
+                    explode: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                })),
+            ),
+            (
+                "cookie",
+                Parameter::Cookie(Box::new(InCookie {
+                    name: "c".into(),
+                    description: Some("a".into()),
+                    required: None,
+                    deprecated: None,
+                    style: None,
+                    explode: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                })),
+                Parameter::Cookie(Box::new(InCookie {
+                    name: "c".into(),
+                    description: Some("b".into()),
+                    required: None,
+                    deprecated: None,
+                    style: None,
+                    explode: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                })),
+            ),
+            (
+                "querystring",
+                Parameter::Querystring(Box::new(InQuerystring {
+                    name: "qs".into(),
+                    description: Some("a".into()),
+                    required: None,
+                    deprecated: None,
+                    content: BTreeMap::new(),
+                    example: None,
+                    examples: None,
+                    extensions: None,
+                })),
+                Parameter::Querystring(Box::new(InQuerystring {
+                    name: "qs".into(),
+                    description: Some("b".into()),
+                    required: None,
+                    deprecated: None,
+                    content: BTreeMap::new(),
+                    example: None,
+                    examples: None,
+                    extensions: None,
+                })),
+            ),
+        ] {
+            let mut b = base;
+            let _ = report(&mut b, incoming, MergeOptions::new());
+            // After merge, description should be "b" for every variant.
+            let desc = match &b {
+                Parameter::Path(p) => p.description.as_deref(),
+                Parameter::Query(p) => p.description.as_deref(),
+                Parameter::Header(p) => p.description.as_deref(),
+                Parameter::Cookie(p) => p.description.as_deref(),
+                Parameter::Querystring(p) => p.description.as_deref(),
+            };
+            assert_eq!(desc, Some("b"), "{name}: incoming description must win");
+        }
+    }
+
+    // ---- ErrorOnConflict success path (commits the working copy) ----
+
+    #[test]
+    fn spec_error_on_conflict_success_commits_working_copy() {
+        // ErrorOnConflict set + no real collision → `Ok` with the
+        // merged result observable on `self`. Exercises the
+        // `*self = working` + Ok return in Spec::merge.
+        let mut base = Spec::default();
+        let incoming = Spec {
+            json_schema_dialect: Some("https://example/dialect".into()),
+            ..Default::default()
+        };
+        base.merge(incoming, MergeOptions::ErrorOnConflict.only())
+            .unwrap();
+        assert_eq!(
+            base.json_schema_dialect.as_deref(),
+            Some("https://example/dialect")
+        );
+    }
+
+    // ---- Responses.default / Operation.request_body — both Some ----
+
+    #[test]
+    fn responses_default_both_some_recurses_into_response() {
+        use crate::v3_2::response::Responses;
+        let mut base = Responses {
+            default: Some(response_with("base")),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Responses {
+                default: Some(response_with("incoming")),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let RefOr::Item(r) = base.default.as_ref().unwrap() else {
+            panic!()
+        };
+        assert_eq!(r.description.as_deref(), Some("incoming"));
+    }
+
+    #[test]
+    fn operation_request_body_both_some_recurses() {
+        use crate::v3_2::media_type::MediaType;
+        use crate::v3_2::request_body::RequestBody;
+        let mut base = Operation {
+            request_body: Some(RefOr::new_item(RequestBody {
+                description: Some("base".into()),
+                content: BTreeMap::from([(
+                    "application/json".to_owned(),
+                    RefOr::new_item(MediaType::default()),
+                )]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                request_body: Some(RefOr::new_item(RequestBody {
+                    description: Some("incoming".into()),
+                    content: BTreeMap::from([(
+                        "application/xml".to_owned(),
+                        RefOr::new_item(MediaType::default()),
+                    )]),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let RefOr::Item(rb) = base.request_body.as_ref().unwrap() else {
+            panic!()
+        };
+        assert_eq!(rb.description.as_deref(), Some("incoming"));
+        assert!(rb.content.contains_key("application/json"));
+        assert!(rb.content.contains_key("application/xml"));
+    }
+
+    // ---- Helpers no-op when ctx.errored already set ----
+
+    #[test]
+    fn component_impls_no_op_when_already_errored() {
+        // Sweep every component impl that has an entry-guard
+        // `if ctx.errored { return; }`. Pre-flip the flag, call the
+        // impl, and confirm nothing mutated. Covers the entry-guard
+        // return branches that otherwise sit dead.
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        ctx.errored = true;
+        let mut path = root_path();
+
+        // PathItem
+        {
+            let mut pi = PathItem {
+                summary: Some("base".into()),
+                ..Default::default()
+            };
+            pi.merge_with_context(
+                PathItem {
+                    summary: Some("incoming".into()),
+                    ..Default::default()
+                },
+                &mut ctx,
+                &mut path,
+            );
+            assert_eq!(pi.summary.as_deref(), Some("base"));
+        }
+        // Responses
+        {
+            use crate::v3_2::response::Responses;
+            let mut r = Responses::default();
+            r.merge_with_context(
+                Responses {
+                    default: Some(response_with("incoming")),
+                    ..Default::default()
+                },
+                &mut ctx,
+                &mut path,
+            );
+            assert!(r.default.is_none());
+        }
+        // Operation
+        {
+            let mut op = Operation::default();
+            op.merge_with_context(
+                Operation {
+                    summary: Some("incoming".into()),
+                    ..Default::default()
+                },
+                &mut ctx,
+                &mut path,
+            );
+            assert!(op.summary.is_none());
+        }
+        // Parameter
+        {
+            let mut p = Parameter::Path(Box::new(mk_inpath("x", None, true)));
+            p.merge_with_context(
+                Parameter::Query(Box::new(InQuery {
+                    name: "x".into(),
+                    description: None,
+                    required: None,
+                    deprecated: None,
+                    allow_empty_value: None,
+                    style: None,
+                    explode: None,
+                    allow_reserved: None,
+                    schema: None,
+                    example: None,
+                    examples: None,
+                    content: None,
+                    extensions: None,
+                })),
+                &mut ctx,
+                &mut path,
+            );
+            assert!(matches!(p, Parameter::Path(_)));
+        }
+        // InPath / InQuery / InHeader / InCookie — entry guards.
+        {
+            let mut p = mk_inpath("a", Some("base"), true);
+            p.merge_with_context(mk_inpath("a", Some("inc"), true), &mut ctx, &mut path);
+            assert_eq!(p.description.as_deref(), Some("base"));
+        }
+    }
+
+    // ---- Schema deep-merge fallback for Object × non-Object ----
+
+    #[test]
+    fn schema_object_vs_string_under_deep_merge_falls_back_to_replace() {
+        use crate::v3_2::schema::StringSchema;
+        let mut base = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            description: Some("base obj".into()),
+            ..Default::default()
+        })));
+        let _ = report(
+            &mut base,
+            Schema::Single(Box::new(SingleSchema::String(StringSchema {
+                description: Some("incoming str".into()),
+                ..Default::default()
+            }))),
+            MergeOptions::DeepMergeObjectSchemas.only(),
+        );
+        // Falls into the `other_single_inner` arm → leaf-replace.
+        assert!(matches!(
+            base,
+            Schema::Single(box_s) if matches!(*box_s, SingleSchema::String(_))
+        ));
+    }
+
+    // ---- Parameter variants: collisions exercise field-level merges ----
+
+    fn mk_inpath(name: &str, description: Option<&str>, required: bool) -> InPath {
+        InPath {
+            name: name.into(),
+            description: description.map(str::to_owned),
+            required,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }
+    }
+
+    #[test]
+    fn in_path_full_field_merge() {
+        let mut base = mk_inpath("id", Some("base"), true);
+        base.explode = Some(false);
+        base.example = Some(serde_json::json!(1));
+        let mut incoming = mk_inpath("id", Some("incoming"), false);
+        incoming.deprecated = Some(true);
+        incoming.explode = Some(true);
+        incoming.example = Some(serde_json::json!(2));
+        let conflicts = report(&mut base, incoming, MergeOptions::new());
+        assert_eq!(base.description.as_deref(), Some("incoming"));
+        assert!(!base.required); // required-scalar collision
+        assert_eq!(base.deprecated, Some(true));
+        assert_eq!(base.explode, Some(true));
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn in_query_full_field_merge() {
+        let mut base = InQuery {
+            name: "q".into(),
+            description: Some("base".into()),
+            required: Some(false),
+            deprecated: None,
+            allow_empty_value: Some(false),
+            style: None,
+            explode: Some(false),
+            allow_reserved: Some(false),
+            schema: None,
+            example: Some(serde_json::json!("a")),
+            examples: None,
+            content: None,
+            extensions: None,
+        };
+        let incoming = InQuery {
+            name: "q".into(),
+            description: Some("incoming".into()),
+            required: Some(true),
+            deprecated: Some(true),
+            allow_empty_value: Some(true),
+            style: None,
+            explode: Some(true),
+            allow_reserved: Some(true),
+            schema: None,
+            example: Some(serde_json::json!("b")),
+            examples: None,
+            content: None,
+            extensions: None,
+        };
+        let conflicts = report(&mut base, incoming, MergeOptions::new());
+        assert_eq!(base.required, Some(true));
+        assert_eq!(base.explode, Some(true));
+        assert_eq!(base.allow_reserved, Some(true));
+        assert!(!conflicts.is_empty());
+    }
+
+    #[test]
+    fn in_header_full_field_merge() {
+        let mut base = InHeader {
+            name: "X-A".into(),
+            description: Some("base".into()),
+            required: Some(false),
+            deprecated: None,
+            style: None,
+            explode: Some(false),
+            schema: None,
+            example: Some(serde_json::json!("a")),
+            examples: None,
+            content: None,
+            extensions: None,
+        };
+        let incoming = InHeader {
+            name: "X-A".into(),
+            description: Some("incoming".into()),
+            required: Some(true),
+            deprecated: Some(true),
+            style: None,
+            explode: Some(true),
+            schema: None,
+            example: Some(serde_json::json!("b")),
+            examples: None,
+            content: None,
+            extensions: None,
+        };
+        let _ = report(&mut base, incoming, MergeOptions::new());
+        assert_eq!(base.required, Some(true));
+        assert_eq!(base.explode, Some(true));
+    }
+
+    #[test]
+    fn in_cookie_full_field_merge() {
+        let mut base = InCookie {
+            name: "c".into(),
+            description: Some("base".into()),
+            required: Some(false),
+            deprecated: None,
+            style: None,
+            explode: Some(false),
+            schema: None,
+            example: Some(serde_json::json!("a")),
+            examples: None,
+            content: None,
+            extensions: None,
+        };
+        let incoming = InCookie {
+            name: "c".into(),
+            description: Some("incoming".into()),
+            required: Some(true),
+            deprecated: Some(true),
+            style: None,
+            explode: Some(true),
+            schema: None,
+            example: Some(serde_json::json!("b")),
+            examples: None,
+            content: None,
+            extensions: None,
+        };
+        let _ = report(&mut base, incoming, MergeOptions::new());
+        assert_eq!(base.required, Some(true));
+        assert_eq!(base.deprecated, Some(true));
+    }
+
+    #[test]
+    fn in_querystring_full_field_merge_with_content_overlap() {
+        use crate::v3_2::media_type::MediaType;
+        let mut base = InQuerystring {
+            name: "qs".into(),
+            description: Some("base".into()),
+            required: Some(false),
+            deprecated: None,
+            content: BTreeMap::from([(
+                "application/json".to_owned(),
+                RefOr::new_item(MediaType {
+                    description: Some("media-base".into()),
+                    ..Default::default()
+                }),
+            )]),
+            example: Some(serde_json::json!("a")),
+            examples: None,
+            extensions: None,
+        };
+        let incoming = InQuerystring {
+            name: "qs".into(),
+            description: Some("incoming".into()),
+            required: Some(true),
+            deprecated: Some(true),
+            content: BTreeMap::from([
+                (
+                    // Overlapping key — exercises the inner loop's
+                    // recursive merge path.
+                    "application/json".to_owned(),
+                    RefOr::new_item(MediaType {
+                        description: Some("media-inc".into()),
+                        ..Default::default()
+                    }),
+                ),
+                (
+                    "text/plain".to_owned(),
+                    RefOr::new_item(MediaType::default()),
+                ),
+            ]),
+            example: Some(serde_json::json!("b")),
+            examples: None,
+            extensions: None,
+        };
+        let _ = report(&mut base, incoming, MergeOptions::new());
+        assert_eq!(base.required, Some(true));
+        assert!(base.content.contains_key("application/json"));
+        assert!(base.content.contains_key("text/plain"));
+    }
+
+    // ---- Callback paths overlap exercises the inline loop ----
+
+    #[test]
+    fn callback_paths_overlap_merges_per_path_expression() {
+        use crate::v3_2::callback::Callback;
+        let mut base = Callback {
+            paths: BTreeMap::from([(
+                "{$request.body#/url}".to_owned(),
+                PathItem {
+                    summary: Some("base".into()),
+                    ..Default::default()
+                },
+            )]),
+            extensions: Some(BTreeMap::from([("x-a".into(), serde_json::json!(1))])),
+        };
+        let incoming = Callback {
+            paths: BTreeMap::from([
+                (
+                    "{$request.body#/url}".to_owned(),
+                    PathItem {
+                        summary: Some("incoming".into()),
+                        ..Default::default()
+                    },
+                ),
+                ("{$response.body#/url}".to_owned(), PathItem::default()),
+            ]),
+            extensions: Some(BTreeMap::from([("x-b".into(), serde_json::json!(2))])),
+        };
+        let _ = report(&mut base, incoming, MergeOptions::new());
+        // Overlapping path-expression — base summary replaced.
+        assert_eq!(
+            base.paths["{$request.body#/url}"].summary.as_deref(),
+            Some("incoming")
+        );
+        // New path-expression appended.
+        assert!(base.paths.contains_key("{$response.body#/url}"));
+    }
+
+    // ---- record_kept_base_or_error covers the openapi mismatch branch ----
+
+    #[test]
+    fn spec_openapi_mismatch_records_resolution_base_under_default() {
+        // Forcing openapi to differ requires `Spec::default()`'s
+        // V3_2_0 to be overridden — go through serde to build two
+        // Specs with different openapi values.
+        let mut base: Spec = serde_json::from_value(serde_json::json!({
+            "openapi": "3.2.0",
+            "info": {"title": "T", "version": "1"},
+        }))
+        .unwrap();
+        let incoming: Spec = serde_json::from_value(serde_json::json!({
+            "openapi": "3.2.1",
+            "info": {"title": "T", "version": "1"},
+        }))
+        .unwrap();
+        let report = base.merge(incoming, MergeOptions::new()).unwrap();
+        assert!(
+            report
+                .conflicts
+                .iter()
+                .any(|c| c.path.ends_with(".openapi") && c.resolution == Resolution::Base)
+        );
+        // Base kept its openapi.
+        let openapi_str = serde_json::to_value(&base.openapi).unwrap();
+        assert_eq!(openapi_str, serde_json::json!("3.2.0"));
+    }
+
+    // ---- ReplaceListsWhenEmpty exercises that branch ----
+
+    #[test]
+    fn replace_lists_when_empty_option_drops_base_list() {
+        let mut base = Spec {
+            servers: Some(vec![Server {
+                url: "https://srv1".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                servers: Some(vec![]),
+                ..Default::default()
+            },
+            MergeOptions::ReplaceListsWhenEmpty.only(),
+        )
+        .unwrap();
+        // With the option set, incoming empty replaces base.
+        let s = base.servers.unwrap();
+        assert!(s.is_empty(), "incoming empty list should replace base");
+    }
+
+    // ---- BaseWins mode propagates through helpers ----
+
+    #[test]
+    fn base_wins_keeps_base_value_in_extensions() {
+        let mut base: Option<BTreeMap<String, serde_json::Value>> =
+            Some(BTreeMap::from([("x-a".into(), serde_json::json!(1))]));
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::BaseWins.only());
+        let mut path = root_path();
+        crate::common::merge::merge_extensions(
+            &mut base,
+            Some(BTreeMap::from([("x-a".into(), serde_json::json!(2))])),
+            &mut ctx,
+            &mut path,
+            ".ext",
+        );
+        let m = base.unwrap();
+        assert_eq!(m.get("x-a"), Some(&serde_json::json!(1)));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].resolution, Resolution::Base);
     }
 }

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -1,0 +1,3253 @@
+//! v3.2 merge: per-component `MergeWithContext<Spec>` impls plus the
+//! public `impl Merge for Spec`.
+//!
+//! Sits alongside `v3_2/validation.rs`. Every component type in v3.2
+//! gets a `merge_with_context` whose shape mirrors its
+//! `validate_with_context` neighbor: walk the fields, recurse into
+//! nested objects, dispatch through `RefOr` / `BoolOr`. Helpers from
+//! [`crate::common::merge`] do the structural plumbing
+//! (`merge_opt_scalar`, `merge_opt_map`, `merge_vec_by_key`,
+//! `merge_extensions`, ...) so each impl reads as a flat list of
+//! "field → rule" lines.
+//!
+//! Conflict policy modes (incoming-wins / base-wins / error-on-conflict),
+//! the `DeepMergeObjectSchemas` opt-in, and the `MergeInfo`
+//! /`ReplaceListsWhenEmpty` toggles all flow through
+//! [`crate::merge::MergeContext`] — the impls themselves stay
+//! policy-free.
+
+use enumset::EnumSet;
+
+use crate::common::merge::{
+    merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct, merge_opt_vec_by_key,
+    merge_opt_vec_set_union, merge_replace_list_when_nonempty, merge_required_scalar,
+};
+use crate::common::reference::RefOr;
+use crate::merge::{
+    ConflictKind, Merge, MergeContext, MergeError, MergeOptions, MergeReport, MergeWithContext,
+};
+
+use crate::v3_2::callback::Callback;
+use crate::v3_2::components::Components;
+use crate::v3_2::discriminator::Discriminator;
+use crate::v3_2::example::Example;
+use crate::v3_2::external_documentation::ExternalDocumentation;
+use crate::v3_2::header::Header;
+use crate::v3_2::info::{Contact, Info, License};
+use crate::v3_2::link::Link;
+use crate::v3_2::media_type::{Encoding, MediaType};
+use crate::v3_2::operation::Operation;
+use crate::v3_2::parameter::{InCookie, InHeader, InPath, InQuery, InQuerystring, Parameter};
+use crate::v3_2::path_item::{PathItem, Paths};
+use crate::v3_2::request_body::RequestBody;
+use crate::v3_2::response::{Response, Responses};
+use crate::v3_2::schema::{
+    AllOfSchema, AnyOfSchema, ArraySchema, BooleanSchema, EmptySchema, IntegerSchema, MultiSchema,
+    NotSchema, NullSchema, NumberSchema, ObjectSchema, OneOfSchema, Schema, SingleSchema,
+    StringSchema,
+};
+use crate::v3_2::security_scheme::{
+    ApiKeySecurityScheme, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow,
+    DeviceAuthorizationOAuth2Flow, HttpSecurityScheme, ImplicitOAuth2Flow, MutualTLSSecurityScheme,
+    OAuth2Flows, OAuth2SecurityScheme, OpenIdConnectSecurityScheme, PasswordOAuth2Flow,
+    SecurityScheme,
+};
+use crate::v3_2::server::{Server, ServerVariable};
+use crate::v3_2::spec::Spec;
+use crate::v3_2::tag::Tag;
+use crate::v3_2::xml::XML;
+
+// String-keyed maps appear everywhere; this is the single fmt_key the
+// helpers want. Cloning is cheap relative to the surrounding work and
+// keeps signatures uniform.
+#[allow(clippy::ptr_arg)]
+fn key_str(s: &String) -> String {
+    s.clone()
+}
+
+// ----- Public entry point -----
+
+impl Merge for Spec {
+    fn merge(
+        &mut self,
+        other: Self,
+        options: EnumSet<MergeOptions>,
+    ) -> Result<MergeReport, MergeError> {
+        // SAFETY of the `&()` trick: `MergeContext.spec` is a `&T`
+        // back-reference the impls don't currently use (no ref
+        // dereferencing happens during merge). Carrying the borrow as
+        // a unit `&()` keeps the type generic without forcing the
+        // caller to clone the base before merging into it.
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        let path = "#".to_owned();
+        // The actual recursion takes `&mut self` so we can't carry a
+        // borrow of `self` in `ctx.spec`. The component impls below
+        // are written against `MergeContext<()>` accordingly.
+        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, path);
+        ctx.into()
+    }
+}
+
+// ----- Top-level Spec -----
+
+impl MergeWithContext<()> for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        // openapi version: keep base by default; under MergeInfo, use
+        // the standard required-scalar policy.
+        if ctx.is_option(MergeOptions::MergeInfo) {
+            merge_required_scalar(
+                &mut self.openapi,
+                other.openapi,
+                ctx,
+                &format!("{path}.openapi"),
+                ConflictKind::RequiredScalarOverridden,
+            );
+            if ctx.errored {
+                return;
+            }
+            self.info
+                .merge_with_context(other.info, ctx, format!("{path}.info"));
+        } else if self.info != other.info {
+            // Record the suppression so the report still shows the
+            // collision (with Resolution::Base).
+            ctx.record(
+                format!("{path}.info"),
+                ConflictKind::RequiredScalarOverridden,
+                crate::merge::Resolution::Base,
+            );
+        }
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.self_uri,
+            other.self_uri,
+            ctx,
+            &format!("{path}.$self"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.json_schema_dialect,
+            other.json_schema_dialect,
+            ctx,
+            &format!("{path}.jsonSchemaDialect"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_replace_list_when_nonempty(
+            &mut self.servers,
+            other.servers,
+            ctx,
+            &format!("{path}.servers"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(&mut self.paths, other.paths, ctx, &format!("{path}.paths"));
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.webhooks,
+            other.webhooks,
+            ctx,
+            &format!("{path}.webhooks"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.components,
+            other.components,
+            ctx,
+            &format!("{path}.components"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            &format!("{path}.security"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_vec_by_key(
+            &mut self.tags,
+            other.tags,
+            ctx,
+            &format!("{path}.tags"),
+            |t: &Tag| t.name.clone(),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            &format!("{path}.externalDocs"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+// ----- Containers -----
+
+impl MergeWithContext<()> for Components {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_map(
+            &mut self.schemas,
+            other.schemas,
+            ctx,
+            &format!("{path}.schemas"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            &format!("{path}.responses"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            &format!("{path}.parameters"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.request_bodies,
+            other.request_bodies,
+            ctx,
+            &format!("{path}.requestBodies"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            &format!("{path}.headers"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.security_schemes,
+            other.security_schemes,
+            ctx,
+            &format!("{path}.securitySchemes"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.links,
+            other.links,
+            ctx,
+            &format!("{path}.links"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.callbacks,
+            other.callbacks,
+            ctx,
+            &format!("{path}.callbacks"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.path_items,
+            other.path_items,
+            ctx,
+            &format!("{path}.pathItems"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.media_types,
+            other.media_types,
+            ctx,
+            &format!("{path}.mediaTypes"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        for (k, incoming) in other.paths {
+            if let Some(base_v) = self.paths.get_mut(&k) {
+                let child = format!("{path}[{k}]");
+                base_v.merge_with_context(incoming, ctx, child);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.paths.insert(k, incoming);
+            }
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Callback {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        for (k, incoming) in other.paths {
+            if let Some(base_v) = self.paths.get_mut(&k) {
+                let child = format!("{path}[{k}]");
+                base_v.merge_with_context(incoming, ctx, child);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.paths.insert(k, incoming);
+            }
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.reference,
+            other.reference,
+            ctx,
+            &format!("{path}.$ref"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            &format!("{path}.summary"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.operations,
+            other.operations,
+            ctx,
+            &path,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.additional_operations,
+            other.additional_operations,
+            ctx,
+            &format!("{path}.additionalOperations"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_replace_list_when_nonempty(
+            &mut self.servers,
+            other.servers,
+            ctx,
+            &format!("{path}.servers"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            &format!("{path}.parameters"),
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            |k| format!("{}:{}", k.0, k.1),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        match (&mut self.default, other.default) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                b.merge_with_context(i, ctx, format!("{path}.default"));
+            }
+        }
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            &path,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_vec_set_union(&mut self.tags, other.tags, ctx, &format!("{path}.tags"));
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            &format!("{path}.summary"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            &format!("{path}.externalDocs"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.operation_id,
+            other.operation_id,
+            ctx,
+            &format!("{path}.operationId"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            &format!("{path}.parameters"),
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            |k| format!("{}:{}", k.0, k.1),
+        );
+        if ctx.errored {
+            return;
+        }
+        match (&mut self.request_body, other.request_body) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.requestBody")),
+        }
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            &format!("{path}.responses"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.callbacks,
+            other.callbacks,
+            ctx,
+            &format!("{path}.callbacks"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            &format!("{path}.security"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_replace_list_when_nonempty(
+            &mut self.servers,
+            other.servers,
+            ctx,
+            &format!("{path}.servers"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+// ----- Parameter (enum + variants) -----
+
+/// Identity key for an operation/path-item `parameters` list:
+/// `(name, location)`. `location` is `"path"` / `"query"` / `"header"`
+/// / `"cookie"` / `"querystring"` for inline `Parameter` items, or
+/// `"ref"` for a `$ref` (the reference string then plays the role of
+/// the name to keep different refs distinct).
+fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
+    match p {
+        RefOr::Ref(r) => (r.reference.clone(), "ref"),
+        RefOr::Item(p) => match p {
+            Parameter::Path(p) => (p.name.clone(), "path"),
+            Parameter::Query(p) => (p.name.clone(), "query"),
+            Parameter::Header(p) => (p.name.clone(), "header"),
+            Parameter::Cookie(p) => (p.name.clone(), "cookie"),
+            Parameter::Querystring(p) => (p.name.clone(), "querystring"),
+        },
+    }
+}
+
+impl MergeWithContext<()> for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        match (self, other) {
+            (Parameter::Path(a), Parameter::Path(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Query(a), Parameter::Query(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Header(a), Parameter::Header(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Cookie(a), Parameter::Cookie(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Querystring(a), Parameter::Querystring(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (slot, incoming) => {
+                if ctx.should_take_incoming(&path, ConflictKind::ParameterVariantMismatch) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for InPath {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            &format!("{path}.style"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            &format!("{path}.explode"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            &format!("{path}.content"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for InQuery {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.allow_empty_value,
+            other.allow_empty_value,
+            ctx,
+            &format!("{path}.allowEmptyValue"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            &format!("{path}.style"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            &format!("{path}.explode"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.allow_reserved,
+            other.allow_reserved,
+            ctx,
+            &format!("{path}.allowReserved"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            &format!("{path}.content"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for InHeader {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            &format!("{path}.style"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            &format!("{path}.explode"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            &format!("{path}.content"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for InCookie {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            &format!("{path}.style"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            &format!("{path}.explode"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            &format!("{path}.content"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for InQuerystring {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        // querystring `content` is a bare BTreeMap (required by the spec).
+        for (k, incoming) in other.content {
+            if let Some(b) = self.content.get_mut(&k) {
+                b.merge_with_context(incoming, ctx, format!("{path}.content.{k}"));
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.content.insert(k, incoming);
+            }
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+/// Shared helper: merge an `Option<RefOr<Schema>>`. Used by every
+/// parameter variant and by Header.
+fn merge_param_schema(
+    base: &mut Option<RefOr<Schema>>,
+    other: Option<RefOr<Schema>>,
+    ctx: &mut MergeContext<()>,
+    path: &str,
+) {
+    match (base.as_mut(), other) {
+        (_, None) => {}
+        (None, Some(v)) => *base = Some(v),
+        (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.schema")),
+    }
+}
+
+// ----- MediaType / Encoding / Header / Response / RequestBody / Example / Link -----
+
+impl MergeWithContext<()> for MediaType {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(&mut self.item_schema, other.item_schema, ctx, &path);
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.encoding,
+            other.encoding,
+            ctx,
+            &format!("{path}.encoding"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        // prefix_encoding is a positional list — replace when non-empty.
+        merge_replace_list_when_nonempty(
+            &mut self.prefix_encoding,
+            other.prefix_encoding,
+            ctx,
+            &format!("{path}.prefixEncoding"),
+        );
+        if ctx.errored {
+            return;
+        }
+        match (&mut self.item_encoding, other.item_encoding) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.itemEncoding")),
+        }
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Encoding {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.content_type,
+            other.content_type,
+            ctx,
+            &format!("{path}.contentType"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            &format!("{path}.headers"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            &format!("{path}.style"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            &format!("{path}.explode"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.allow_reserved,
+            other.allow_reserved,
+            ctx,
+            &format!("{path}.allowReserved"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.encoding,
+            other.encoding,
+            ctx,
+            &format!("{path}.encoding"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_replace_list_when_nonempty(
+            &mut self.prefix_encoding,
+            other.prefix_encoding,
+            ctx,
+            &format!("{path}.prefixEncoding"),
+        );
+        if ctx.errored {
+            return;
+        }
+        match (&mut self.item_encoding, other.item_encoding) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => b.merge_with_context(*i, ctx, format!("{path}.itemEncoding")),
+        }
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            &format!("{path}.style"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            &format!("{path}.explode"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            &format!("{path}.content"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            &format!("{path}.summary"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            &format!("{path}.headers"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            &format!("{path}.content"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.links,
+            other.links,
+            ctx,
+            &format!("{path}.links"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for RequestBody {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        // content is a bare BTreeMap (required).
+        for (k, incoming) in other.content {
+            if let Some(b) = self.content.get_mut(&k) {
+                b.merge_with_context(incoming, ctx, format!("{path}.content.{k}"));
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.content.insert(k, incoming);
+            }
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Example {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            &format!("{path}.summary"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.value,
+            other.value,
+            ctx,
+            &format!("{path}.value"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.serialized_value,
+            other.serialized_value,
+            ctx,
+            &format!("{path}.serializedValue"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.data_value,
+            other.data_value,
+            ctx,
+            &format!("{path}.dataValue"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.external_value,
+            other.external_value,
+            ctx,
+            &format!("{path}.externalValue"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Link {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.operation_ref,
+            other.operation_ref,
+            ctx,
+            &format!("{path}.operationRef"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.operation_id,
+            other.operation_id,
+            ctx,
+            &format!("{path}.operationId"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        // Link.parameters is `Option<BTreeMap<String, serde_json::Value>>`
+        // — treat like extensions.
+        merge_extensions(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            &format!("{path}.parameters"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.request_body,
+            other.request_body,
+            ctx,
+            &format!("{path}.requestBody"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.server,
+            other.server,
+            ctx,
+            &format!("{path}.server"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+// ----- Leaves: Tag, Info, Contact, License, ExternalDocumentation,
+//                Discriminator, XML, Server, ServerVariable -----
+
+impl MergeWithContext<()> for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            &format!("{path}.name"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            &format!("{path}.summary"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            &format!("{path}.externalDocs"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.parent,
+            other.parent,
+            ctx,
+            &format!("{path}.parent"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.kind,
+            other.kind,
+            ctx,
+            &format!("{path}.kind"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            &format!("{path}.title"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            &format!("{path}.summary"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.terms_of_service,
+            other.terms_of_service,
+            ctx,
+            &format!("{path}.termsOfService"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.contact,
+            other.contact,
+            ctx,
+            &format!("{path}.contact"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.license,
+            other.license,
+            ctx,
+            &format!("{path}.license"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.version,
+            other.version,
+            ctx,
+            &format!("{path}.version"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            &format!("{path}.name"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            &format!("{path}.url"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.email,
+            other.email,
+            ctx,
+            &format!("{path}.email"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            &format!("{path}.name"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.identifier,
+            other.identifier,
+            ctx,
+            &format!("{path}.identifier"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            &format!("{path}.url"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            &format!("{path}.url"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Discriminator {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.property_name,
+            other.property_name,
+            ctx,
+            &format!("{path}.propertyName"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        // mapping is Option<BTreeMap<String,String>>; per-key incoming wins.
+        if let Some(other_map) = other.mapping {
+            let base_map = self
+                .mapping
+                .get_or_insert_with(std::collections::BTreeMap::new);
+            for (k, v) in other_map {
+                match base_map.get_mut(&k) {
+                    None => {
+                        base_map.insert(k, v);
+                    }
+                    Some(existing) => {
+                        if *existing != v
+                            && ctx.should_take_incoming(
+                                &format!("{path}.mapping.{k}"),
+                                ConflictKind::ScalarOverridden,
+                            )
+                        {
+                            *existing = v;
+                        }
+                    }
+                }
+                if ctx.errored {
+                    return;
+                }
+            }
+        }
+        merge_opt_scalar(
+            &mut self.default_mapping,
+            other.default_mapping,
+            ctx,
+            &format!("{path}.defaultMapping"),
+            ConflictKind::ScalarOverridden,
+        );
+    }
+}
+
+impl MergeWithContext<()> for XML {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            &format!("{path}.name"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.namespace,
+            other.namespace,
+            ctx,
+            &format!("{path}.namespace"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.prefix,
+            other.prefix,
+            ctx,
+            &format!("{path}.prefix"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.attribute,
+            other.attribute,
+            ctx,
+            &format!("{path}.attribute"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.wrapped,
+            other.wrapped,
+            ctx,
+            &format!("{path}.wrapped"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.node_type,
+            other.node_type,
+            ctx,
+            &format!("{path}.nodeType"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            &format!("{path}.url"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            &format!("{path}.name"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.variables,
+            other.variables,
+            ctx,
+            &format!("{path}.variables"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for ServerVariable {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        // ServerVariable in our model has only `extensions`; the
+        // spec's `default`/`enum`/`description` are public fields on
+        // the struct but not enumerated above. Fall back to a full
+        // field walk via mem::replace so we don't drop incoming
+        // fields silently.
+        let ServerVariable { extensions, .. } = other;
+        merge_extensions(
+            &mut self.extensions,
+            extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+// ----- SecurityScheme -----
+
+impl MergeWithContext<()> for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        match (self, other) {
+            (SecurityScheme::ApiKey(a), SecurityScheme::ApiKey(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::HTTP(a), SecurityScheme::HTTP(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::OAuth2(a), SecurityScheme::OAuth2(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::OpenIdConnect(a), SecurityScheme::OpenIdConnect(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::MutualTLS(a), SecurityScheme::MutualTLS(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (slot, incoming) => {
+                if ctx.should_take_incoming(&path, ConflictKind::ParameterVariantMismatch) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for ApiKeySecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            &format!("{path}.name"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.location,
+            other.location,
+            ctx,
+            &format!("{path}.in"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for HttpSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.scheme,
+            other.scheme,
+            ctx,
+            &format!("{path}.scheme"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.bearer_format,
+            other.bearer_format,
+            ctx,
+            &format!("{path}.bearerFormat"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for MutualTLSSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_required_scalar(
+            &mut self.open_id_connect_url,
+            other.open_id_connect_url,
+            ctx,
+            &format!("{path}.openIdConnectUrl"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for OAuth2SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        self.flows
+            .merge_with_context(other.flows, ctx, format!("{path}.flows"));
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.oauth2_metadata_url,
+            other.oauth2_metadata_url,
+            ctx,
+            &format!("{path}.oauth2MetadataUrl"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+impl MergeWithContext<()> for OAuth2Flows {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_struct(
+            &mut self.implicit,
+            other.implicit,
+            ctx,
+            &format!("{path}.implicit"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.password,
+            other.password,
+            ctx,
+            &format!("{path}.password"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.client_credentials,
+            other.client_credentials,
+            ctx,
+            &format!("{path}.clientCredentials"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.authorization_code,
+            other.authorization_code,
+            ctx,
+            &format!("{path}.authorizationCode"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.device_authorization,
+            other.device_authorization,
+            ctx,
+            &format!("{path}.deviceAuthorization"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+/// Each OAuth flow has the same shape: optional URL fields + a bare
+/// `BTreeMap<String, String>` of scopes + extensions. Macro keeps it
+/// from sprawling.
+macro_rules! oauth_flow_merge {
+    ($t:ty, $($url_field:ident => $url_path:literal),* $(,)?) => {
+        impl MergeWithContext<()> for $t {
+            fn merge_with_context(
+                &mut self,
+                other: Self,
+                ctx: &mut MergeContext<()>,
+                path: String,
+            ) {
+                $(
+                    merge_required_scalar(
+                        &mut self.$url_field,
+                        other.$url_field,
+                        ctx,
+                        &format!("{path}.{}", $url_path),
+                        ConflictKind::RequiredScalarOverridden,
+                    );
+                    if ctx.errored {
+                        return;
+                    }
+                )*
+                merge_opt_scalar(
+                    &mut self.refresh_url,
+                    other.refresh_url,
+                    ctx,
+                    &format!("{path}.refreshUrl"),
+                    ConflictKind::ScalarOverridden,
+                );
+                if ctx.errored {
+                    return;
+                }
+                // scopes is a bare BTreeMap<String, String>.
+                for (k, v) in other.scopes {
+                    match self.scopes.get_mut(&k) {
+                        None => {
+                            self.scopes.insert(k, v);
+                        }
+                        Some(existing) => {
+                            if *existing != v
+                                && ctx.should_take_incoming(
+                                    &format!("{path}.scopes.{k}"),
+                                    ConflictKind::ScalarOverridden,
+                                )
+                            {
+                                *existing = v;
+                            }
+                        }
+                    }
+                    if ctx.errored {
+                        return;
+                    }
+                }
+                merge_extensions(
+                    &mut self.extensions,
+                    other.extensions,
+                    ctx,
+                    &format!("{path}.extensions"),
+                );
+            }
+        }
+    };
+}
+
+oauth_flow_merge!(ImplicitOAuth2Flow, authorization_url => "authorizationUrl");
+oauth_flow_merge!(PasswordOAuth2Flow, token_url => "tokenUrl");
+oauth_flow_merge!(ClientCredentialsOAuth2Flow, token_url => "tokenUrl");
+oauth_flow_merge!(
+    AuthorizationCodeOAuth2Flow,
+    authorization_url => "authorizationUrl",
+    token_url => "tokenUrl",
+);
+oauth_flow_merge!(
+    DeviceAuthorizationOAuth2Flow,
+    device_authorization_url => "deviceAuthorizationUrl",
+    token_url => "tokenUrl",
+);
+
+// ----- Schema -----
+
+impl MergeWithContext<()> for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        // ObjectSchema deep-merge is the one variant pairing that
+        // recurses — everything else falls back to leaf-replace.
+        if ctx.is_option(MergeOptions::DeepMergeObjectSchemas)
+            && let (Schema::Single(self_single), Schema::Single(other_single)) =
+                (&mut *self, &other)
+            && let (SingleSchema::Object(_), SingleSchema::Object(_)) =
+                (&**self_single, &**other_single)
+        {
+            // Drop into a fresh match to take ownership of the
+            // incoming side.
+            let Schema::Single(other_single) = other else {
+                unreachable!()
+            };
+            let SingleSchema::Object(other_obj) = *other_single else {
+                unreachable!()
+            };
+            let SingleSchema::Object(self_obj) = &mut **self_single else {
+                unreachable!()
+            };
+            self_obj.merge_with_context(other_obj, ctx, path);
+            return;
+        }
+        // Default: leaf-replace policy.
+        if *self != other && ctx.should_take_incoming(&path, ConflictKind::SchemaLeafReplaced) {
+            *self = other;
+        }
+    }
+}
+
+impl MergeWithContext<()> for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        merge_opt_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            &format!("{path}.title"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.properties,
+            other.properties,
+            ctx,
+            &format!("{path}.properties"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.pattern_properties,
+            other.pattern_properties,
+            ctx,
+            &format!("{path}.patternProperties"),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.default,
+            other.default,
+            ctx,
+            &format!("{path}.default"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.max_properties,
+            other.max_properties,
+            ctx,
+            &format!("{path}.maxProperties"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.min_properties,
+            other.min_properties,
+            ctx,
+            &format!("{path}.minProperties"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        match (&mut self.additional_properties, other.additional_properties) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                b.merge_with_context(i, ctx, format!("{path}.additionalProperties"))
+            }
+        }
+        if ctx.errored {
+            return;
+        }
+        match (
+            &mut self.unevaluated_properties,
+            other.unevaluated_properties,
+        ) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                b.merge_with_context(i, ctx, format!("{path}.unevaluatedProperties"))
+            }
+        }
+        if ctx.errored {
+            return;
+        }
+        merge_param_schema(
+            &mut self.property_names,
+            other.property_names,
+            ctx,
+            &format!("{path}.propertyNames"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_vec_set_union(
+            &mut self.required,
+            other.required,
+            ctx,
+            &format!("{path}.required"),
+        );
+        merge_opt_scalar(
+            &mut self.read_only,
+            other.read_only,
+            ctx,
+            &format!("{path}.readOnly"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.write_only,
+            other.write_only,
+            ctx,
+            &format!("{path}.writeOnly"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            &format!("{path}.deprecated"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(&mut self.xml, other.xml, ctx, &format!("{path}.xml"));
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            &format!("{path}.externalDocs"),
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            &format!("{path}.example"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            &format!("{path}.examples"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
+// Schema sub-types that aren't recursively deep-merged still need a
+// `MergeWithContext<()>` impl so the generic `RefOr<X>::merge_with_context`
+// compiles when `X` is one of them. They land here as opaque leaves
+// (replace incoming-wins, recorded as `SchemaLeafReplaced`).
+macro_rules! leaf_schema_merge {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl MergeWithContext<()> for $t {
+                fn merge_with_context(
+                    &mut self,
+                    other: Self,
+                    ctx: &mut MergeContext<()>,
+                    path: String,
+                ) {
+                    if *self != other
+                        && ctx.should_take_incoming(&path, ConflictKind::SchemaLeafReplaced)
+                    {
+                        *self = other;
+                    }
+                }
+            }
+        )*
+    };
+}
+
+leaf_schema_merge!(
+    EmptySchema,
+    StringSchema,
+    IntegerSchema,
+    NumberSchema,
+    BooleanSchema,
+    ArraySchema,
+    NullSchema,
+    AllOfSchema,
+    AnyOfSchema,
+    OneOfSchema,
+    NotSchema,
+    MultiSchema,
+    SingleSchema,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::reference::{Ref, RefOr};
+    use crate::merge::{ConflictKind, MergeOptions, Resolution};
+    use crate::v3_2::components::Components;
+    use crate::v3_2::operation::Operation;
+    use crate::v3_2::parameter::{InPath, InQuery, Parameter};
+    use crate::v3_2::path_item::{PathItem, Paths};
+    use crate::v3_2::response::{Response, Responses};
+    use crate::v3_2::schema::{ObjectSchema, Schema, SingleSchema};
+    use crate::v3_2::tag::Tag;
+    use std::collections::BTreeMap;
+
+    fn param_path(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Path(Box::new(InPath {
+            name: name.into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn param_query(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Query(Box::new(InQuery {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn response_with(description: &str) -> RefOr<Response> {
+        RefOr::new_item(Response {
+            description: Some(description.into()),
+            ..Default::default()
+        })
+    }
+
+    // ---- RefOr collisions ----
+
+    #[test]
+    fn refor_item_item_recurses() {
+        let mut base: RefOr<Tag> = RefOr::new_item(Tag {
+            name: "pets".into(),
+            description: Some("base".into()),
+            ..Default::default()
+        });
+        let incoming: RefOr<Tag> = RefOr::new_item(Tag {
+            name: "pets".into(),
+            summary: Some("from incoming".into()),
+            ..Default::default()
+        });
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#.tags[pets]".into());
+        match base {
+            RefOr::Item(t) => {
+                assert_eq!(t.description.as_deref(), Some("base"));
+                assert_eq!(t.summary.as_deref(), Some("from incoming"));
+            }
+            _ => panic!("expected Item"),
+        }
+    }
+
+    #[test]
+    fn refor_ref_ref_same_target_merges_metadata() {
+        let mut base: RefOr<Tag> = RefOr::Ref(Box::new(Ref {
+            reference: "#/components/tags/Pets".into(),
+            summary: Some("base summary".into()),
+            description: None,
+        }));
+        let incoming: RefOr<Tag> = RefOr::Ref(Box::new(Ref {
+            reference: "#/components/tags/Pets".into(),
+            summary: None,
+            description: Some("new desc".into()),
+        }));
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#".into());
+        match base {
+            RefOr::Ref(r) => {
+                assert_eq!(r.summary.as_deref(), Some("base summary"));
+                assert_eq!(r.description.as_deref(), Some("new desc"));
+            }
+            _ => panic!("expected Ref"),
+        }
+        assert!(ctx.conflicts.is_empty());
+    }
+
+    #[test]
+    fn refor_ref_ref_different_target_replaces_and_records() {
+        let mut base: RefOr<Tag> = RefOr::Ref(Box::new(Ref::new("#/components/tags/A")));
+        let incoming: RefOr<Tag> = RefOr::Ref(Box::new(Ref::new("#/components/tags/B")));
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#.tags[0]".into());
+        match base {
+            RefOr::Ref(r) => assert_eq!(r.reference, "#/components/tags/B"),
+            _ => panic!("expected Ref"),
+        }
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::RefReplaced);
+        assert_eq!(ctx.conflicts[0].resolution, Resolution::Incoming);
+    }
+
+    #[test]
+    fn refor_ref_vs_item_records_ref_vs_value() {
+        let mut base: RefOr<Tag> = RefOr::Ref(Box::new(Ref::new("#/components/tags/A")));
+        let incoming: RefOr<Tag> = RefOr::new_item(Tag {
+            name: "x".into(),
+            ..Default::default()
+        });
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#".into());
+        assert!(matches!(base, RefOr::Item(_)));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::RefVsValue);
+    }
+
+    // ---- Operation: responses across status codes ----
+
+    #[test]
+    fn operation_responses_keeps_base_status_codes_not_in_incoming() {
+        let mut base = Operation {
+            responses: Some(Responses {
+                responses: Some(BTreeMap::from([
+                    ("200".into(), response_with("ok")),
+                    ("404".into(), response_with("missing")),
+                ])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let incoming = Operation {
+            responses: Some(Responses {
+                responses: Some(BTreeMap::from([
+                    ("200".into(), response_with("ok updated")),
+                    ("500".into(), response_with("server error")),
+                ])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#.op".into());
+
+        let r = base.responses.unwrap().responses.unwrap();
+        assert!(r.contains_key("200"));
+        assert!(r.contains_key("404"), "base-only status preserved");
+        assert!(r.contains_key("500"), "incoming-only status added");
+        let RefOr::Item(r200) = r.get("200").unwrap() else {
+            panic!()
+        };
+        assert_eq!(r200.description.as_deref(), Some("ok updated"));
+    }
+
+    // ---- Operation: parameter dedup by (name, in) ----
+
+    #[test]
+    fn operation_parameters_dedup_by_name_in() {
+        let mut base = Operation {
+            parameters: Some(vec![param_path("id"), param_query("limit")]),
+            ..Default::default()
+        };
+        let incoming = Operation {
+            // Same (name="id", in=path) — should overwrite base's id, not append.
+            // New (name="filter", in=query) — should append.
+            parameters: Some(vec![param_path("id"), param_query("filter")]),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#.op".into());
+        let params = base.parameters.unwrap();
+        assert_eq!(params.len(), 3, "no duplicates by (name, in)");
+    }
+
+    // ---- PathItem: method coexistence ----
+
+    #[test]
+    fn pathitem_get_and_post_coexist_after_merge() {
+        let mut base = PathItem {
+            operations: Some(BTreeMap::from([("get".to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let incoming = PathItem {
+            operations: Some(BTreeMap::from([("post".to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#.paths[/pets]".into());
+        let ops = base.operations.unwrap();
+        assert!(ops.contains_key("get"));
+        assert!(ops.contains_key("post"));
+    }
+
+    // ---- Schema: leaf replace by default ----
+
+    #[test]
+    fn schema_collision_replaces_by_default_records_leaf_replaced() {
+        let mut base = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            required: Some(vec!["a".into()]),
+            ..Default::default()
+        })));
+        let incoming = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            required: Some(vec!["b".into()]),
+            ..Default::default()
+        })));
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#.s".into());
+        // Replaced — `required` is now from incoming.
+        let Schema::Single(box_single) = &base else {
+            panic!()
+        };
+        let SingleSchema::Object(obj) = &**box_single else {
+            panic!()
+        };
+        assert_eq!(obj.required.as_deref(), Some(&["b".to_owned()][..]));
+        assert_eq!(ctx.conflicts.len(), 1);
+        assert_eq!(ctx.conflicts[0].kind, ConflictKind::SchemaLeafReplaced);
+    }
+
+    #[test]
+    fn schema_object_deep_merge_under_option() {
+        let mut base = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            properties: Some(BTreeMap::from([(
+                "a".to_owned(),
+                RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                    ObjectSchema::default(),
+                )))),
+            )])),
+            required: Some(vec!["a".into()]),
+            ..Default::default()
+        })));
+        let incoming = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            properties: Some(BTreeMap::from([(
+                "b".to_owned(),
+                RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                    ObjectSchema::default(),
+                )))),
+            )])),
+            required: Some(vec!["b".into()]),
+            ..Default::default()
+        })));
+        let mut ctx: MergeContext<()> =
+            MergeContext::new(&(), MergeOptions::DeepMergeObjectSchemas.only());
+        base.merge_with_context(incoming, &mut ctx, "#.s".into());
+        let Schema::Single(box_single) = &base else {
+            panic!()
+        };
+        let SingleSchema::Object(obj) = &**box_single else {
+            panic!()
+        };
+        let props = obj.properties.as_ref().unwrap();
+        assert!(props.contains_key("a"));
+        assert!(props.contains_key("b"));
+        let req = obj.required.as_ref().unwrap();
+        assert!(req.contains(&"a".to_owned()));
+        assert!(req.contains(&"b".to_owned()));
+    }
+
+    // ---- Spec: three modes ----
+
+    fn spec_with_description(desc: &str) -> Spec {
+        Spec {
+            json_schema_dialect: Some(desc.into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn spec_default_incoming_wins() {
+        let mut base = spec_with_description("base");
+        let incoming = spec_with_description("incoming");
+        let report = base.merge(incoming, MergeOptions::new()).unwrap();
+        assert_eq!(base.json_schema_dialect.as_deref(), Some("incoming"));
+        assert_eq!(report.len(), 1);
+        assert_eq!(report.conflicts[0].resolution, Resolution::Incoming);
+    }
+
+    #[test]
+    fn spec_base_wins_mode() {
+        let mut base = spec_with_description("base");
+        let incoming = spec_with_description("incoming");
+        let report = base.merge(incoming, MergeOptions::BaseWins.only()).unwrap();
+        assert_eq!(base.json_schema_dialect.as_deref(), Some("base"));
+        assert_eq!(report.conflicts[0].resolution, Resolution::Base);
+    }
+
+    #[test]
+    fn spec_error_on_conflict_returns_err() {
+        let mut base = spec_with_description("base");
+        let incoming = spec_with_description("incoming");
+        let result = base.merge(incoming, MergeOptions::ErrorOnConflict.only());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(!err.conflicts.is_empty());
+        assert_eq!(err.conflicts[0].resolution, Resolution::Errored);
+    }
+
+    // ---- Spec.tags: dedup by name with recursion ----
+
+    #[test]
+    fn spec_tags_dedup_by_name() {
+        let mut base = Spec {
+            tags: Some(vec![Tag {
+                name: "pets".into(),
+                description: Some("base".into()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let incoming = Spec {
+            tags: Some(vec![
+                // same name — should recurse, not append.
+                Tag {
+                    name: "pets".into(),
+                    summary: Some("from incoming".into()),
+                    ..Default::default()
+                },
+                // new name — should append.
+                Tag {
+                    name: "stores".into(),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        };
+        base.merge(incoming, MergeOptions::new()).unwrap();
+        let tags = base.tags.unwrap();
+        assert_eq!(tags.len(), 2);
+        let pets = tags.iter().find(|t| t.name == "pets").unwrap();
+        assert_eq!(pets.description.as_deref(), Some("base"));
+        assert_eq!(pets.summary.as_deref(), Some("from incoming"));
+    }
+
+    // ---- Spec.paths: deep merge keeps unrelated methods ----
+
+    #[test]
+    fn spec_paths_deep_merge_preserves_unrelated_methods() {
+        let mk_pi = |method: &str| PathItem {
+            operations: Some(BTreeMap::from([(method.to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let mut base = Spec {
+            paths: Some(Paths {
+                paths: BTreeMap::from([("/pets".to_owned(), mk_pi("get"))]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let incoming = Spec {
+            paths: Some(Paths {
+                paths: BTreeMap::from([("/pets".to_owned(), mk_pi("post"))]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        base.merge(incoming, MergeOptions::new()).unwrap();
+        let pi = &base.paths.unwrap().paths["/pets"];
+        let ops = pi.operations.as_ref().unwrap();
+        assert!(ops.contains_key("get"));
+        assert!(ops.contains_key("post"));
+    }
+
+    // ---- Spec.info kept on base by default; merged under MergeInfo ----
+
+    #[test]
+    fn spec_info_kept_on_base_by_default() {
+        use crate::v3_2::info::Info;
+        let mut base = Spec {
+            info: Info {
+                title: "Base API".into(),
+                version: "1.0.0".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let incoming = Spec {
+            info: Info {
+                title: "Incoming API".into(),
+                version: "2.0.0".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let report = base.merge(incoming, MergeOptions::new()).unwrap();
+        assert_eq!(base.info.title, "Base API");
+        assert_eq!(base.info.version, "1.0.0");
+        // Conflict was still recorded.
+        assert!(
+            report
+                .conflicts
+                .iter()
+                .any(|c| c.path.ends_with(".info") && c.resolution == Resolution::Base)
+        );
+    }
+
+    #[test]
+    fn spec_info_merged_under_merge_info_option() {
+        use crate::v3_2::info::Info;
+        let mut base = Spec {
+            info: Info {
+                title: "Base".into(),
+                version: "1.0.0".into(),
+                description: Some("base desc".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let incoming = Spec {
+            info: Info {
+                title: "Base".into(),
+                version: "1.0.0".into(),
+                summary: Some("from incoming".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        base.merge(incoming, MergeOptions::MergeInfo.only())
+            .unwrap();
+        assert_eq!(base.info.description.as_deref(), Some("base desc"));
+        assert_eq!(base.info.summary.as_deref(), Some("from incoming"));
+    }
+
+    // ---- Components: schemas collision uses leaf replace by default ----
+
+    #[test]
+    fn components_schema_collision_default_is_leaf_replace() {
+        let s1 = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            required: Some(vec!["a".into()]),
+            ..Default::default()
+        })));
+        let s2 = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            required: Some(vec!["b".into()]),
+            ..Default::default()
+        })));
+        let mut base = Spec {
+            components: Some(Components {
+                schemas: Some(BTreeMap::from([("Pet".to_owned(), RefOr::new_item(s1))])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let incoming = Spec {
+            components: Some(Components {
+                schemas: Some(BTreeMap::from([("Pet".to_owned(), RefOr::new_item(s2))])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let report = base.merge(incoming, MergeOptions::new()).unwrap();
+        let schemas = base.components.unwrap().schemas.unwrap();
+        let RefOr::Item(pet) = schemas.get("Pet").unwrap() else {
+            panic!()
+        };
+        let Schema::Single(box_s) = pet else { panic!() };
+        let SingleSchema::Object(obj) = &**box_s else {
+            panic!()
+        };
+        assert_eq!(obj.required.as_deref(), Some(&["b".to_owned()][..]));
+        assert!(
+            report
+                .conflicts
+                .iter()
+                .any(|c| c.kind == ConflictKind::SchemaLeafReplaced)
+        );
+    }
+}

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -1827,6 +1827,12 @@ impl MergeWithContext<()> for Discriminator {
                         }
                     }
                 }
+                // ErrorOnConflict: bail on the first collision; matches
+                // the OAuth scopes loop and the documented "first real
+                // collision triggers early error" contract.
+                if ctx.errored {
+                    return;
+                }
             }
         }
         merge_opt_scalar(
@@ -2896,6 +2902,42 @@ mod tests {
         let err = result.unwrap_err();
         assert!(!err.conflicts.is_empty());
         assert_eq!(err.conflicts[0].resolution, Resolution::Errored);
+    }
+
+    #[test]
+    fn discriminator_mapping_loop_breaks_on_error_on_conflict() {
+        use crate::v3_2::discriminator::Discriminator;
+        // Two mapping collisions in a row; under ErrorOnConflict only
+        // the first should land in the report — the loop must `return`
+        // after the first collision, not keep recording. Before the
+        // early-break fix this test would see two recorded conflicts.
+        let mut base = Discriminator {
+            property_name: "kind".into(),
+            mapping: Some(BTreeMap::from([
+                ("a".to_owned(), "#/c/A".to_owned()),
+                ("b".to_owned(), "#/c/B".to_owned()),
+            ])),
+            ..Default::default()
+        };
+        let incoming = Discriminator {
+            property_name: "kind".into(),
+            mapping: Some(BTreeMap::from([
+                ("a".to_owned(), "#/c/AA".to_owned()),
+                ("b".to_owned(), "#/c/BB".to_owned()),
+            ])),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> =
+            MergeContext::new(&(), MergeOptions::ErrorOnConflict.only());
+        let mut path = String::from("#.d");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        assert!(ctx.errored, "first mapping collision must trip errored");
+        assert_eq!(
+            ctx.conflicts.len(),
+            1,
+            "loop must return after first collision, got {} conflicts",
+            ctx.conflicts.len()
+        );
     }
 
     #[test]

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -19,8 +19,9 @@
 use enumset::EnumSet;
 
 use crate::common::merge::{
-    merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct, merge_opt_vec_by_key,
-    merge_opt_vec_set_union, merge_replace_list_when_nonempty, merge_required_scalar,
+    PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
+    merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
+    merge_required_scalar,
 };
 use crate::common::reference::RefOr;
 use crate::merge::{
@@ -57,12 +58,22 @@ use crate::v3_2::spec::Spec;
 use crate::v3_2::tag::Tag;
 use crate::v3_2::xml::XML;
 
-// String-keyed maps appear everywhere; this is the single fmt_key the
-// helpers want. Cloning is cheap relative to the surrounding work and
-// keeps signatures uniform.
+// String-keyed maps appear everywhere; this is the single fmt_key
+// the helpers want. Writes the key directly into the path buffer
+// instead of allocating a fresh String — the helpers' `fmt_key`
+// signature is `Fn(&K, &mut String)` for exactly this reason.
 #[allow(clippy::ptr_arg)]
-fn key_str(s: &String) -> String {
-    s.clone()
+fn key_str(s: &String, out: &mut String) {
+    out.push_str(s);
+}
+
+/// `fmt_key` for the `(name, location)` keys used by
+/// `Operation.parameters` / `PathItem.parameters`. Writes
+/// `<name>:<location>` into the path buffer.
+fn fmt_param_key(k: &(String, &'static str), out: &mut String) {
+    out.push_str(&k.0);
+    out.push(':');
+    out.push_str(k.1);
 }
 
 // ----- Public entry point -----
@@ -79,7 +90,9 @@ impl Merge for Spec {
         // a unit `&()` keeps the type generic without forcing the
         // caller to clone the base before merging into it.
         let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
-        let path = "#".to_owned();
+        // Single owned `String` for the whole merge — every child
+        // pushes/truncates segments onto it via the helper guards.
+        let mut path = String::from("#");
 
         if options.contains(MergeOptions::ErrorOnConflict) {
             // Strict-mode rollback: clone `self` into a working copy
@@ -90,7 +103,12 @@ impl Merge for Spec {
             // `ErrorOnConflict` to get. The clone cost is paid only
             // when the option is opted in.
             let mut working = self.clone();
-            <Spec as MergeWithContext<()>>::merge_with_context(&mut working, other, &mut ctx, path);
+            <Spec as MergeWithContext<()>>::merge_with_context(
+                &mut working,
+                other,
+                &mut ctx,
+                &mut path,
+            );
             if ctx.errored {
                 return Err(MergeError {
                     conflicts: ctx.conflicts,
@@ -105,7 +123,7 @@ impl Merge for Spec {
         // Non-strict modes mutate `self` in place — the report still
         // captures every resolution, so callers wanting "see what
         // changed" don't need the clone-and-replace overhead.
-        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, path);
+        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
         ctx.into()
     }
 }
@@ -113,7 +131,7 @@ impl Merge for Spec {
 // ----- Top-level Spec -----
 
 impl MergeWithContext<()> for Spec {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -132,23 +150,29 @@ impl MergeWithContext<()> for Spec {
                 &mut self.openapi,
                 other.openapi,
                 ctx,
-                &format!("{path}.openapi"),
+                path,
+                ".openapi",
                 ConflictKind::RequiredScalarOverridden,
             );
-            self.info
-                .merge_with_context(other.info, ctx, format!("{path}.info"));
+            {
+                let mut guard = PathGuard::new(path, ".info");
+                self.info
+                    .merge_with_context(other.info, ctx, guard.path_mut());
+            }
         } else {
             if self.openapi != other.openapi {
                 record_kept_base_or_error(
                     ctx,
-                    &format!("{path}.openapi"),
+                    path,
+                    ".openapi",
                     ConflictKind::RequiredScalarOverridden,
                 );
             }
             if !ctx.errored && self.info != other.info {
                 record_kept_base_or_error(
                     ctx,
-                    &format!("{path}.info"),
+                    path,
+                    ".info",
                     ConflictKind::RequiredScalarOverridden,
                 );
             }
@@ -157,46 +181,41 @@ impl MergeWithContext<()> for Spec {
             &mut self.self_uri,
             other.self_uri,
             ctx,
-            &format!("{path}.$self"),
+            path,
+            ".$self",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.json_schema_dialect,
             other.json_schema_dialect,
             ctx,
-            &format!("{path}.jsonSchemaDialect"),
+            path,
+            ".jsonSchemaDialect",
             ConflictKind::ScalarOverridden,
         );
-        merge_replace_list_when_nonempty(
-            &mut self.servers,
-            other.servers,
-            ctx,
-            &format!("{path}.servers"),
-        );
-        merge_opt_struct(&mut self.paths, other.paths, ctx, &format!("{path}.paths"));
-        merge_opt_struct(
-            &mut self.webhooks,
-            other.webhooks,
-            ctx,
-            &format!("{path}.webhooks"),
-        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
+        merge_opt_struct(&mut self.paths, other.paths, ctx, path, ".paths");
+        merge_opt_struct(&mut self.webhooks, other.webhooks, ctx, path, ".webhooks");
         merge_opt_struct(
             &mut self.components,
             other.components,
             ctx,
-            &format!("{path}.components"),
+            path,
+            ".components",
         );
         merge_replace_list_when_nonempty(
             &mut self.security,
             other.security,
             ctx,
-            &format!("{path}.security"),
+            path,
+            ".security",
         );
         merge_opt_vec_by_key(
             &mut self.tags,
             other.tags,
             ctx,
-            &format!("{path}.tags"),
+            path,
+            ".tags",
             |t: &Tag| t.name.clone(),
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
@@ -205,13 +224,15 @@ impl MergeWithContext<()> for Spec {
             &mut self.external_docs,
             other.external_docs,
             ctx,
-            &format!("{path}.externalDocs"),
+            path,
+            ".externalDocs",
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
@@ -219,7 +240,7 @@ impl MergeWithContext<()> for Spec {
 // ----- Containers -----
 
 impl MergeWithContext<()> for Components {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -227,7 +248,8 @@ impl MergeWithContext<()> for Components {
             &mut self.schemas,
             other.schemas,
             ctx,
-            &format!("{path}.schemas"),
+            path,
+            ".schemas",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -235,7 +257,8 @@ impl MergeWithContext<()> for Components {
             &mut self.responses,
             other.responses,
             ctx,
-            &format!("{path}.responses"),
+            path,
+            ".responses",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -243,7 +266,8 @@ impl MergeWithContext<()> for Components {
             &mut self.parameters,
             other.parameters,
             ctx,
-            &format!("{path}.parameters"),
+            path,
+            ".parameters",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -251,7 +275,8 @@ impl MergeWithContext<()> for Components {
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -259,7 +284,8 @@ impl MergeWithContext<()> for Components {
             &mut self.request_bodies,
             other.request_bodies,
             ctx,
-            &format!("{path}.requestBodies"),
+            path,
+            ".requestBodies",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -267,7 +293,8 @@ impl MergeWithContext<()> for Components {
             &mut self.headers,
             other.headers,
             ctx,
-            &format!("{path}.headers"),
+            path,
+            ".headers",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -275,7 +302,8 @@ impl MergeWithContext<()> for Components {
             &mut self.security_schemes,
             other.security_schemes,
             ctx,
-            &format!("{path}.securitySchemes"),
+            path,
+            ".securitySchemes",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -283,7 +311,8 @@ impl MergeWithContext<()> for Components {
             &mut self.links,
             other.links,
             ctx,
-            &format!("{path}.links"),
+            path,
+            ".links",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -291,7 +320,8 @@ impl MergeWithContext<()> for Components {
             &mut self.callbacks,
             other.callbacks,
             ctx,
-            &format!("{path}.callbacks"),
+            path,
+            ".callbacks",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -299,7 +329,8 @@ impl MergeWithContext<()> for Components {
             &mut self.path_items,
             other.path_items,
             ctx,
-            &format!("{path}.pathItems"),
+            path,
+            ".pathItems",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -307,7 +338,8 @@ impl MergeWithContext<()> for Components {
             &mut self.media_types,
             other.media_types,
             ctx,
-            &format!("{path}.mediaTypes"),
+            path,
+            ".mediaTypes",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -315,20 +347,28 @@ impl MergeWithContext<()> for Components {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Paths {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
         for (k, incoming) in other.paths {
             if let Some(base_v) = self.paths.get_mut(&k) {
-                let child = format!("{path}[{k}]");
-                base_v.merge_with_context(incoming, ctx, child);
+                let original_len = path.len();
+                path.push('[');
+                path.push_str(&k);
+                path.push(']');
+                base_v.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
             } else {
                 self.paths.insert(k, incoming);
             }
@@ -337,20 +377,28 @@ impl MergeWithContext<()> for Paths {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Callback {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
         for (k, incoming) in other.paths {
             if let Some(base_v) = self.paths.get_mut(&k) {
-                let child = format!("{path}[{k}]");
-                base_v.merge_with_context(incoming, ctx, child);
+                let original_len = path.len();
+                path.push('[');
+                path.push_str(&k);
+                path.push(']');
+                base_v.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
             } else {
                 self.paths.insert(k, incoming);
             }
@@ -359,13 +407,14 @@ impl MergeWithContext<()> for Callback {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for PathItem {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -373,28 +422,34 @@ impl MergeWithContext<()> for PathItem {
             &mut self.reference,
             other.reference,
             ctx,
-            &format!("{path}.$ref"),
+            path,
+            ".$ref",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
             ctx,
-            &format!("{path}.summary"),
+            path,
+            ".summary",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.operations,
             other.operations,
             ctx,
-            &path,
+            path,
+            // No outer segment — operations live directly under the
+            // path item (e.g. `#.paths[/pets].get`).
+            "",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -402,36 +457,34 @@ impl MergeWithContext<()> for PathItem {
             &mut self.additional_operations,
             other.additional_operations,
             ctx,
-            &format!("{path}.additionalOperations"),
+            path,
+            ".additionalOperations",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        merge_replace_list_when_nonempty(
-            &mut self.servers,
-            other.servers,
-            ctx,
-            &format!("{path}.servers"),
-        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
         merge_opt_vec_by_key(
             &mut self.parameters,
             other.parameters,
             ctx,
-            &format!("{path}.parameters"),
+            path,
+            ".parameters",
             parameter_ref_key,
             |b, i, c, p| b.merge_with_context(i, c, p),
-            |k| format!("{}:{}", k.0, k.1),
+            fmt_param_key,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Responses {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -439,14 +492,18 @@ impl MergeWithContext<()> for Responses {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => {
-                b.merge_with_context(i, ctx, format!("{path}.default"));
+                let mut guard = PathGuard::new(path, ".default");
+                b.merge_with_context(i, ctx, guard.path_mut());
             }
         }
         merge_opt_map(
             &mut self.responses,
             other.responses,
             ctx,
-            &path,
+            path,
+            // Per-status responses live directly under Responses
+            // (e.g. `#.responses.200`).
+            "",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -454,69 +511,80 @@ impl MergeWithContext<()> for Responses {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Operation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
-        merge_opt_vec_set_union(&mut self.tags, other.tags, ctx, &format!("{path}.tags"));
+        merge_opt_vec_set_union(&mut self.tags, other.tags, ctx, path, ".tags");
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
             ctx,
-            &format!("{path}.summary"),
+            path,
+            ".summary",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_struct(
             &mut self.external_docs,
             other.external_docs,
             ctx,
-            &format!("{path}.externalDocs"),
+            path,
+            ".externalDocs",
         );
         merge_opt_scalar(
             &mut self.operation_id,
             other.operation_id,
             ctx,
-            &format!("{path}.operationId"),
+            path,
+            ".operationId",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_vec_by_key(
             &mut self.parameters,
             other.parameters,
             ctx,
-            &format!("{path}.parameters"),
+            path,
+            ".parameters",
             parameter_ref_key,
             |b, i, c, p| b.merge_with_context(i, c, p),
-            |k| format!("{}:{}", k.0, k.1),
+            fmt_param_key,
         );
         match (&mut self.request_body, other.request_body) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
-            (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.requestBody")),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".requestBody");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
         }
         merge_opt_struct(
             &mut self.responses,
             other.responses,
             ctx,
-            &format!("{path}.responses"),
+            path,
+            ".responses",
         );
         merge_opt_map(
             &mut self.callbacks,
             other.callbacks,
             ctx,
-            &format!("{path}.callbacks"),
+            path,
+            ".callbacks",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -524,26 +592,24 @@ impl MergeWithContext<()> for Operation {
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_replace_list_when_nonempty(
             &mut self.security,
             other.security,
             ctx,
-            &format!("{path}.security"),
+            path,
+            ".security",
         );
-        merge_replace_list_when_nonempty(
-            &mut self.servers,
-            other.servers,
-            ctx,
-            &format!("{path}.servers"),
-        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
@@ -569,7 +635,7 @@ fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
 }
 
 impl MergeWithContext<()> for Parameter {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -582,7 +648,7 @@ impl MergeWithContext<()> for Parameter {
                 a.merge_with_context(*b, ctx, path)
             }
             (slot, incoming) => {
-                if ctx.should_take_incoming(&path, ConflictKind::ParameterVariantMismatch) {
+                if ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
                     *slot = incoming;
                 }
             }
@@ -591,7 +657,7 @@ impl MergeWithContext<()> for Parameter {
 }
 
 impl MergeWithContext<()> for InPath {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -599,50 +665,57 @@ impl MergeWithContext<()> for InPath {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_required_scalar(
             &mut self.required,
             other.required,
             ctx,
-            &format!("{path}.required"),
+            path,
+            ".required",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.style,
             other.style,
             ctx,
-            &format!("{path}.style"),
+            path,
+            ".style",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
             ctx,
-            &format!("{path}.explode"),
+            path,
+            ".explode",
             ConflictKind::ScalarOverridden,
         );
-        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -650,7 +723,8 @@ impl MergeWithContext<()> for InPath {
             &mut self.content,
             other.content,
             ctx,
-            &format!("{path}.content"),
+            path,
+            ".content",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -658,13 +732,14 @@ impl MergeWithContext<()> for InPath {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for InQuery {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -672,64 +747,73 @@ impl MergeWithContext<()> for InQuery {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.required,
             other.required,
             ctx,
-            &format!("{path}.required"),
+            path,
+            ".required",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.allow_empty_value,
             other.allow_empty_value,
             ctx,
-            &format!("{path}.allowEmptyValue"),
+            path,
+            ".allowEmptyValue",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.style,
             other.style,
             ctx,
-            &format!("{path}.style"),
+            path,
+            ".style",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
             ctx,
-            &format!("{path}.explode"),
+            path,
+            ".explode",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.allow_reserved,
             other.allow_reserved,
             ctx,
-            &format!("{path}.allowReserved"),
+            path,
+            ".allowReserved",
             ConflictKind::ScalarOverridden,
         );
-        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -737,7 +821,8 @@ impl MergeWithContext<()> for InQuery {
             &mut self.content,
             other.content,
             ctx,
-            &format!("{path}.content"),
+            path,
+            ".content",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -745,13 +830,14 @@ impl MergeWithContext<()> for InQuery {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for InHeader {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -759,50 +845,57 @@ impl MergeWithContext<()> for InHeader {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.required,
             other.required,
             ctx,
-            &format!("{path}.required"),
+            path,
+            ".required",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.style,
             other.style,
             ctx,
-            &format!("{path}.style"),
+            path,
+            ".style",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
             ctx,
-            &format!("{path}.explode"),
+            path,
+            ".explode",
             ConflictKind::ScalarOverridden,
         );
-        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -810,7 +903,8 @@ impl MergeWithContext<()> for InHeader {
             &mut self.content,
             other.content,
             ctx,
-            &format!("{path}.content"),
+            path,
+            ".content",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -818,13 +912,14 @@ impl MergeWithContext<()> for InHeader {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for InCookie {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -832,50 +927,57 @@ impl MergeWithContext<()> for InCookie {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.required,
             other.required,
             ctx,
-            &format!("{path}.required"),
+            path,
+            ".required",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.style,
             other.style,
             ctx,
-            &format!("{path}.style"),
+            path,
+            ".style",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
             ctx,
-            &format!("{path}.explode"),
+            path,
+            ".explode",
             ConflictKind::ScalarOverridden,
         );
-        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -883,7 +985,8 @@ impl MergeWithContext<()> for InCookie {
             &mut self.content,
             other.content,
             ctx,
-            &format!("{path}.content"),
+            path,
+            ".content",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -891,13 +994,14 @@ impl MergeWithContext<()> for InCookie {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for InQuerystring {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -905,27 +1009,37 @@ impl MergeWithContext<()> for InQuerystring {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.required,
             other.required,
             ctx,
-            &format!("{path}.required"),
+            path,
+            ".required",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         // querystring `content` is a bare BTreeMap (required by the spec).
         for (k, incoming) in other.content {
             if let Some(b) = self.content.get_mut(&k) {
-                b.merge_with_context(incoming, ctx, format!("{path}.content.{k}"));
+                let original_len = path.len();
+                path.push_str(".content.");
+                path.push_str(&k);
+                b.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
             } else {
                 self.content.insert(k, incoming);
             }
@@ -934,14 +1048,16 @@ impl MergeWithContext<()> for InQuerystring {
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -949,7 +1065,8 @@ impl MergeWithContext<()> for InQuerystring {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
@@ -962,20 +1079,29 @@ fn merge_schema_field(
     base: &mut Option<RefOr<Schema>>,
     other: Option<RefOr<Schema>>,
     ctx: &mut MergeContext<()>,
-    path: &str,
+    path: &mut String,
     field_name: &str,
 ) {
+    if ctx.errored {
+        return;
+    }
     match (base.as_mut(), other) {
         (_, None) => {}
         (None, Some(v)) => *base = Some(v),
-        (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.{field_name}")),
+        (Some(b), Some(i)) => {
+            let original_len = path.len();
+            path.push('.');
+            path.push_str(field_name);
+            b.merge_with_context(i, ctx, path);
+            path.truncate(original_len);
+        }
     }
 }
 
 // ----- MediaType / Encoding / Header / Response / RequestBody / Example / Link -----
 
 impl MergeWithContext<()> for MediaType {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -983,29 +1109,32 @@ impl MergeWithContext<()> for MediaType {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
-        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
         merge_schema_field(
             &mut self.item_schema,
             other.item_schema,
             ctx,
-            &path,
+            path,
             "itemSchema",
         );
         merge_opt_scalar(
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1013,7 +1142,8 @@ impl MergeWithContext<()> for MediaType {
             &mut self.encoding,
             other.encoding,
             ctx,
-            &format!("{path}.encoding"),
+            path,
+            ".encoding",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1022,24 +1152,29 @@ impl MergeWithContext<()> for MediaType {
             &mut self.prefix_encoding,
             other.prefix_encoding,
             ctx,
-            &format!("{path}.prefixEncoding"),
+            path,
+            ".prefixEncoding",
         );
         match (&mut self.item_encoding, other.item_encoding) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
-            (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.itemEncoding")),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".itemEncoding");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
         }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Encoding {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1047,14 +1182,16 @@ impl MergeWithContext<()> for Encoding {
             &mut self.content_type,
             other.content_type,
             ctx,
-            &format!("{path}.contentType"),
+            path,
+            ".contentType",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.headers,
             other.headers,
             ctx,
-            &format!("{path}.headers"),
+            path,
+            ".headers",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1062,28 +1199,32 @@ impl MergeWithContext<()> for Encoding {
             &mut self.style,
             other.style,
             ctx,
-            &format!("{path}.style"),
+            path,
+            ".style",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
             ctx,
-            &format!("{path}.explode"),
+            path,
+            ".explode",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.allow_reserved,
             other.allow_reserved,
             ctx,
-            &format!("{path}.allowReserved"),
+            path,
+            ".allowReserved",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.encoding,
             other.encoding,
             ctx,
-            &format!("{path}.encoding"),
+            path,
+            ".encoding",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1091,24 +1232,29 @@ impl MergeWithContext<()> for Encoding {
             &mut self.prefix_encoding,
             other.prefix_encoding,
             ctx,
-            &format!("{path}.prefixEncoding"),
+            path,
+            ".prefixEncoding",
         );
         match (&mut self.item_encoding, other.item_encoding) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
-            (Some(b), Some(i)) => b.merge_with_context(*i, ctx, format!("{path}.itemEncoding")),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".itemEncoding");
+                b.merge_with_context(*i, ctx, guard.path_mut());
+            }
         }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Header {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1116,50 +1262,57 @@ impl MergeWithContext<()> for Header {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.required,
             other.required,
             ctx,
-            &format!("{path}.required"),
+            path,
+            ".required",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.style,
             other.style,
             ctx,
-            &format!("{path}.style"),
+            path,
+            ".style",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
             ctx,
-            &format!("{path}.explode"),
+            path,
+            ".explode",
             ConflictKind::ScalarOverridden,
         );
-        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1167,7 +1320,8 @@ impl MergeWithContext<()> for Header {
             &mut self.content,
             other.content,
             ctx,
-            &format!("{path}.content"),
+            path,
+            ".content",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1175,13 +1329,14 @@ impl MergeWithContext<()> for Header {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Response {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1189,21 +1344,24 @@ impl MergeWithContext<()> for Response {
             &mut self.summary,
             other.summary,
             ctx,
-            &format!("{path}.summary"),
+            path,
+            ".summary",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.headers,
             other.headers,
             ctx,
-            &format!("{path}.headers"),
+            path,
+            ".headers",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1211,7 +1369,8 @@ impl MergeWithContext<()> for Response {
             &mut self.content,
             other.content,
             ctx,
-            &format!("{path}.content"),
+            path,
+            ".content",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1219,7 +1378,8 @@ impl MergeWithContext<()> for Response {
             &mut self.links,
             other.links,
             ctx,
-            &format!("{path}.links"),
+            path,
+            ".links",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1227,13 +1387,14 @@ impl MergeWithContext<()> for Response {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for RequestBody {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1241,13 +1402,21 @@ impl MergeWithContext<()> for RequestBody {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         // content is a bare BTreeMap (required).
         for (k, incoming) in other.content {
             if let Some(b) = self.content.get_mut(&k) {
-                b.merge_with_context(incoming, ctx, format!("{path}.content.{k}"));
+                let original_len = path.len();
+                path.push_str(".content.");
+                path.push_str(&k);
+                b.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
             } else {
                 self.content.insert(k, incoming);
             }
@@ -1256,20 +1425,22 @@ impl MergeWithContext<()> for RequestBody {
             &mut self.required,
             other.required,
             ctx,
-            &format!("{path}.required"),
+            path,
+            ".required",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Example {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1277,55 +1448,62 @@ impl MergeWithContext<()> for Example {
             &mut self.summary,
             other.summary,
             ctx,
-            &format!("{path}.summary"),
+            path,
+            ".summary",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.value,
             other.value,
             ctx,
-            &format!("{path}.value"),
+            path,
+            ".value",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.serialized_value,
             other.serialized_value,
             ctx,
-            &format!("{path}.serializedValue"),
+            path,
+            ".serializedValue",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.data_value,
             other.data_value,
             ctx,
-            &format!("{path}.dataValue"),
+            path,
+            ".dataValue",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.external_value,
             other.external_value,
             ctx,
-            &format!("{path}.externalValue"),
+            path,
+            ".externalValue",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Link {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1333,14 +1511,16 @@ impl MergeWithContext<()> for Link {
             &mut self.operation_ref,
             other.operation_ref,
             ctx,
-            &format!("{path}.operationRef"),
+            path,
+            ".operationRef",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.operation_id,
             other.operation_id,
             ctx,
-            &format!("{path}.operationId"),
+            path,
+            ".operationId",
             ConflictKind::ScalarOverridden,
         );
         // Link.parameters is `Option<BTreeMap<String, serde_json::Value>>`
@@ -1349,33 +1529,32 @@ impl MergeWithContext<()> for Link {
             &mut self.parameters,
             other.parameters,
             ctx,
-            &format!("{path}.parameters"),
+            path,
+            ".parameters",
         );
         merge_opt_scalar(
             &mut self.request_body,
             other.request_body,
             ctx,
-            &format!("{path}.requestBody"),
+            path,
+            ".requestBody",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
-        merge_opt_struct(
-            &mut self.server,
-            other.server,
-            ctx,
-            &format!("{path}.server"),
-        );
+        merge_opt_struct(&mut self.server, other.server, ctx, path, ".server");
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
@@ -1384,7 +1563,7 @@ impl MergeWithContext<()> for Link {
 //                Discriminator, XML, Server, ServerVariable -----
 
 impl MergeWithContext<()> for Tag {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1392,54 +1571,61 @@ impl MergeWithContext<()> for Tag {
             &mut self.name,
             other.name,
             ctx,
-            &format!("{path}.name"),
+            path,
+            ".name",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
             ctx,
-            &format!("{path}.summary"),
+            path,
+            ".summary",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_struct(
             &mut self.external_docs,
             other.external_docs,
             ctx,
-            &format!("{path}.externalDocs"),
+            path,
+            ".externalDocs",
         );
         merge_opt_scalar(
             &mut self.parent,
             other.parent,
             ctx,
-            &format!("{path}.parent"),
+            path,
+            ".parent",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.kind,
             other.kind,
             ctx,
-            &format!("{path}.kind"),
+            path,
+            ".kind",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Info {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1447,60 +1633,56 @@ impl MergeWithContext<()> for Info {
             &mut self.title,
             other.title,
             ctx,
-            &format!("{path}.title"),
+            path,
+            ".title",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
             ctx,
-            &format!("{path}.summary"),
+            path,
+            ".summary",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.terms_of_service,
             other.terms_of_service,
             ctx,
-            &format!("{path}.termsOfService"),
+            path,
+            ".termsOfService",
             ConflictKind::ScalarOverridden,
         );
-        merge_opt_struct(
-            &mut self.contact,
-            other.contact,
-            ctx,
-            &format!("{path}.contact"),
-        );
-        merge_opt_struct(
-            &mut self.license,
-            other.license,
-            ctx,
-            &format!("{path}.license"),
-        );
+        merge_opt_struct(&mut self.contact, other.contact, ctx, path, ".contact");
+        merge_opt_struct(&mut self.license, other.license, ctx, path, ".license");
         merge_required_scalar(
             &mut self.version,
             other.version,
             ctx,
-            &format!("{path}.version"),
+            path,
+            ".version",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Contact {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1508,34 +1690,38 @@ impl MergeWithContext<()> for Contact {
             &mut self.name,
             other.name,
             ctx,
-            &format!("{path}.name"),
+            path,
+            ".name",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.url,
             other.url,
             ctx,
-            &format!("{path}.url"),
+            path,
+            ".url",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.email,
             other.email,
             ctx,
-            &format!("{path}.email"),
+            path,
+            ".email",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for License {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1543,34 +1729,38 @@ impl MergeWithContext<()> for License {
             &mut self.name,
             other.name,
             ctx,
-            &format!("{path}.name"),
+            path,
+            ".name",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.identifier,
             other.identifier,
             ctx,
-            &format!("{path}.identifier"),
+            path,
+            ".identifier",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.url,
             other.url,
             ctx,
-            &format!("{path}.url"),
+            path,
+            ".url",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for ExternalDocumentation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1578,27 +1768,30 @@ impl MergeWithContext<()> for ExternalDocumentation {
             &mut self.url,
             other.url,
             ctx,
-            &format!("{path}.url"),
+            path,
+            ".url",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Discriminator {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1606,7 +1799,8 @@ impl MergeWithContext<()> for Discriminator {
             &mut self.property_name,
             other.property_name,
             ctx,
-            &format!("{path}.propertyName"),
+            path,
+            ".propertyName",
             ConflictKind::RequiredScalarOverridden,
         );
         // mapping is Option<BTreeMap<String,String>>; per-key incoming wins.
@@ -1620,13 +1814,16 @@ impl MergeWithContext<()> for Discriminator {
                         base_map.insert(k, v);
                     }
                     Some(existing) => {
-                        if *existing != v
-                            && ctx.should_take_incoming(
-                                &format!("{path}.mapping.{k}"),
-                                ConflictKind::ScalarOverridden,
-                            )
-                        {
-                            *existing = v;
+                        if *existing != v {
+                            let original_len = path.len();
+                            path.push_str(".mapping.");
+                            path.push_str(&k);
+                            let take =
+                                ctx.should_take_incoming(path, ConflictKind::ScalarOverridden);
+                            path.truncate(original_len);
+                            if take {
+                                *existing = v;
+                            }
                         }
                     }
                 }
@@ -1636,14 +1833,15 @@ impl MergeWithContext<()> for Discriminator {
             &mut self.default_mapping,
             other.default_mapping,
             ctx,
-            &format!("{path}.defaultMapping"),
+            path,
+            ".defaultMapping",
             ConflictKind::ScalarOverridden,
         );
     }
 }
 
 impl MergeWithContext<()> for XML {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1651,55 +1849,62 @@ impl MergeWithContext<()> for XML {
             &mut self.name,
             other.name,
             ctx,
-            &format!("{path}.name"),
+            path,
+            ".name",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.namespace,
             other.namespace,
             ctx,
-            &format!("{path}.namespace"),
+            path,
+            ".namespace",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.prefix,
             other.prefix,
             ctx,
-            &format!("{path}.prefix"),
+            path,
+            ".prefix",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.attribute,
             other.attribute,
             ctx,
-            &format!("{path}.attribute"),
+            path,
+            ".attribute",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.wrapped,
             other.wrapped,
             ctx,
-            &format!("{path}.wrapped"),
+            path,
+            ".wrapped",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.node_type,
             other.node_type,
             ctx,
-            &format!("{path}.nodeType"),
+            path,
+            ".nodeType",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for Server {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1707,28 +1912,32 @@ impl MergeWithContext<()> for Server {
             &mut self.url,
             other.url,
             ctx,
-            &format!("{path}.url"),
+            path,
+            ".url",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.name,
             other.name,
             ctx,
-            &format!("{path}.name"),
+            path,
+            ".name",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.variables,
             other.variables,
             ctx,
-            &format!("{path}.variables"),
+            path,
+            ".variables",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -1736,7 +1945,8 @@ impl MergeWithContext<()> for Server {
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
@@ -1744,7 +1954,7 @@ impl MergeWithContext<()> for Server {
 // ----- SecurityScheme -----
 
 impl MergeWithContext<()> for SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1765,7 +1975,7 @@ impl MergeWithContext<()> for SecurityScheme {
                 a.merge_with_context(*b, ctx, path)
             }
             (slot, incoming) => {
-                if ctx.should_take_incoming(&path, ConflictKind::ParameterVariantMismatch) {
+                if ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
                     *slot = incoming;
                 }
             }
@@ -1774,7 +1984,7 @@ impl MergeWithContext<()> for SecurityScheme {
 }
 
 impl MergeWithContext<()> for ApiKeySecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1782,41 +1992,46 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
             &mut self.name,
             other.name,
             ctx,
-            &format!("{path}.name"),
+            path,
+            ".name",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_required_scalar(
             &mut self.location,
             other.location,
             ctx,
-            &format!("{path}.in"),
+            path,
+            ".in",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for HttpSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1824,41 +2039,46 @@ impl MergeWithContext<()> for HttpSecurityScheme {
             &mut self.scheme,
             other.scheme,
             ctx,
-            &format!("{path}.scheme"),
+            path,
+            ".scheme",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.bearer_format,
             other.bearer_format,
             ctx,
-            &format!("{path}.bearerFormat"),
+            path,
+            ".bearerFormat",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for MutualTLSSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1866,27 +2086,30 @@ impl MergeWithContext<()> for MutualTLSSecurityScheme {
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1894,109 +2117,114 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
             &mut self.open_id_connect_url,
             other.open_id_connect_url,
             ctx,
-            &format!("{path}.openIdConnectUrl"),
+            path,
+            ".openIdConnectUrl",
             ConflictKind::RequiredScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for OAuth2SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
-        self.flows
-            .merge_with_context(other.flows, ctx, format!("{path}.flows"));
+        {
+            let mut guard = PathGuard::new(path, ".flows");
+            self.flows
+                .merge_with_context(other.flows, ctx, guard.path_mut());
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.oauth2_metadata_url,
             other.oauth2_metadata_url,
             ctx,
-            &format!("{path}.oauth2MetadataUrl"),
+            path,
+            ".oauth2MetadataUrl",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
 
 impl MergeWithContext<()> for OAuth2Flows {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
-        merge_opt_struct(
-            &mut self.implicit,
-            other.implicit,
-            ctx,
-            &format!("{path}.implicit"),
-        );
-        merge_opt_struct(
-            &mut self.password,
-            other.password,
-            ctx,
-            &format!("{path}.password"),
-        );
+        merge_opt_struct(&mut self.implicit, other.implicit, ctx, path, ".implicit");
+        merge_opt_struct(&mut self.password, other.password, ctx, path, ".password");
         merge_opt_struct(
             &mut self.client_credentials,
             other.client_credentials,
             ctx,
-            &format!("{path}.clientCredentials"),
+            path,
+            ".clientCredentials",
         );
         merge_opt_struct(
             &mut self.authorization_code,
             other.authorization_code,
             ctx,
-            &format!("{path}.authorizationCode"),
+            path,
+            ".authorizationCode",
         );
         merge_opt_struct(
             &mut self.device_authorization,
             other.device_authorization,
             ctx,
-            &format!("{path}.deviceAuthorization"),
+            path,
+            ".deviceAuthorization",
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
@@ -2011,7 +2239,7 @@ macro_rules! oauth_flow_merge {
                 &mut self,
                 other: Self,
                 ctx: &mut MergeContext<()>,
-                path: String,
+                path: &mut String,
             ) {
                 if ctx.errored { return; }
                 $(
@@ -2019,7 +2247,8 @@ macro_rules! oauth_flow_merge {
                         &mut self.$url_field,
                         other.$url_field,
                         ctx,
-                        &format!("{path}.{}", $url_path),
+                        path,
+                        concat!(".", $url_path),
                         ConflictKind::RequiredScalarOverridden,
                     );
                 )*
@@ -2027,7 +2256,8 @@ macro_rules! oauth_flow_merge {
                     &mut self.refresh_url,
                     other.refresh_url,
                     ctx,
-                    &format!("{path}.refreshUrl"),
+                    path,
+                    ".refreshUrl",
                     ConflictKind::ScalarOverridden,
                 );
                 // scopes is a bare BTreeMap<String, String>.
@@ -2037,13 +2267,21 @@ macro_rules! oauth_flow_merge {
                             self.scopes.insert(k, v);
                         }
                         Some(existing) => {
-                            if *existing != v
-                                && ctx.should_take_incoming(
-                                    &format!("{path}.scopes.{k}"),
+                            if *existing != v {
+                                let original_len = path.len();
+                                path.push_str(".scopes.");
+                                path.push_str(&k);
+                                let take = ctx.should_take_incoming(
+                                    path,
                                     ConflictKind::ScalarOverridden,
-                                )
-                            {
-                                *existing = v;
+                                );
+                                path.truncate(original_len);
+                                if take {
+                                    *existing = v;
+                                }
+                                if ctx.errored {
+                                    return;
+                                }
                             }
                         }
                     }
@@ -2052,7 +2290,8 @@ macro_rules! oauth_flow_merge {
                     &mut self.extensions,
                     other.extensions,
                     ctx,
-                    &format!("{path}.extensions"),
+                    path,
+                    ".extensions",
                 );
             }
         }
@@ -2076,7 +2315,7 @@ oauth_flow_merge!(
 // ----- Schema -----
 
 impl MergeWithContext<()> for Schema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2104,16 +2343,16 @@ impl MergeWithContext<()> for Schema {
                             self,
                             Schema::Single(Box::new(other_single_inner)),
                             ctx,
-                            &path,
+                            path,
                         );
                     }
                 },
                 non_single => {
-                    return leaf_replace_schema(self, non_single, ctx, &path);
+                    return leaf_replace_schema(self, non_single, ctx, path);
                 }
             }
         }
-        leaf_replace_schema(self, other, ctx, &path);
+        leaf_replace_schema(self, other, ctx, path);
     }
 }
 
@@ -2127,18 +2366,28 @@ fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<
 /// kept" — used for `Spec.info` / `Spec.openapi` when `MergeInfo` is
 /// off. Records `Resolution::Base` in the default / `BaseWins` modes
 /// (reflecting what actually happened), and trips
-/// `ErrorOnConflict` when set.
-fn record_kept_base_or_error(ctx: &mut MergeContext<()>, path: &str, kind: ConflictKind) {
+/// `ErrorOnConflict` when set. Pushes `segment` onto `path` only
+/// when actually recording, keeping the eager-allocation
+/// regression off the non-conflict path.
+fn record_kept_base_or_error(
+    ctx: &mut MergeContext<()>,
+    path: &mut String,
+    segment: &str,
+    kind: ConflictKind,
+) {
+    let original_len = path.len();
+    path.push_str(segment);
     if ctx.is_option(MergeOptions::ErrorOnConflict) {
-        ctx.record(path.to_owned(), kind, crate::merge::Resolution::Errored);
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
         ctx.errored = true;
     } else {
-        ctx.record(path.to_owned(), kind, crate::merge::Resolution::Base);
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
     }
+    path.truncate(original_len);
 }
 
 impl MergeWithContext<()> for ObjectSchema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2146,21 +2395,24 @@ impl MergeWithContext<()> for ObjectSchema {
             &mut self.title,
             other.title,
             ctx,
-            &format!("{path}.title"),
+            path,
+            ".title",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_map(
             &mut self.properties,
             other.properties,
             ctx,
-            &format!("{path}.properties"),
+            path,
+            ".properties",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -2168,7 +2420,8 @@ impl MergeWithContext<()> for ObjectSchema {
             &mut self.pattern_properties,
             other.pattern_properties,
             ctx,
-            &format!("{path}.patternProperties"),
+            path,
+            ".patternProperties",
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
@@ -2176,28 +2429,32 @@ impl MergeWithContext<()> for ObjectSchema {
             &mut self.default,
             other.default,
             ctx,
-            &format!("{path}.default"),
+            path,
+            ".default",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.max_properties,
             other.max_properties,
             ctx,
-            &format!("{path}.maxProperties"),
+            path,
+            ".maxProperties",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.min_properties,
             other.min_properties,
             ctx,
-            &format!("{path}.minProperties"),
+            path,
+            ".minProperties",
             ConflictKind::ScalarOverridden,
         );
         match (&mut self.additional_properties, other.additional_properties) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => {
-                b.merge_with_context(i, ctx, format!("{path}.additionalProperties"))
+                let mut guard = PathGuard::new(path, ".additionalProperties");
+                b.merge_with_context(i, ctx, guard.path_mut());
             }
         }
         match (
@@ -2207,69 +2464,72 @@ impl MergeWithContext<()> for ObjectSchema {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => {
-                b.merge_with_context(i, ctx, format!("{path}.unevaluatedProperties"))
+                let mut guard = PathGuard::new(path, ".unevaluatedProperties");
+                b.merge_with_context(i, ctx, guard.path_mut());
             }
         }
         merge_schema_field(
             &mut self.property_names,
             other.property_names,
             ctx,
-            &path,
+            path,
             "propertyNames",
         );
-        merge_opt_vec_set_union(
-            &mut self.required,
-            other.required,
-            ctx,
-            &format!("{path}.required"),
-        );
+        merge_opt_vec_set_union(&mut self.required, other.required, ctx, path, ".required");
         merge_opt_scalar(
             &mut self.read_only,
             other.read_only,
             ctx,
-            &format!("{path}.readOnly"),
+            path,
+            ".readOnly",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.write_only,
             other.write_only,
             ctx,
-            &format!("{path}.writeOnly"),
+            path,
+            ".writeOnly",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
             ctx,
-            &format!("{path}.deprecated"),
+            path,
+            ".deprecated",
             ConflictKind::ScalarOverridden,
         );
-        merge_opt_struct(&mut self.xml, other.xml, ctx, &format!("{path}.xml"));
+        merge_opt_struct(&mut self.xml, other.xml, ctx, path, ".xml");
         merge_opt_struct(
             &mut self.external_docs,
             other.external_docs,
             ctx,
-            &format!("{path}.externalDocs"),
+            path,
+            ".externalDocs",
         );
         merge_opt_scalar(
             &mut self.example,
             other.example,
             ctx,
-            &format!("{path}.example"),
+            path,
+            ".example",
             ConflictKind::ScalarOverridden,
         );
         merge_opt_scalar(
             &mut self.examples,
             other.examples,
             ctx,
-            &format!("{path}.examples"),
+            path,
+            ".examples",
             ConflictKind::ScalarOverridden,
         );
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }
@@ -2286,11 +2546,11 @@ macro_rules! leaf_schema_merge {
                     &mut self,
                     other: Self,
                     ctx: &mut MergeContext<()>,
-                    path: String,
+                    path: &mut String,
                 ) {
                     if ctx.errored { return; }
                     if *self != other
-                        && ctx.should_take_incoming(&path, ConflictKind::SchemaLeafReplaced)
+                        && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced)
                     {
                         *self = other;
                     }
@@ -2386,7 +2646,8 @@ mod tests {
             ..Default::default()
         });
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#.tags[pets]".into());
+        let mut path = String::from("#.tags[pets]");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         match base {
             RefOr::Item(t) => {
                 assert_eq!(t.description.as_deref(), Some("base"));
@@ -2409,7 +2670,8 @@ mod tests {
             description: Some("new desc".into()),
         }));
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#".into());
+        let mut path = String::from("#");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         match base {
             RefOr::Ref(r) => {
                 assert_eq!(r.summary.as_deref(), Some("base summary"));
@@ -2425,7 +2687,8 @@ mod tests {
         let mut base: RefOr<Tag> = RefOr::Ref(Box::new(Ref::new("#/components/tags/A")));
         let incoming: RefOr<Tag> = RefOr::Ref(Box::new(Ref::new("#/components/tags/B")));
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#.tags[0]".into());
+        let mut path = String::from("#.tags[0]");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         match base {
             RefOr::Ref(r) => assert_eq!(r.reference, "#/components/tags/B"),
             _ => panic!("expected Ref"),
@@ -2443,7 +2706,8 @@ mod tests {
             ..Default::default()
         });
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#".into());
+        let mut path = String::from("#");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         assert!(matches!(base, RefOr::Item(_)));
         assert_eq!(ctx.conflicts.len(), 1);
         assert_eq!(ctx.conflicts[0].kind, ConflictKind::RefVsValue);
@@ -2474,7 +2738,8 @@ mod tests {
             ..Default::default()
         };
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#.op".into());
+        let mut path = String::from("#.op");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
 
         let r = base.responses.unwrap().responses.unwrap();
         assert!(r.contains_key("200"));
@@ -2501,7 +2766,8 @@ mod tests {
             ..Default::default()
         };
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#.op".into());
+        let mut path = String::from("#.op");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         let params = base.parameters.unwrap();
         assert_eq!(params.len(), 3, "no duplicates by (name, in)");
     }
@@ -2519,7 +2785,8 @@ mod tests {
             ..Default::default()
         };
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#.paths[/pets]".into());
+        let mut path = String::from("#.paths[/pets]");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         let ops = base.operations.unwrap();
         assert!(ops.contains_key("get"));
         assert!(ops.contains_key("post"));
@@ -2538,7 +2805,8 @@ mod tests {
             ..Default::default()
         })));
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#.s".into());
+        let mut path = String::from("#.s");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         // Replaced — `required` is now from incoming.
         let Schema::Single(box_single) = &base else {
             panic!()
@@ -2575,7 +2843,8 @@ mod tests {
         })));
         let mut ctx: MergeContext<()> =
             MergeContext::new(&(), MergeOptions::DeepMergeObjectSchemas.only());
-        base.merge_with_context(incoming, &mut ctx, "#.s".into());
+        let mut path = String::from("#.s");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         let Schema::Single(box_single) = &base else {
             panic!()
         };
@@ -2908,7 +3177,8 @@ mod tests {
             ..Default::default()
         };
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base.merge_with_context(incoming, &mut ctx, "#.mt".into());
+        let mut path = String::from("#.mt");
+        base.merge_with_context(incoming, &mut ctx, &mut path);
         // Conflict path should mention itemSchema, not schema.
         assert!(
             ctx.conflicts.iter().any(|c| c.path.contains("itemSchema")),
@@ -2952,7 +3222,8 @@ mod tests {
             ..Default::default()
         };
         let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
-        base_server.merge_with_context(incoming_server, &mut ctx, "#.srv".into());
+        let mut path = String::from("#.srv");
+        base_server.merge_with_context(incoming_server, &mut ctx, &mut path);
         let merged = base_server.variables.unwrap();
         let v = merged.get("ver").unwrap();
         // Round-trip through serde to inspect the private fields.
@@ -2960,6 +3231,52 @@ mod tests {
         assert_eq!(json["description"], "incoming desc");
         assert_eq!(json["enum"], serde_json::json!(["v1", "v2"]));
         assert_eq!(json["default"], "v1");
+    }
+
+    // ---- Coverage: lazy paths balance correctly through deep recursion ----
+
+    #[test]
+    fn lazy_path_balances_after_deep_merge_of_identical_trees() {
+        // Identical Spec subtrees: no conflicts should be recorded
+        // and the `&mut String` path stack must end balanced. A
+        // missed `path.truncate()` would either panic in truncate or
+        // leak segments — the assertion that the empty conflict list
+        // came back tells us neither happened.
+        let mut base = Spec {
+            components: Some(Components {
+                schemas: Some(BTreeMap::from([(
+                    "Pet".to_owned(),
+                    RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                        ObjectSchema {
+                            properties: Some(BTreeMap::from([(
+                                "name".to_owned(),
+                                RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                                    ObjectSchema {
+                                        description: Some("base".into()),
+                                        ..Default::default()
+                                    },
+                                )))),
+                            )])),
+                            ..Default::default()
+                        },
+                    )))),
+                )])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let incoming = base.clone();
+        let report = base
+            .merge(
+                incoming,
+                MergeOptions::DeepMergeObjectSchemas | MergeOptions::MergeInfo,
+            )
+            .unwrap();
+        assert!(
+            report.conflicts.is_empty(),
+            "identical trees should produce no conflicts: {:?}",
+            report.conflicts
+        );
     }
 
     // ---- Components: schemas collision uses leaf replace by default ----

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -52,7 +52,7 @@ use crate::v3_2::security_scheme::{
     OAuth2Flows, OAuth2SecurityScheme, OpenIdConnectSecurityScheme, PasswordOAuth2Flow,
     SecurityScheme,
 };
-use crate::v3_2::server::{Server, ServerVariable};
+use crate::v3_2::server::Server;
 use crate::v3_2::spec::Spec;
 use crate::v3_2::tag::Tag;
 use crate::v3_2::xml::XML;
@@ -92,8 +92,19 @@ impl Merge for Spec {
 
 impl MergeWithContext<()> for Spec {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
-        // openapi version: keep base by default; under MergeInfo, use
-        // the standard required-scalar policy.
+        if ctx.errored {
+            return;
+        }
+        // openapi version + info: under MergeInfo, full required-scalar
+        // policy; otherwise the documented contract is "kept on base."
+        // We still want `ErrorOnConflict` to catch a real mismatch and
+        // we still want the conflict in the report (with
+        // `Resolution::Base` to reflect that base actually won),
+        // hence the explicit comparison + `record_kept_base_or_error`
+        // helper rather than routing through `should_take_incoming`
+        // (which embeds the default incoming-wins policy and would
+        // record `Resolution::Incoming` even though no mutation
+        // happened).
         if ctx.is_option(MergeOptions::MergeInfo) {
             merge_required_scalar(
                 &mut self.openapi,
@@ -102,22 +113,23 @@ impl MergeWithContext<()> for Spec {
                 &format!("{path}.openapi"),
                 ConflictKind::RequiredScalarOverridden,
             );
-            if ctx.errored {
-                return;
-            }
             self.info
                 .merge_with_context(other.info, ctx, format!("{path}.info"));
-        } else if self.info != other.info {
-            // Record the suppression so the report still shows the
-            // collision (with Resolution::Base).
-            ctx.record(
-                format!("{path}.info"),
-                ConflictKind::RequiredScalarOverridden,
-                crate::merge::Resolution::Base,
-            );
-        }
-        if ctx.errored {
-            return;
+        } else {
+            if self.openapi != other.openapi {
+                record_kept_base_or_error(
+                    ctx,
+                    &format!("{path}.openapi"),
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
+            if !ctx.errored && self.info != other.info {
+                record_kept_base_or_error(
+                    ctx,
+                    &format!("{path}.info"),
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
         }
         merge_opt_scalar(
             &mut self.self_uri,
@@ -126,9 +138,6 @@ impl MergeWithContext<()> for Spec {
             &format!("{path}.$self"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.json_schema_dialect,
             other.json_schema_dialect,
@@ -136,49 +145,31 @@ impl MergeWithContext<()> for Spec {
             &format!("{path}.jsonSchemaDialect"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_replace_list_when_nonempty(
             &mut self.servers,
             other.servers,
             ctx,
             &format!("{path}.servers"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(&mut self.paths, other.paths, ctx, &format!("{path}.paths"));
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.webhooks,
             other.webhooks,
             ctx,
             &format!("{path}.webhooks"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.components,
             other.components,
             ctx,
             &format!("{path}.components"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_replace_list_when_nonempty(
             &mut self.security,
             other.security,
             ctx,
             &format!("{path}.security"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_vec_by_key(
             &mut self.tags,
             other.tags,
@@ -188,18 +179,12 @@ impl MergeWithContext<()> for Spec {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.external_docs,
             other.external_docs,
             ctx,
             &format!("{path}.externalDocs"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -213,6 +198,9 @@ impl MergeWithContext<()> for Spec {
 
 impl MergeWithContext<()> for Components {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_map(
             &mut self.schemas,
             other.schemas,
@@ -221,9 +209,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.responses,
             other.responses,
@@ -232,9 +217,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.parameters,
             other.parameters,
@@ -243,9 +225,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -254,9 +233,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.request_bodies,
             other.request_bodies,
@@ -265,9 +241,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.headers,
             other.headers,
@@ -276,9 +249,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.security_schemes,
             other.security_schemes,
@@ -287,9 +257,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.links,
             other.links,
@@ -298,9 +265,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.callbacks,
             other.callbacks,
@@ -309,9 +273,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.path_items,
             other.path_items,
@@ -320,9 +281,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.media_types,
             other.media_types,
@@ -331,9 +289,6 @@ impl MergeWithContext<()> for Components {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -345,13 +300,13 @@ impl MergeWithContext<()> for Components {
 
 impl MergeWithContext<()> for Paths {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         for (k, incoming) in other.paths {
             if let Some(base_v) = self.paths.get_mut(&k) {
                 let child = format!("{path}[{k}]");
                 base_v.merge_with_context(incoming, ctx, child);
-                if ctx.errored {
-                    return;
-                }
             } else {
                 self.paths.insert(k, incoming);
             }
@@ -367,13 +322,13 @@ impl MergeWithContext<()> for Paths {
 
 impl MergeWithContext<()> for Callback {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         for (k, incoming) in other.paths {
             if let Some(base_v) = self.paths.get_mut(&k) {
                 let child = format!("{path}[{k}]");
                 base_v.merge_with_context(incoming, ctx, child);
-                if ctx.errored {
-                    return;
-                }
             } else {
                 self.paths.insert(k, incoming);
             }
@@ -389,6 +344,9 @@ impl MergeWithContext<()> for Callback {
 
 impl MergeWithContext<()> for PathItem {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.reference,
             other.reference,
@@ -396,9 +354,6 @@ impl MergeWithContext<()> for PathItem {
             &format!("{path}.$ref"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
@@ -406,9 +361,6 @@ impl MergeWithContext<()> for PathItem {
             &format!("{path}.summary"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -416,9 +368,6 @@ impl MergeWithContext<()> for PathItem {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.operations,
             other.operations,
@@ -427,9 +376,6 @@ impl MergeWithContext<()> for PathItem {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.additional_operations,
             other.additional_operations,
@@ -438,18 +384,12 @@ impl MergeWithContext<()> for PathItem {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_replace_list_when_nonempty(
             &mut self.servers,
             other.servers,
             ctx,
             &format!("{path}.servers"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_vec_by_key(
             &mut self.parameters,
             other.parameters,
@@ -459,9 +399,6 @@ impl MergeWithContext<()> for PathItem {
             |b, i, c, p| b.merge_with_context(i, c, p),
             |k| format!("{}:{}", k.0, k.1),
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -473,15 +410,15 @@ impl MergeWithContext<()> for PathItem {
 
 impl MergeWithContext<()> for Responses {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         match (&mut self.default, other.default) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => {
                 b.merge_with_context(i, ctx, format!("{path}.default"));
             }
-        }
-        if ctx.errored {
-            return;
         }
         merge_opt_map(
             &mut self.responses,
@@ -491,9 +428,6 @@ impl MergeWithContext<()> for Responses {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -505,6 +439,9 @@ impl MergeWithContext<()> for Responses {
 
 impl MergeWithContext<()> for Operation {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_vec_set_union(&mut self.tags, other.tags, ctx, &format!("{path}.tags"));
         merge_opt_scalar(
             &mut self.summary,
@@ -513,9 +450,6 @@ impl MergeWithContext<()> for Operation {
             &format!("{path}.summary"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -523,18 +457,12 @@ impl MergeWithContext<()> for Operation {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.external_docs,
             other.external_docs,
             ctx,
             &format!("{path}.externalDocs"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.operation_id,
             other.operation_id,
@@ -542,9 +470,6 @@ impl MergeWithContext<()> for Operation {
             &format!("{path}.operationId"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_vec_by_key(
             &mut self.parameters,
             other.parameters,
@@ -554,16 +479,10 @@ impl MergeWithContext<()> for Operation {
             |b, i, c, p| b.merge_with_context(i, c, p),
             |k| format!("{}:{}", k.0, k.1),
         );
-        if ctx.errored {
-            return;
-        }
         match (&mut self.request_body, other.request_body) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.requestBody")),
-        }
-        if ctx.errored {
-            return;
         }
         merge_opt_struct(
             &mut self.responses,
@@ -571,9 +490,6 @@ impl MergeWithContext<()> for Operation {
             ctx,
             &format!("{path}.responses"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.callbacks,
             other.callbacks,
@@ -582,9 +498,6 @@ impl MergeWithContext<()> for Operation {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -592,27 +505,18 @@ impl MergeWithContext<()> for Operation {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_replace_list_when_nonempty(
             &mut self.security,
             other.security,
             ctx,
             &format!("{path}.security"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_replace_list_when_nonempty(
             &mut self.servers,
             other.servers,
             ctx,
             &format!("{path}.servers"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -644,6 +548,9 @@ fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
 
 impl MergeWithContext<()> for Parameter {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         match (self, other) {
             (Parameter::Path(a), Parameter::Path(b)) => a.merge_with_context(*b, ctx, path),
             (Parameter::Query(a), Parameter::Query(b)) => a.merge_with_context(*b, ctx, path),
@@ -663,6 +570,9 @@ impl MergeWithContext<()> for Parameter {
 
 impl MergeWithContext<()> for InPath {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -670,9 +580,6 @@ impl MergeWithContext<()> for InPath {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_required_scalar(
             &mut self.required,
             other.required,
@@ -680,9 +587,6 @@ impl MergeWithContext<()> for InPath {
             &format!("{path}.required"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -690,9 +594,6 @@ impl MergeWithContext<()> for InPath {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.style,
             other.style,
@@ -700,9 +601,6 @@ impl MergeWithContext<()> for InPath {
             &format!("{path}.style"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
@@ -710,13 +608,7 @@ impl MergeWithContext<()> for InPath {
             &format!("{path}.explode"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
-        if ctx.errored {
-            return;
-        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
@@ -724,9 +616,6 @@ impl MergeWithContext<()> for InPath {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -735,9 +624,6 @@ impl MergeWithContext<()> for InPath {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.content,
             other.content,
@@ -746,9 +632,6 @@ impl MergeWithContext<()> for InPath {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -760,6 +643,9 @@ impl MergeWithContext<()> for InPath {
 
 impl MergeWithContext<()> for InQuery {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -767,9 +653,6 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.required,
             other.required,
@@ -777,9 +660,6 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.required"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -787,9 +667,6 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.allow_empty_value,
             other.allow_empty_value,
@@ -797,9 +674,6 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.allowEmptyValue"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.style,
             other.style,
@@ -807,9 +681,6 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.style"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
@@ -817,9 +688,6 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.explode"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.allow_reserved,
             other.allow_reserved,
@@ -827,13 +695,7 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.allowReserved"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
-        if ctx.errored {
-            return;
-        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
@@ -841,9 +703,6 @@ impl MergeWithContext<()> for InQuery {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -852,9 +711,6 @@ impl MergeWithContext<()> for InQuery {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.content,
             other.content,
@@ -863,9 +719,6 @@ impl MergeWithContext<()> for InQuery {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -877,6 +730,9 @@ impl MergeWithContext<()> for InQuery {
 
 impl MergeWithContext<()> for InHeader {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -884,9 +740,6 @@ impl MergeWithContext<()> for InHeader {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.required,
             other.required,
@@ -894,9 +747,6 @@ impl MergeWithContext<()> for InHeader {
             &format!("{path}.required"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -904,9 +754,6 @@ impl MergeWithContext<()> for InHeader {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.style,
             other.style,
@@ -914,9 +761,6 @@ impl MergeWithContext<()> for InHeader {
             &format!("{path}.style"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
@@ -924,13 +768,7 @@ impl MergeWithContext<()> for InHeader {
             &format!("{path}.explode"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
-        if ctx.errored {
-            return;
-        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
@@ -938,9 +776,6 @@ impl MergeWithContext<()> for InHeader {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -949,9 +784,6 @@ impl MergeWithContext<()> for InHeader {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.content,
             other.content,
@@ -960,9 +792,6 @@ impl MergeWithContext<()> for InHeader {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -974,6 +803,9 @@ impl MergeWithContext<()> for InHeader {
 
 impl MergeWithContext<()> for InCookie {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -981,9 +813,6 @@ impl MergeWithContext<()> for InCookie {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.required,
             other.required,
@@ -991,9 +820,6 @@ impl MergeWithContext<()> for InCookie {
             &format!("{path}.required"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -1001,9 +827,6 @@ impl MergeWithContext<()> for InCookie {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.style,
             other.style,
@@ -1011,9 +834,6 @@ impl MergeWithContext<()> for InCookie {
             &format!("{path}.style"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
@@ -1021,13 +841,7 @@ impl MergeWithContext<()> for InCookie {
             &format!("{path}.explode"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
-        if ctx.errored {
-            return;
-        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
@@ -1035,9 +849,6 @@ impl MergeWithContext<()> for InCookie {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -1046,9 +857,6 @@ impl MergeWithContext<()> for InCookie {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.content,
             other.content,
@@ -1057,9 +865,6 @@ impl MergeWithContext<()> for InCookie {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1071,6 +876,9 @@ impl MergeWithContext<()> for InCookie {
 
 impl MergeWithContext<()> for InQuerystring {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1078,9 +886,6 @@ impl MergeWithContext<()> for InQuerystring {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.required,
             other.required,
@@ -1088,9 +893,6 @@ impl MergeWithContext<()> for InQuerystring {
             &format!("{path}.required"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -1098,16 +900,10 @@ impl MergeWithContext<()> for InQuerystring {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         // querystring `content` is a bare BTreeMap (required by the spec).
         for (k, incoming) in other.content {
             if let Some(b) = self.content.get_mut(&k) {
                 b.merge_with_context(incoming, ctx, format!("{path}.content.{k}"));
-                if ctx.errored {
-                    return;
-                }
             } else {
                 self.content.insert(k, incoming);
             }
@@ -1119,9 +915,6 @@ impl MergeWithContext<()> for InQuerystring {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -1130,9 +923,6 @@ impl MergeWithContext<()> for InQuerystring {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1142,18 +932,21 @@ impl MergeWithContext<()> for InQuerystring {
     }
 }
 
-/// Shared helper: merge an `Option<RefOr<Schema>>`. Used by every
-/// parameter variant and by Header.
-fn merge_param_schema(
+/// Shared helper: merge an `Option<RefOr<Schema>>`. `field_name` is
+/// the JSONPath segment (`schema`, `itemSchema`, `propertyNames`, …)
+/// — without it, every collision was previously misreported as
+/// `.schema`.
+fn merge_schema_field(
     base: &mut Option<RefOr<Schema>>,
     other: Option<RefOr<Schema>>,
     ctx: &mut MergeContext<()>,
     path: &str,
+    field_name: &str,
 ) {
     match (base.as_mut(), other) {
         (_, None) => {}
         (None, Some(v)) => *base = Some(v),
-        (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.schema")),
+        (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.{field_name}")),
     }
 }
 
@@ -1161,6 +954,9 @@ fn merge_param_schema(
 
 impl MergeWithContext<()> for MediaType {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1168,17 +964,14 @@ impl MergeWithContext<()> for MediaType {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(&mut self.item_schema, other.item_schema, ctx, &path);
-        if ctx.errored {
-            return;
-        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
+        merge_schema_field(
+            &mut self.item_schema,
+            other.item_schema,
+            ctx,
+            &path,
+            "itemSchema",
+        );
         merge_opt_scalar(
             &mut self.example,
             other.example,
@@ -1186,9 +979,6 @@ impl MergeWithContext<()> for MediaType {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -1197,9 +987,6 @@ impl MergeWithContext<()> for MediaType {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.encoding,
             other.encoding,
@@ -1208,9 +995,6 @@ impl MergeWithContext<()> for MediaType {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         // prefix_encoding is a positional list — replace when non-empty.
         merge_replace_list_when_nonempty(
             &mut self.prefix_encoding,
@@ -1218,16 +1002,10 @@ impl MergeWithContext<()> for MediaType {
             ctx,
             &format!("{path}.prefixEncoding"),
         );
-        if ctx.errored {
-            return;
-        }
         match (&mut self.item_encoding, other.item_encoding) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => b.merge_with_context(i, ctx, format!("{path}.itemEncoding")),
-        }
-        if ctx.errored {
-            return;
         }
         merge_extensions(
             &mut self.extensions,
@@ -1240,6 +1018,9 @@ impl MergeWithContext<()> for MediaType {
 
 impl MergeWithContext<()> for Encoding {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.content_type,
             other.content_type,
@@ -1247,9 +1028,6 @@ impl MergeWithContext<()> for Encoding {
             &format!("{path}.contentType"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.headers,
             other.headers,
@@ -1258,9 +1036,6 @@ impl MergeWithContext<()> for Encoding {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.style,
             other.style,
@@ -1268,9 +1043,6 @@ impl MergeWithContext<()> for Encoding {
             &format!("{path}.style"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
@@ -1278,9 +1050,6 @@ impl MergeWithContext<()> for Encoding {
             &format!("{path}.explode"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.allow_reserved,
             other.allow_reserved,
@@ -1288,9 +1057,6 @@ impl MergeWithContext<()> for Encoding {
             &format!("{path}.allowReserved"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.encoding,
             other.encoding,
@@ -1299,25 +1065,16 @@ impl MergeWithContext<()> for Encoding {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_replace_list_when_nonempty(
             &mut self.prefix_encoding,
             other.prefix_encoding,
             ctx,
             &format!("{path}.prefixEncoding"),
         );
-        if ctx.errored {
-            return;
-        }
         match (&mut self.item_encoding, other.item_encoding) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => b.merge_with_context(*i, ctx, format!("{path}.itemEncoding")),
-        }
-        if ctx.errored {
-            return;
         }
         merge_extensions(
             &mut self.extensions,
@@ -1330,6 +1087,9 @@ impl MergeWithContext<()> for Encoding {
 
 impl MergeWithContext<()> for Header {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1337,9 +1097,6 @@ impl MergeWithContext<()> for Header {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.required,
             other.required,
@@ -1347,9 +1104,6 @@ impl MergeWithContext<()> for Header {
             &format!("{path}.required"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -1357,9 +1111,6 @@ impl MergeWithContext<()> for Header {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.style,
             other.style,
@@ -1367,9 +1118,6 @@ impl MergeWithContext<()> for Header {
             &format!("{path}.style"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.explode,
             other.explode,
@@ -1377,13 +1125,7 @@ impl MergeWithContext<()> for Header {
             &format!("{path}.explode"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(&mut self.schema, other.schema, ctx, &path);
-        if ctx.errored {
-            return;
-        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, &path, "schema");
         merge_opt_scalar(
             &mut self.example,
             other.example,
@@ -1391,9 +1133,6 @@ impl MergeWithContext<()> for Header {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.examples,
             other.examples,
@@ -1402,9 +1141,6 @@ impl MergeWithContext<()> for Header {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.content,
             other.content,
@@ -1413,9 +1149,6 @@ impl MergeWithContext<()> for Header {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1427,6 +1160,9 @@ impl MergeWithContext<()> for Header {
 
 impl MergeWithContext<()> for Response {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
@@ -1434,9 +1170,6 @@ impl MergeWithContext<()> for Response {
             &format!("{path}.summary"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1444,9 +1177,6 @@ impl MergeWithContext<()> for Response {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.headers,
             other.headers,
@@ -1455,9 +1185,6 @@ impl MergeWithContext<()> for Response {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.content,
             other.content,
@@ -1466,9 +1193,6 @@ impl MergeWithContext<()> for Response {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.links,
             other.links,
@@ -1477,9 +1201,6 @@ impl MergeWithContext<()> for Response {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1491,6 +1212,9 @@ impl MergeWithContext<()> for Response {
 
 impl MergeWithContext<()> for RequestBody {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1498,16 +1222,10 @@ impl MergeWithContext<()> for RequestBody {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         // content is a bare BTreeMap (required).
         for (k, incoming) in other.content {
             if let Some(b) = self.content.get_mut(&k) {
                 b.merge_with_context(incoming, ctx, format!("{path}.content.{k}"));
-                if ctx.errored {
-                    return;
-                }
             } else {
                 self.content.insert(k, incoming);
             }
@@ -1519,9 +1237,6 @@ impl MergeWithContext<()> for RequestBody {
             &format!("{path}.required"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1533,6 +1248,9 @@ impl MergeWithContext<()> for RequestBody {
 
 impl MergeWithContext<()> for Example {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
@@ -1540,9 +1258,6 @@ impl MergeWithContext<()> for Example {
             &format!("{path}.summary"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1550,9 +1265,6 @@ impl MergeWithContext<()> for Example {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.value,
             other.value,
@@ -1560,9 +1272,6 @@ impl MergeWithContext<()> for Example {
             &format!("{path}.value"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.serialized_value,
             other.serialized_value,
@@ -1570,9 +1279,6 @@ impl MergeWithContext<()> for Example {
             &format!("{path}.serializedValue"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.data_value,
             other.data_value,
@@ -1580,9 +1286,6 @@ impl MergeWithContext<()> for Example {
             &format!("{path}.dataValue"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.external_value,
             other.external_value,
@@ -1590,9 +1293,6 @@ impl MergeWithContext<()> for Example {
             &format!("{path}.externalValue"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1604,6 +1304,9 @@ impl MergeWithContext<()> for Example {
 
 impl MergeWithContext<()> for Link {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.operation_ref,
             other.operation_ref,
@@ -1611,9 +1314,6 @@ impl MergeWithContext<()> for Link {
             &format!("{path}.operationRef"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.operation_id,
             other.operation_id,
@@ -1621,9 +1321,6 @@ impl MergeWithContext<()> for Link {
             &format!("{path}.operationId"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         // Link.parameters is `Option<BTreeMap<String, serde_json::Value>>`
         // — treat like extensions.
         merge_extensions(
@@ -1632,9 +1329,6 @@ impl MergeWithContext<()> for Link {
             ctx,
             &format!("{path}.parameters"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.request_body,
             other.request_body,
@@ -1642,9 +1336,6 @@ impl MergeWithContext<()> for Link {
             &format!("{path}.requestBody"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1652,18 +1343,12 @@ impl MergeWithContext<()> for Link {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.server,
             other.server,
             ctx,
             &format!("{path}.server"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1678,6 +1363,9 @@ impl MergeWithContext<()> for Link {
 
 impl MergeWithContext<()> for Tag {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.name,
             other.name,
@@ -1685,9 +1373,6 @@ impl MergeWithContext<()> for Tag {
             &format!("{path}.name"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
@@ -1695,9 +1380,6 @@ impl MergeWithContext<()> for Tag {
             &format!("{path}.summary"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1705,18 +1387,12 @@ impl MergeWithContext<()> for Tag {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.external_docs,
             other.external_docs,
             ctx,
             &format!("{path}.externalDocs"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.parent,
             other.parent,
@@ -1724,9 +1400,6 @@ impl MergeWithContext<()> for Tag {
             &format!("{path}.parent"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.kind,
             other.kind,
@@ -1734,9 +1407,6 @@ impl MergeWithContext<()> for Tag {
             &format!("{path}.kind"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1748,6 +1418,9 @@ impl MergeWithContext<()> for Tag {
 
 impl MergeWithContext<()> for Info {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.title,
             other.title,
@@ -1755,9 +1428,6 @@ impl MergeWithContext<()> for Info {
             &format!("{path}.title"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.summary,
             other.summary,
@@ -1765,9 +1435,6 @@ impl MergeWithContext<()> for Info {
             &format!("{path}.summary"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1775,9 +1442,6 @@ impl MergeWithContext<()> for Info {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.terms_of_service,
             other.terms_of_service,
@@ -1785,27 +1449,18 @@ impl MergeWithContext<()> for Info {
             &format!("{path}.termsOfService"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.contact,
             other.contact,
             ctx,
             &format!("{path}.contact"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.license,
             other.license,
             ctx,
             &format!("{path}.license"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_required_scalar(
             &mut self.version,
             other.version,
@@ -1813,9 +1468,6 @@ impl MergeWithContext<()> for Info {
             &format!("{path}.version"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1827,6 +1479,9 @@ impl MergeWithContext<()> for Info {
 
 impl MergeWithContext<()> for Contact {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.name,
             other.name,
@@ -1834,9 +1489,6 @@ impl MergeWithContext<()> for Contact {
             &format!("{path}.name"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.url,
             other.url,
@@ -1844,9 +1496,6 @@ impl MergeWithContext<()> for Contact {
             &format!("{path}.url"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.email,
             other.email,
@@ -1854,9 +1503,6 @@ impl MergeWithContext<()> for Contact {
             &format!("{path}.email"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1868,6 +1514,9 @@ impl MergeWithContext<()> for Contact {
 
 impl MergeWithContext<()> for License {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.name,
             other.name,
@@ -1875,9 +1524,6 @@ impl MergeWithContext<()> for License {
             &format!("{path}.name"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.identifier,
             other.identifier,
@@ -1885,9 +1531,6 @@ impl MergeWithContext<()> for License {
             &format!("{path}.identifier"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.url,
             other.url,
@@ -1895,9 +1538,6 @@ impl MergeWithContext<()> for License {
             &format!("{path}.url"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1909,6 +1549,9 @@ impl MergeWithContext<()> for License {
 
 impl MergeWithContext<()> for ExternalDocumentation {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.url,
             other.url,
@@ -1916,9 +1559,6 @@ impl MergeWithContext<()> for ExternalDocumentation {
             &format!("{path}.url"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -1926,9 +1566,6 @@ impl MergeWithContext<()> for ExternalDocumentation {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -1940,6 +1577,9 @@ impl MergeWithContext<()> for ExternalDocumentation {
 
 impl MergeWithContext<()> for Discriminator {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.property_name,
             other.property_name,
@@ -1947,9 +1587,6 @@ impl MergeWithContext<()> for Discriminator {
             &format!("{path}.propertyName"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         // mapping is Option<BTreeMap<String,String>>; per-key incoming wins.
         if let Some(other_map) = other.mapping {
             let base_map = self
@@ -1971,9 +1608,6 @@ impl MergeWithContext<()> for Discriminator {
                         }
                     }
                 }
-                if ctx.errored {
-                    return;
-                }
             }
         }
         merge_opt_scalar(
@@ -1988,6 +1622,9 @@ impl MergeWithContext<()> for Discriminator {
 
 impl MergeWithContext<()> for XML {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.name,
             other.name,
@@ -1995,9 +1632,6 @@ impl MergeWithContext<()> for XML {
             &format!("{path}.name"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.namespace,
             other.namespace,
@@ -2005,9 +1639,6 @@ impl MergeWithContext<()> for XML {
             &format!("{path}.namespace"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.prefix,
             other.prefix,
@@ -2015,9 +1646,6 @@ impl MergeWithContext<()> for XML {
             &format!("{path}.prefix"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.attribute,
             other.attribute,
@@ -2025,9 +1653,6 @@ impl MergeWithContext<()> for XML {
             &format!("{path}.attribute"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.wrapped,
             other.wrapped,
@@ -2035,9 +1660,6 @@ impl MergeWithContext<()> for XML {
             &format!("{path}.wrapped"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.node_type,
             other.node_type,
@@ -2045,9 +1667,6 @@ impl MergeWithContext<()> for XML {
             &format!("{path}.nodeType"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2059,6 +1678,9 @@ impl MergeWithContext<()> for XML {
 
 impl MergeWithContext<()> for Server {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.url,
             other.url,
@@ -2066,9 +1688,6 @@ impl MergeWithContext<()> for Server {
             &format!("{path}.url"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.name,
             other.name,
@@ -2076,9 +1695,6 @@ impl MergeWithContext<()> for Server {
             &format!("{path}.name"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -2086,9 +1702,6 @@ impl MergeWithContext<()> for Server {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.variables,
             other.variables,
@@ -2097,29 +1710,9 @@ impl MergeWithContext<()> for Server {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
-            ctx,
-            &format!("{path}.extensions"),
-        );
-    }
-}
-
-impl MergeWithContext<()> for ServerVariable {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
-        // ServerVariable in our model has only `extensions`; the
-        // spec's `default`/`enum`/`description` are public fields on
-        // the struct but not enumerated above. Fall back to a full
-        // field walk via mem::replace so we don't drop incoming
-        // fields silently.
-        let ServerVariable { extensions, .. } = other;
-        merge_extensions(
-            &mut self.extensions,
-            extensions,
             ctx,
             &format!("{path}.extensions"),
         );
@@ -2130,6 +1723,9 @@ impl MergeWithContext<()> for ServerVariable {
 
 impl MergeWithContext<()> for SecurityScheme {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         match (self, other) {
             (SecurityScheme::ApiKey(a), SecurityScheme::ApiKey(b)) => {
                 a.merge_with_context(*b, ctx, path)
@@ -2157,6 +1753,9 @@ impl MergeWithContext<()> for SecurityScheme {
 
 impl MergeWithContext<()> for ApiKeySecurityScheme {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.name,
             other.name,
@@ -2164,9 +1763,6 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
             &format!("{path}.name"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_required_scalar(
             &mut self.location,
             other.location,
@@ -2174,9 +1770,6 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
             &format!("{path}.in"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -2184,9 +1777,6 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -2194,9 +1784,6 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2208,6 +1795,9 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
 
 impl MergeWithContext<()> for HttpSecurityScheme {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.scheme,
             other.scheme,
@@ -2215,9 +1805,6 @@ impl MergeWithContext<()> for HttpSecurityScheme {
             &format!("{path}.scheme"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.bearer_format,
             other.bearer_format,
@@ -2225,9 +1812,6 @@ impl MergeWithContext<()> for HttpSecurityScheme {
             &format!("{path}.bearerFormat"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -2235,9 +1819,6 @@ impl MergeWithContext<()> for HttpSecurityScheme {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -2245,9 +1826,6 @@ impl MergeWithContext<()> for HttpSecurityScheme {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2259,6 +1837,9 @@ impl MergeWithContext<()> for HttpSecurityScheme {
 
 impl MergeWithContext<()> for MutualTLSSecurityScheme {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -2266,9 +1847,6 @@ impl MergeWithContext<()> for MutualTLSSecurityScheme {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -2276,9 +1854,6 @@ impl MergeWithContext<()> for MutualTLSSecurityScheme {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2290,6 +1865,9 @@ impl MergeWithContext<()> for MutualTLSSecurityScheme {
 
 impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_required_scalar(
             &mut self.open_id_connect_url,
             other.open_id_connect_url,
@@ -2297,9 +1875,6 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
             &format!("{path}.openIdConnectUrl"),
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -2307,9 +1882,6 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -2317,9 +1889,6 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2331,11 +1900,11 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
 
 impl MergeWithContext<()> for OAuth2SecurityScheme {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
-        self.flows
-            .merge_with_context(other.flows, ctx, format!("{path}.flows"));
         if ctx.errored {
             return;
         }
+        self.flows
+            .merge_with_context(other.flows, ctx, format!("{path}.flows"));
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -2343,9 +1912,6 @@ impl MergeWithContext<()> for OAuth2SecurityScheme {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.oauth2_metadata_url,
             other.oauth2_metadata_url,
@@ -2353,9 +1919,6 @@ impl MergeWithContext<()> for OAuth2SecurityScheme {
             &format!("{path}.oauth2MetadataUrl"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -2363,9 +1926,6 @@ impl MergeWithContext<()> for OAuth2SecurityScheme {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2377,51 +1937,39 @@ impl MergeWithContext<()> for OAuth2SecurityScheme {
 
 impl MergeWithContext<()> for OAuth2Flows {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_struct(
             &mut self.implicit,
             other.implicit,
             ctx,
             &format!("{path}.implicit"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.password,
             other.password,
             ctx,
             &format!("{path}.password"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.client_credentials,
             other.client_credentials,
             ctx,
             &format!("{path}.clientCredentials"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.authorization_code,
             other.authorization_code,
             ctx,
             &format!("{path}.authorizationCode"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.device_authorization,
             other.device_authorization,
             ctx,
             &format!("{path}.deviceAuthorization"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2443,6 +1991,7 @@ macro_rules! oauth_flow_merge {
                 ctx: &mut MergeContext<()>,
                 path: String,
             ) {
+                if ctx.errored { return; }
                 $(
                     merge_required_scalar(
                         &mut self.$url_field,
@@ -2451,9 +2000,6 @@ macro_rules! oauth_flow_merge {
                         &format!("{path}.{}", $url_path),
                         ConflictKind::RequiredScalarOverridden,
                     );
-                    if ctx.errored {
-                        return;
-                    }
                 )*
                 merge_opt_scalar(
                     &mut self.refresh_url,
@@ -2462,9 +2008,6 @@ macro_rules! oauth_flow_merge {
                     &format!("{path}.refreshUrl"),
                     ConflictKind::ScalarOverridden,
                 );
-                if ctx.errored {
-                    return;
-                }
                 // scopes is a bare BTreeMap<String, String>.
                 for (k, v) in other.scopes {
                     match self.scopes.get_mut(&k) {
@@ -2481,9 +2024,6 @@ macro_rules! oauth_flow_merge {
                                 *existing = v;
                             }
                         }
-                    }
-                    if ctx.errored {
-                        return;
                     }
                 }
                 merge_extensions(
@@ -2515,37 +2055,71 @@ oauth_flow_merge!(
 
 impl MergeWithContext<()> for Schema {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
-        // ObjectSchema deep-merge is the one variant pairing that
-        // recurses — everything else falls back to leaf-replace.
-        if ctx.is_option(MergeOptions::DeepMergeObjectSchemas)
-            && let (Schema::Single(self_single), Schema::Single(other_single)) =
-                (&mut *self, &other)
-            && let (SingleSchema::Object(_), SingleSchema::Object(_)) =
-                (&**self_single, &**other_single)
-        {
-            // Drop into a fresh match to take ownership of the
-            // incoming side.
-            let Schema::Single(other_single) = other else {
-                unreachable!()
-            };
-            let SingleSchema::Object(other_obj) = *other_single else {
-                unreachable!()
-            };
-            let SingleSchema::Object(self_obj) = &mut **self_single else {
-                unreachable!()
-            };
-            self_obj.merge_with_context(other_obj, ctx, path);
+        if ctx.errored {
             return;
         }
-        // Default: leaf-replace policy.
-        if *self != other && ctx.should_take_incoming(&path, ConflictKind::SchemaLeafReplaced) {
-            *self = other;
+        // ObjectSchema deep-merge is the one variant pairing that
+        // recurses — everything else falls back to leaf-replace.
+        //
+        // Take ownership of `other` up front so the match is on owned
+        // values, avoiding the borrow-then-re-destructure dance that
+        // previously needed three `unreachable!()` guards. If the
+        // variants don't match, the bound-once `incoming` is reused
+        // for the leaf-replace fallback below.
+        if ctx.is_option(MergeOptions::DeepMergeObjectSchemas)
+            && let Schema::Single(self_single) = self
+            && let SingleSchema::Object(self_obj) = self_single.as_mut()
+        {
+            match other {
+                Schema::Single(other_single) => match *other_single {
+                    SingleSchema::Object(other_obj) => {
+                        self_obj.merge_with_context(other_obj, ctx, path);
+                        return;
+                    }
+                    other_single_inner => {
+                        // Re-box and fall through to leaf-replace.
+                        return leaf_replace_schema(
+                            self,
+                            Schema::Single(Box::new(other_single_inner)),
+                            ctx,
+                            &path,
+                        );
+                    }
+                },
+                non_single => {
+                    return leaf_replace_schema(self, non_single, ctx, &path);
+                }
+            }
         }
+        leaf_replace_schema(self, other, ctx, &path);
+    }
+}
+
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+    if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
+        *base = other;
+    }
+}
+
+/// Record a collision where the documented contract says "base is
+/// kept" — used for `Spec.info` / `Spec.openapi` when `MergeInfo` is
+/// off. Records `Resolution::Base` in the default / `BaseWins` modes
+/// (reflecting what actually happened), and trips
+/// `ErrorOnConflict` when set.
+fn record_kept_base_or_error(ctx: &mut MergeContext<()>, path: &str, kind: ConflictKind) {
+    if ctx.is_option(MergeOptions::ErrorOnConflict) {
+        ctx.record(path.to_owned(), kind, crate::merge::Resolution::Errored);
+        ctx.errored = true;
+    } else {
+        ctx.record(path.to_owned(), kind, crate::merge::Resolution::Base);
     }
 }
 
 impl MergeWithContext<()> for ObjectSchema {
     fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: String) {
+        if ctx.errored {
+            return;
+        }
         merge_opt_scalar(
             &mut self.title,
             other.title,
@@ -2553,9 +2127,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.title"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
@@ -2563,9 +2134,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.description"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.properties,
             other.properties,
@@ -2574,9 +2142,6 @@ impl MergeWithContext<()> for ObjectSchema {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_map(
             &mut self.pattern_properties,
             other.pattern_properties,
@@ -2585,9 +2150,6 @@ impl MergeWithContext<()> for ObjectSchema {
             |b, i, c, p| b.merge_with_context(i, c, p),
             key_str,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.default,
             other.default,
@@ -2595,9 +2157,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.default"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.max_properties,
             other.max_properties,
@@ -2605,9 +2164,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.maxProperties"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.min_properties,
             other.min_properties,
@@ -2615,18 +2171,12 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.minProperties"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         match (&mut self.additional_properties, other.additional_properties) {
             (_, None) => {}
             (slot @ None, Some(v)) => *slot = Some(v),
             (Some(b), Some(i)) => {
                 b.merge_with_context(i, ctx, format!("{path}.additionalProperties"))
             }
-        }
-        if ctx.errored {
-            return;
         }
         match (
             &mut self.unevaluated_properties,
@@ -2638,18 +2188,13 @@ impl MergeWithContext<()> for ObjectSchema {
                 b.merge_with_context(i, ctx, format!("{path}.unevaluatedProperties"))
             }
         }
-        if ctx.errored {
-            return;
-        }
-        merge_param_schema(
+        merge_schema_field(
             &mut self.property_names,
             other.property_names,
             ctx,
-            &format!("{path}.propertyNames"),
+            &path,
+            "propertyNames",
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_vec_set_union(
             &mut self.required,
             other.required,
@@ -2663,9 +2208,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.readOnly"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.write_only,
             other.write_only,
@@ -2673,9 +2215,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.writeOnly"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.deprecated,
             other.deprecated,
@@ -2683,22 +2222,13 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.deprecated"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(&mut self.xml, other.xml, ctx, &format!("{path}.xml"));
-        if ctx.errored {
-            return;
-        }
         merge_opt_struct(
             &mut self.external_docs,
             other.external_docs,
             ctx,
             &format!("{path}.externalDocs"),
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.example,
             other.example,
@@ -2706,9 +2236,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.example"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.examples,
             other.examples,
@@ -2716,9 +2243,6 @@ impl MergeWithContext<()> for ObjectSchema {
             &format!("{path}.examples"),
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
@@ -2742,6 +2266,7 @@ macro_rules! leaf_schema_merge {
                     ctx: &mut MergeContext<()>,
                     path: String,
                 ) {
+                    if ctx.errored { return; }
                     if *self != other
                         && ctx.should_take_incoming(&path, ConflictKind::SchemaLeafReplaced)
                     {
@@ -3205,6 +2730,112 @@ mod tests {
             .unwrap();
         assert_eq!(base.info.description.as_deref(), Some("base desc"));
         assert_eq!(base.info.summary.as_deref(), Some("from incoming"));
+    }
+
+    // ---- Coverage: ErrorOnConflict catches info mismatch even when base is kept ----
+
+    #[test]
+    fn spec_info_mismatch_trips_error_on_conflict_even_without_merge_info() {
+        use crate::v3_2::info::Info;
+        let mut base = Spec {
+            info: Info {
+                title: "Base".into(),
+                version: "1.0.0".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let incoming = Spec {
+            info: Info {
+                title: "Incoming".into(),
+                version: "2.0.0".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        // Without MergeInfo, default mode kept base silently before
+        // the fix; with the fix, ErrorOnConflict trips on the info
+        // mismatch.
+        let err = base
+            .merge(incoming, MergeOptions::ErrorOnConflict.only())
+            .expect_err("info mismatch should error under ErrorOnConflict");
+        assert!(err.conflicts.iter().any(|c| c.path.ends_with(".info")));
+    }
+
+    // ---- Coverage: itemSchema conflict path is correct ----
+
+    #[test]
+    fn media_type_item_schema_conflict_path_is_item_schema() {
+        use crate::v3_2::media_type::MediaType;
+        let s1 = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            required: Some(vec!["a".into()]),
+            ..Default::default()
+        })));
+        let s2 = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            required: Some(vec!["b".into()]),
+            ..Default::default()
+        })));
+        let mut base = MediaType {
+            item_schema: Some(RefOr::new_item(s1)),
+            ..Default::default()
+        };
+        let incoming = MediaType {
+            item_schema: Some(RefOr::new_item(s2)),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base.merge_with_context(incoming, &mut ctx, "#.mt".into());
+        // Conflict path should mention itemSchema, not schema.
+        assert!(
+            ctx.conflicts.iter().any(|c| c.path.contains("itemSchema")),
+            "conflict paths: {:?}",
+            ctx.conflicts.iter().map(|c| &c.path).collect::<Vec<_>>()
+        );
+        assert!(
+            !ctx.conflicts
+                .iter()
+                .any(|c| c.path.ends_with(".schema") && !c.path.contains("itemSchema")),
+            "unexpected `.schema` path: {:?}",
+            ctx.conflicts.iter().map(|c| &c.path).collect::<Vec<_>>()
+        );
+    }
+
+    // ---- Coverage: ServerVariable carries default/enum/description through merge ----
+
+    #[test]
+    fn server_variable_full_field_merge_through_server_variables_map() {
+        use crate::v3_2::server::{Server, ServerVariable};
+        // The variable fields are private, so build via serde round-trip.
+        let base_var: ServerVariable = serde_json::from_value(serde_json::json!({
+            "default": "v1",
+            "description": "base desc"
+        }))
+        .unwrap();
+        let incoming_var: ServerVariable = serde_json::from_value(serde_json::json!({
+            "default": "v1",
+            "enum": ["v1", "v2"],
+            "description": "incoming desc"
+        }))
+        .unwrap();
+        let mut base_server = Server {
+            url: "https://api.example".into(),
+            variables: Some(BTreeMap::from([("ver".to_owned(), base_var)])),
+            ..Default::default()
+        };
+        let incoming_server = Server {
+            url: "https://api.example".into(),
+            variables: Some(BTreeMap::from([("ver".to_owned(), incoming_var)])),
+            ..Default::default()
+        };
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        base_server.merge_with_context(incoming_server, &mut ctx, "#.srv".into());
+        let merged = base_server.variables.unwrap();
+        let v = merged.get("ver").unwrap();
+        // Round-trip through serde to inspect the private fields.
+        let json = serde_json::to_value(v).unwrap();
+        assert_eq!(json["description"], "incoming desc");
+        assert_eq!(json["enum"], serde_json::json!(["v1", "v2"]));
+        assert_eq!(json["default"], "v1");
     }
 
     // ---- Components: schemas collision uses leaf replace by default ----

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -80,9 +80,31 @@ impl Merge for Spec {
         // caller to clone the base before merging into it.
         let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
         let path = "#".to_owned();
-        // The actual recursion takes `&mut self` so we can't carry a
-        // borrow of `self` in `ctx.spec`. The component impls below
-        // are written against `MergeContext<()>` accordingly.
+
+        if options.contains(MergeOptions::ErrorOnConflict) {
+            // Strict-mode rollback: clone `self` into a working copy
+            // and only commit it back on success. Without this, an
+            // `Err` would leave `self` partially merged (additive
+            // steps run before the first collision flips `ctx.errored`),
+            // which contradicts the contract callers reach for
+            // `ErrorOnConflict` to get. The clone cost is paid only
+            // when the option is opted in.
+            let mut working = self.clone();
+            <Spec as MergeWithContext<()>>::merge_with_context(&mut working, other, &mut ctx, path);
+            if ctx.errored {
+                return Err(MergeError {
+                    conflicts: ctx.conflicts,
+                });
+            }
+            *self = working;
+            return Ok(MergeReport {
+                conflicts: ctx.conflicts,
+            });
+        }
+
+        // Non-strict modes mutate `self` in place — the report still
+        // captures every resolution, so callers wanting "see what
+        // changed" don't need the clone-and-replace overhead.
         <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, path);
         ctx.into()
     }
@@ -2605,6 +2627,108 @@ mod tests {
         let err = result.unwrap_err();
         assert!(!err.conflicts.is_empty());
         assert_eq!(err.conflicts[0].resolution, Resolution::Errored);
+    }
+
+    #[test]
+    fn spec_error_on_conflict_rolls_back_base_on_err() {
+        // Base has tags=[A,B], a 200 response on /pets.get, and a
+        // jsonSchemaDialect. Incoming adds a tag C (additive — no
+        // conflict by itself), a 404 response (additive), and a
+        // different jsonSchemaDialect that *will* collide. With
+        // `ErrorOnConflict`, the additive bits that ran *before*
+        // hitting the dialect conflict must not be observable on
+        // `base` after the `Err` returns — the rollback contract.
+        let mut base = Spec {
+            tags: Some(vec![
+                Tag {
+                    name: "A".into(),
+                    ..Default::default()
+                },
+                Tag {
+                    name: "B".into(),
+                    ..Default::default()
+                },
+            ]),
+            paths: Some(Paths {
+                paths: BTreeMap::from([(
+                    "/pets".to_owned(),
+                    PathItem {
+                        operations: Some(BTreeMap::from([(
+                            "get".to_owned(),
+                            Operation {
+                                responses: Some(Responses {
+                                    responses: Some(BTreeMap::from([(
+                                        "200".to_owned(),
+                                        response_with("ok"),
+                                    )])),
+                                    ..Default::default()
+                                }),
+                                ..Default::default()
+                            },
+                        )])),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }),
+            json_schema_dialect: Some("base-dialect".into()),
+            ..Default::default()
+        };
+        let incoming = Spec {
+            tags: Some(vec![Tag {
+                name: "C".into(),
+                ..Default::default()
+            }]),
+            paths: Some(Paths {
+                paths: BTreeMap::from([(
+                    "/pets".to_owned(),
+                    PathItem {
+                        operations: Some(BTreeMap::from([(
+                            "get".to_owned(),
+                            Operation {
+                                responses: Some(Responses {
+                                    responses: Some(BTreeMap::from([(
+                                        "404".to_owned(),
+                                        response_with("missing"),
+                                    )])),
+                                    ..Default::default()
+                                }),
+                                ..Default::default()
+                            },
+                        )])),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }),
+            json_schema_dialect: Some("incoming-dialect".into()),
+            ..Default::default()
+        };
+        let result = base.merge(incoming, MergeOptions::ErrorOnConflict.only());
+        assert!(result.is_err());
+        // Base is untouched: still 2 tags, still only the 200 response,
+        // still the original dialect.
+        let tag_names: Vec<_> = base
+            .tags
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|t| t.name.as_str())
+            .collect();
+        assert_eq!(tag_names, vec!["A", "B"]);
+        let responses = base.paths.as_ref().unwrap().paths["/pets"]
+            .operations
+            .as_ref()
+            .unwrap()["get"]
+            .responses
+            .as_ref()
+            .unwrap()
+            .responses
+            .as_ref()
+            .unwrap();
+        assert!(responses.contains_key("200"));
+        assert!(!responses.contains_key("404"), "404 must not have leaked");
+        assert_eq!(base.json_schema_dialect.as_deref(), Some("base-dialect"));
     }
 
     // ---- Spec.tags: dedup by name with recursion ----

--- a/crates/roas/src/v3_2/server.rs
+++ b/crates/roas/src/v3_2/server.rs
@@ -155,6 +155,54 @@ impl ValidateWithContext<Spec> for ServerVariable {
     }
 }
 
+impl crate::merge::MergeWithContext<()> for ServerVariable {
+    fn merge_with_context(
+        &mut self,
+        other: Self,
+        ctx: &mut crate::merge::MergeContext<()>,
+        path: String,
+    ) {
+        use crate::common::merge::{merge_extensions, merge_opt_scalar, merge_required_scalar};
+        use crate::merge::ConflictKind;
+        merge_opt_scalar(
+            &mut self.enum_values,
+            other.enum_values,
+            ctx,
+            &format!("{path}.enum"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.default,
+            other.default,
+            ctx,
+            &format!("{path}.default"),
+            ConflictKind::RequiredScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            &format!("{path}.description"),
+            ConflictKind::ScalarOverridden,
+        );
+        if ctx.errored {
+            return;
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            &format!("{path}.extensions"),
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/roas/src/v3_2/server.rs
+++ b/crates/roas/src/v3_2/server.rs
@@ -160,45 +160,43 @@ impl crate::merge::MergeWithContext<()> for ServerVariable {
         &mut self,
         other: Self,
         ctx: &mut crate::merge::MergeContext<()>,
-        path: String,
+        path: &mut String,
     ) {
+        if ctx.errored {
+            return;
+        }
         use crate::common::merge::{merge_extensions, merge_opt_scalar, merge_required_scalar};
         use crate::merge::ConflictKind;
         merge_opt_scalar(
             &mut self.enum_values,
             other.enum_values,
             ctx,
-            &format!("{path}.enum"),
+            path,
+            ".enum",
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_required_scalar(
             &mut self.default,
             other.default,
             ctx,
-            &format!("{path}.default"),
+            path,
+            ".default",
             ConflictKind::RequiredScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_opt_scalar(
             &mut self.description,
             other.description,
             ctx,
-            &format!("{path}.description"),
+            path,
+            ".description",
             ConflictKind::ScalarOverridden,
         );
-        if ctx.errored {
-            return;
-        }
         merge_extensions(
             &mut self.extensions,
             other.extensions,
             ctx,
-            &format!("{path}.extensions"),
+            path,
+            ".extensions",
         );
     }
 }

--- a/crates/roas/src/v3_2/server.rs
+++ b/crates/roas/src/v3_2/server.rs
@@ -155,6 +155,13 @@ impl ValidateWithContext<Spec> for ServerVariable {
     }
 }
 
+// `ServerVariable` is the only v3.2 component whose `MergeWithContext`
+// impl lives outside `crates/roas/src/v3_2/merge.rs` — its `default`,
+// `enum_values`, and `description` fields are crate-private and not
+// reachable from the consolidated merge module. Keep this impl
+// alongside the type until those fields are exposed (or until we
+// move every component impl into its component file in a future
+// reorganization).
 impl crate::merge::MergeWithContext<()> for ServerVariable {
     fn merge_with_context(
         &mut self,


### PR DESCRIPTION
Adds a public `Merge` trait + crate-internal `MergeWithContext<T>` recursive trait mirroring the existing `Validate` / `ValidateWithContext` pair (`crates/roas/src/validation.rs:538`). v3.2 only in this PR; v2 / v3.0 / v3.1 will follow in a separate PR that mostly copies the v3.2 impls.

```rust
use roas::merge::{Merge, MergeOptions};
let mut base: v3_2::Spec = ...;
let incoming: v3_2::Spec = ...;
let report = base.merge(incoming, MergeOptions::new())?;
```

Previous attempt (#142) took an "incoming wins at the top, deep-merge only at `PathItem`" path, which dropped meaningful structure on collisions below `PathItem` (e.g. two `Operation.responses` with different status codes — base statuses were lost). This rewrite walks every component recursively so unrelated fields coexist.

**Policy choices (per the design questions):**

- **Schemas** are leaves by default — `Schema × Schema` collision replaces, recorded as `SchemaLeafReplaced`. `MergeOptions::DeepMergeObjectSchemas` opts into recursive merge when both sides are `Schema::Single(SingleSchema::Object(_))` — `properties` per-key, `required` set-union, `additional_properties` recurses through `BoolOr<RefOr<Schema>>`.
- **Three conflict modes**: default incoming-wins, `MergeOptions::BaseWins`, `MergeOptions::ErrorOnConflict`. Every resolution recorded in `MergeReport` regardless.
- **RefOr** policy: `Item × Item` recurses; `Ref × Ref` same target merges metadata; mismatched refs or ref-vs-value replace with conflict recorded.
- **Info / openapi version** preserved on base by default; `MergeOptions::MergeInfo` recurses through `Info::merge`.
- **Operation.parameters** dedup by `(name, in)`; `Spec.tags` dedup by `name`.

Tests: 17 new in `crates/roas/src/v3_2/merge.rs` covering RefOr cases, response per-status merging, parameter dedup, PathItem method coexistence, leaf vs deep-merge schemas, three modes, tags by name, paths deep-merge, info preservation. Full suite: 1528 passed, fmt+clippy clean, doc builds.