### PR TITLE
feat(roas): port Spec::merge to v2, v3.0, v3.1

### DIFF
--- a/crates/roas/src/common/bool_or.rs
+++ b/crates/roas/src/common/bool_or.rs
@@ -25,14 +25,14 @@ impl<D> BoolOr<RefOr<D>> {
     }
 }
 
-impl<D, T> crate::merge::MergeWithContext<T> for BoolOr<D>
+impl<D> crate::merge::MergeWithContext for BoolOr<D>
 where
-    D: crate::merge::MergeWithContext<T>,
+    D: crate::merge::MergeWithContext,
 {
     fn merge_with_context(
         &mut self,
         other: Self,
-        ctx: &mut crate::merge::MergeContext<T>,
+        ctx: &mut crate::merge::MergeContext,
         path: &mut String,
     ) {
         if ctx.errored {
@@ -127,13 +127,8 @@ mod tests {
 
     use crate::merge::{ConflictKind, MergeContext, MergeOptions, MergeWithContext, Resolution};
 
-    impl MergeWithContext<()> for Foo {
-        fn merge_with_context(
-            &mut self,
-            other: Self,
-            ctx: &mut MergeContext<()>,
-            path: &mut String,
-        ) {
+    impl MergeWithContext for Foo {
+        fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
             if self.foo != other.foo
                 && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden)
             {
@@ -142,8 +137,8 @@ mod tests {
         }
     }
 
-    fn ctx_with(opts: enumset::EnumSet<MergeOptions>) -> MergeContext<'static, ()> {
-        MergeContext::new(&(), opts)
+    fn ctx_with(opts: enumset::EnumSet<MergeOptions>) -> MergeContext {
+        MergeContext::new(opts)
     }
 
     #[test]

--- a/crates/roas/src/common/merge.rs
+++ b/crates/roas/src/common/merge.rs
@@ -386,6 +386,32 @@ pub(crate) fn merge_opt_struct<S>(
     }
 }
 
+/// Record a collision where the documented contract says "base is
+/// kept" — used by every per-version `Spec::merge_with_context` for
+/// `info` / `openapi` (or `swagger` in v2) when `MergeInfo` is off.
+/// Records `Resolution::Base` in the default / `BaseWins` modes
+/// (reflecting what actually happened) and trips
+/// `ErrorOnConflict` when set. Pushes `segment` onto `path` only
+/// when actually recording, keeping the eager-allocation regression
+/// off the non-conflict path.
+pub(crate) fn record_kept_base_or_error(
+    ctx: &mut MergeContext,
+    path: &mut String,
+    segment: &str,
+    kind: ConflictKind,
+) {
+    use crate::merge::{MergeOptions, Resolution};
+    let original_len = path.len();
+    path.push_str(segment);
+    if ctx.is_option(MergeOptions::ErrorOnConflict) {
+        ctx.record(path.clone(), kind, Resolution::Errored);
+        ctx.errored = true;
+    } else {
+        ctx.record(path.clone(), kind, Resolution::Base);
+    }
+    path.truncate(original_len);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/roas/src/common/merge.rs
+++ b/crates/roas/src/common/merge.rs
@@ -65,12 +65,12 @@ pub(crate) fn with_segment<R>(
 /// Merge two bare `BTreeMap`s by key. Used by `Paths`, `Callback`,
 /// `Components.<bag>` (each bag is `Option<BTreeMap<...>>` — wrap with
 /// [`merge_opt_map`] for those).
-pub(crate) fn merge_map<T, K, V>(
+pub(crate) fn merge_map<K, V>(
     base: &mut BTreeMap<K, V>,
     other: BTreeMap<K, V>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
-    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    mut recurse: impl FnMut(&mut V, V, &mut MergeContext, &mut String),
     fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord,
@@ -101,13 +101,13 @@ pub(crate) fn merge_map<T, K, V>(
 /// Merge two `Option<BTreeMap<K, V>>` (the common shape for
 /// `Components.<bag>` and the dozens of optional-map sub-fields).
 /// Pushes `segment` onto `path` only when there's something to do.
-pub(crate) fn merge_opt_map<T, K, V>(
+pub(crate) fn merge_opt_map<K, V>(
     base: &mut Option<BTreeMap<K, V>>,
     other: Option<BTreeMap<K, V>>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
-    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    recurse: impl FnMut(&mut V, V, &mut MergeContext, &mut String),
     fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord,
@@ -128,13 +128,13 @@ pub(crate) fn merge_opt_map<T, K, V>(
 /// Merge an identity-keyed `Vec` (e.g. `tags` by name, `parameters` by
 /// `(name, in)`). On collision the recursion callback decides what
 /// happens; new keys are appended in incoming order.
-pub(crate) fn merge_vec_by_key<T, V, K>(
+pub(crate) fn merge_vec_by_key<V, K>(
     base: &mut Vec<V>,
     other: Vec<V>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     key_of: impl Fn(&V) -> K,
-    mut recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    mut recurse: impl FnMut(&mut V, V, &mut MergeContext, &mut String),
     fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord + Clone,
@@ -170,14 +170,14 @@ pub(crate) fn merge_vec_by_key<T, V, K>(
 /// Merge an optional identity-keyed vec, treating `None` like an
 /// empty list on either side.
 #[allow(clippy::too_many_arguments)] // 8 args; this is a structural plumbing helper.
-pub(crate) fn merge_opt_vec_by_key<T, V, K>(
+pub(crate) fn merge_opt_vec_by_key<V, K>(
     base: &mut Option<Vec<V>>,
     other: Option<Vec<V>>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
     key_of: impl Fn(&V) -> K,
-    recurse: impl FnMut(&mut V, V, &mut MergeContext<T>, &mut String),
+    recurse: impl FnMut(&mut V, V, &mut MergeContext, &mut String),
     fmt_key: impl Fn(&K, &mut String),
 ) where
     K: Ord + Clone,
@@ -209,10 +209,10 @@ pub(crate) fn merge_opt_vec_by_key<T, V, K>(
 /// additive.
 ///
 /// Linear-scan dedup: `Vec::contains` against the grown base.
-pub(crate) fn merge_opt_vec_set_union<T, V>(
+pub(crate) fn merge_opt_vec_set_union<V>(
     base: &mut Option<Vec<V>>,
     other: Option<Vec<V>>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     _path: &mut String,
     _segment: &str,
 ) where
@@ -240,10 +240,10 @@ pub(crate) fn merge_opt_vec_set_union<T, V>(
 ///
 /// `segment` is appended onto `path` only when a real conflict is
 /// recorded — the non-conflict path never grows `path`.
-pub(crate) fn merge_opt_scalar<T, V>(
+pub(crate) fn merge_opt_scalar<V>(
     base: &mut Option<V>,
     other: Option<V>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
     kind: ConflictKind,
@@ -270,10 +270,10 @@ pub(crate) fn merge_opt_scalar<T, V>(
 /// Merge a required scalar (one that's always present, like
 /// `info.title`). Same policy as [`merge_opt_scalar`] for the
 /// `Some × Some` arm.
-pub(crate) fn merge_required_scalar<T, V>(
+pub(crate) fn merge_required_scalar<V>(
     base: &mut V,
     other: V,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
     kind: ConflictKind,
@@ -294,10 +294,10 @@ pub(crate) fn merge_required_scalar<T, V>(
 /// Replace `base` with `other` only when `other` is non-empty.
 /// Records [`ConflictKind::ListReplaced`] when an actual replacement
 /// occurs. Used for `servers`, `security`, etc.
-pub(crate) fn merge_replace_list_when_nonempty<T, V>(
+pub(crate) fn merge_replace_list_when_nonempty<V>(
     base: &mut Option<Vec<V>>,
     other: Option<Vec<V>>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
 ) {
@@ -326,10 +326,10 @@ pub(crate) fn merge_replace_list_when_nonempty<T, V>(
 /// Merge `Option<BTreeMap<String, serde_json::Value>>` extensions
 /// per-key. Identical JSON values are no-ops; differing values go
 /// through the policy.
-pub(crate) fn merge_extensions<T>(
+pub(crate) fn merge_extensions(
     base: &mut Option<BTreeMap<String, serde_json::Value>>,
     other: Option<BTreeMap<String, serde_json::Value>>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
 ) {
@@ -362,16 +362,16 @@ pub(crate) fn merge_extensions<T>(
     }
 }
 
-/// Merge two `Option<S>` where `S: MergeWithContext<T>`. Mirrors the
+/// Merge two `Option<S>` where `S: MergeWithContext`. Mirrors the
 /// scalar shape but recurses on `Some × Some`.
-pub(crate) fn merge_opt_struct<T, S>(
+pub(crate) fn merge_opt_struct<S>(
     base: &mut Option<S>,
     other: Option<S>,
-    ctx: &mut MergeContext<T>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
 ) where
-    S: MergeWithContext<T>,
+    S: MergeWithContext,
 {
     if ctx.errored {
         return;
@@ -398,7 +398,7 @@ mod tests {
     #[test]
     fn merge_opt_scalar_none_incoming_no_op() {
         let mut base: Option<String> = Some("a".into());
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_opt_scalar(
             &mut base,
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn merge_opt_scalar_none_base_takes_incoming() {
         let mut base: Option<String> = None;
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_opt_scalar(
             &mut base,
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     fn merge_opt_scalar_same_value_no_conflict() {
         let mut base: Option<String> = Some("a".into());
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_opt_scalar(
             &mut base,
@@ -450,7 +450,7 @@ mod tests {
     #[test]
     fn merge_opt_scalar_differing_takes_incoming_by_default() {
         let mut base: Option<String> = Some("a".into());
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_opt_scalar(
             &mut base,
@@ -469,7 +469,7 @@ mod tests {
     #[test]
     fn merge_opt_vec_set_union_dedupes_and_preserves_base_order() {
         let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_opt_vec_set_union(&mut base, Some(vec![2, 3]), &mut ctx, &mut path, ".x");
         assert_eq!(base.unwrap(), vec![1, 2, 3]);
@@ -485,7 +485,7 @@ mod tests {
         });
         let mut other = BTreeMap::new();
         other.insert("x-b".into(), serde_json::json!(2));
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_extensions(&mut base, Some(other), &mut ctx, &mut path, ".ext");
         let b = base.unwrap();
@@ -497,7 +497,7 @@ mod tests {
     #[test]
     fn merge_replace_list_keeps_populated_base_when_incoming_empty() {
         let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_replace_list_when_nonempty(&mut base, Some(vec![]), &mut ctx, &mut path, ".servers");
         assert_eq!(base, Some(vec![1, 2]));
@@ -507,7 +507,7 @@ mod tests {
     #[test]
     fn merge_replace_list_replaces_when_both_non_empty() {
         let mut base: Option<Vec<i32>> = Some(vec![1, 2]);
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         merge_replace_list_when_nonempty(
             &mut base,

--- a/crates/roas/src/common/reference.rs
+++ b/crates/roas/src/common/reference.rs
@@ -444,14 +444,14 @@ impl Ref {
 
 // ---- merge ----
 
-impl<D, T> crate::merge::MergeWithContext<T> for RefOr<D>
+impl<D> crate::merge::MergeWithContext for RefOr<D>
 where
-    D: crate::merge::MergeWithContext<T>,
+    D: crate::merge::MergeWithContext,
 {
     fn merge_with_context(
         &mut self,
         other: Self,
-        ctx: &mut crate::merge::MergeContext<T>,
+        ctx: &mut crate::merge::MergeContext,
         path: &mut String,
     ) {
         if ctx.errored {
@@ -481,11 +481,11 @@ where
     }
 }
 
-impl<T> crate::merge::MergeWithContext<T> for Ref {
+impl crate::merge::MergeWithContext for Ref {
     fn merge_with_context(
         &mut self,
         other: Self,
-        ctx: &mut crate::merge::MergeContext<T>,
+        ctx: &mut crate::merge::MergeContext,
         path: &mut String,
     ) {
         use crate::common::merge::merge_opt_scalar;
@@ -1165,13 +1165,8 @@ mod tests {
 
     use crate::merge::{ConflictKind, MergeContext, MergeOptions, MergeWithContext, Resolution};
 
-    impl MergeWithContext<()> for Foo {
-        fn merge_with_context(
-            &mut self,
-            other: Self,
-            ctx: &mut MergeContext<()>,
-            path: &mut String,
-        ) {
+    impl MergeWithContext for Foo {
+        fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
             if self.foo != other.foo
                 && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden)
             {
@@ -1180,8 +1175,8 @@ mod tests {
         }
     }
 
-    fn merge_ctx(opts: enumset::EnumSet<MergeOptions>) -> MergeContext<'static, ()> {
-        MergeContext::new(&(), opts)
+    fn merge_ctx(opts: enumset::EnumSet<MergeOptions>) -> MergeContext {
+        MergeContext::new(opts)
     }
 
     #[test]

--- a/crates/roas/src/merge.rs
+++ b/crates/roas/src/merge.rs
@@ -3,7 +3,7 @@
 //! Sits parallel to [`crate::validation`]:
 //!
 //! * The public [`Merge`] trait is what callers reach for — `base.merge(incoming, opts)`.
-//! * [`MergeWithContext<T>`] is the crate-internal recursive trait every
+//! * [`MergeWithContext`] is the crate-internal recursive trait every
 //!   component type implements. Implementors mutate `self` in place,
 //!   record [`MergeConflict`]s into [`MergeContext::conflicts`], and
 //!   recurse into children via each child's `merge_with_context`. The
@@ -256,22 +256,20 @@ pub trait Merge: Sized {
 /// most call sites don't have to. This turns the previous
 /// O(nodes × fields) `format!` allocations into O(conflicts) —
 /// only the conflict-recording path materialises an owned `String`.
-pub(crate) trait MergeWithContext<T> {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<T>, path: &mut String);
+pub(crate) trait MergeWithContext {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String);
 }
 
-/// Merge context — carries the spec being merged into, the options,
-/// and accumulated conflicts.
+/// Merge context — carries the per-call options and accumulated
+/// conflicts.
 ///
-/// The `spec` back-reference is currently unused by every concrete
-/// `MergeWithContext` impl (merge recurses through owned subtrees, so
-/// there's nothing to resolve against the parent spec). It's kept on
-/// the type for symmetry with `validation::Context<T>` and so v2 /
-/// v3.0 / v3.1 ports can introduce ref-following merge later without
-/// reshaping every signature. If it stays unused once all four
-/// versions land, drop `T` / `spec` in a follow-up.
-pub(crate) struct MergeContext<'a, T> {
-    pub spec: &'a T,
+/// No back-reference to the spec being merged into (unlike
+/// [`crate::validation::Context<T>`]): merge recurses through *owned*
+/// subtrees and never resolves a `$ref` against the spec, so there
+/// is nothing for the context to point at. If ref-following merge is
+/// ever wired up, reintroduce a `spec: &'a T` field and the trait /
+/// helper generics that go with it.
+pub(crate) struct MergeContext {
     pub options: EnumSet<MergeOptions>,
     pub conflicts: Vec<MergeConflict>,
     /// Set by [`Self::should_take_incoming`] when
@@ -282,7 +280,7 @@ pub(crate) struct MergeContext<'a, T> {
     pub errored: bool,
 }
 
-impl<T> MergeContext<'_, T> {
+impl MergeContext {
     pub fn is_option(&self, o: MergeOptions) -> bool {
         self.options.contains(o)
     }
@@ -317,12 +315,9 @@ impl<T> MergeContext<'_, T> {
             true
         }
     }
-}
 
-impl<T> MergeContext<'_, T> {
-    pub(crate) fn new<'a>(spec: &'a T, options: EnumSet<MergeOptions>) -> MergeContext<'a, T> {
+    pub(crate) fn new(options: EnumSet<MergeOptions>) -> MergeContext {
         MergeContext {
-            spec,
             options,
             conflicts: Vec::new(),
             errored: false,
@@ -330,8 +325,8 @@ impl<T> MergeContext<'_, T> {
     }
 }
 
-impl<'a, T> From<MergeContext<'a, T>> for Result<MergeReport, MergeError> {
-    fn from(ctx: MergeContext<'a, T>) -> Self {
+impl From<MergeContext> for Result<MergeReport, MergeError> {
+    fn from(ctx: MergeContext) -> Self {
         if ctx.errored {
             Err(MergeError {
                 conflicts: ctx.conflicts,
@@ -344,10 +339,9 @@ impl<'a, T> From<MergeContext<'a, T>> for Result<MergeReport, MergeError> {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for MergeContext<'_, T> {
+impl fmt::Debug for MergeContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MergeContext")
-            .field("spec", &self.spec)
             .field("options", &self.options)
             .field("conflicts", &self.conflicts)
             .field("errored", &self.errored)
@@ -361,7 +355,7 @@ mod tests {
 
     #[test]
     fn should_take_incoming_default_takes_incoming_and_records() {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let took = ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
         assert!(took);
         assert!(!ctx.errored);
@@ -371,7 +365,7 @@ mod tests {
 
     #[test]
     fn should_take_incoming_base_wins_keeps_base() {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::BaseWins.only());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::BaseWins.only());
         let took = ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
         assert!(!took);
         assert!(!ctx.errored);
@@ -380,8 +374,7 @@ mod tests {
 
     #[test]
     fn should_take_incoming_error_mode_marks_errored() {
-        let mut ctx: MergeContext<()> =
-            MergeContext::new(&(), MergeOptions::ErrorOnConflict.only());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::ErrorOnConflict.only());
         let took = ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
         assert!(!took);
         assert!(ctx.errored);
@@ -390,8 +383,7 @@ mod tests {
 
     #[test]
     fn context_into_result_returns_err_when_errored() {
-        let mut ctx: MergeContext<()> =
-            MergeContext::new(&(), MergeOptions::ErrorOnConflict.only());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::ErrorOnConflict.only());
         ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
         let res: Result<MergeReport, MergeError> = ctx.into();
         assert!(res.is_err());
@@ -399,7 +391,7 @@ mod tests {
 
     #[test]
     fn context_into_result_returns_ok_with_report() {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         ctx.should_take_incoming("#.x", ConflictKind::ScalarOverridden);
         let res: Result<MergeReport, MergeError> = ctx.into();
         let report = res.expect("ok");
@@ -499,7 +491,7 @@ mod tests {
 
     #[test]
     fn merge_context_debug_includes_state() {
-        let ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let s = format!("{ctx:?}");
         assert!(s.contains("MergeContext"));
         assert!(s.contains("conflicts: []"));
@@ -512,7 +504,7 @@ mod tests {
         // This test confirms the public surface no longer carries
         // either by reaching into Debug — defensive against accidental
         // re-introduction.
-        let ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let ctx: MergeContext = MergeContext::new(MergeOptions::new());
         assert!(!format!("{ctx:?}").contains("visited"));
     }
 }

--- a/crates/roas/src/v2.rs
+++ b/crates/roas/src/v2.rs
@@ -22,6 +22,7 @@ pub mod external_documentation;
 pub mod header;
 pub mod info;
 pub mod items;
+pub mod merge;
 pub mod operation;
 pub mod parameter;
 pub mod path_item;

--- a/crates/roas/src/v2/merge.rs
+++ b/crates/roas/src/v2/merge.rs
@@ -26,7 +26,7 @@ use enumset::EnumSet;
 use crate::common::merge::{
     PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
     merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
-    merge_required_scalar,
+    merge_required_scalar, record_kept_base_or_error,
 };
 use crate::common::reference::RefOr;
 use crate::merge::{
@@ -510,48 +510,53 @@ fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
     match p {
         RefOr::Ref(r) => (r.reference.clone(), "ref"),
         RefOr::Item(p) => match p {
-            Parameter::Body(b) => (b.name.clone(), "body"),
-            Parameter::Path(_) => (parameter_name(p), "path"),
-            Parameter::Query(_) => (parameter_name(p), "query"),
-            Parameter::Header(_) => (parameter_name(p), "header"),
-            Parameter::FormData(_) => (parameter_name(p), "formData"),
+            Parameter::Body(p) => (p.name.clone(), "body"),
+            Parameter::Path(p) => (in_path_name(p), "path"),
+            Parameter::Query(p) => (in_query_name(p), "query"),
+            Parameter::Header(p) => (in_header_name(p), "header"),
+            Parameter::FormData(p) => (in_form_data_name(p), "formData"),
         },
     }
 }
 
-fn parameter_name(p: &Parameter) -> String {
-    use crate::v2::parameter::{InFormData, InHeader, InPath, InQuery};
+fn in_path_name(p: &InPath) -> String {
     match p {
-        Parameter::Body(b) => b.name.clone(),
-        Parameter::Path(p) => match &**p {
-            InPath::String(p) => p.name.clone(),
-            InPath::Integer(p) => p.name.clone(),
-            InPath::Number(p) => p.name.clone(),
-            InPath::Boolean(p) => p.name.clone(),
-            InPath::Array(p) => p.name.clone(),
-        },
-        Parameter::Query(p) => match &**p {
-            InQuery::String(p) => p.name.clone(),
-            InQuery::Integer(p) => p.name.clone(),
-            InQuery::Number(p) => p.name.clone(),
-            InQuery::Boolean(p) => p.name.clone(),
-            InQuery::Array(p) => p.name.clone(),
-        },
-        Parameter::Header(p) => match &**p {
-            InHeader::String(p) => p.name.clone(),
-            InHeader::Integer(p) => p.name.clone(),
-            InHeader::Number(p) => p.name.clone(),
-            InHeader::Boolean(p) => p.name.clone(),
-            InHeader::Array(p) => p.name.clone(),
-        },
-        Parameter::FormData(p) => match &**p {
-            InFormData::String(p) => p.name.clone(),
-            InFormData::Integer(p) => p.name.clone(),
-            InFormData::Number(p) => p.name.clone(),
-            InFormData::Boolean(p) => p.name.clone(),
-            InFormData::Array(p) => p.name.clone(),
-            InFormData::File(p) => p.name.clone(),
-        },
+        InPath::String(p) => p.name.clone(),
+        InPath::Integer(p) => p.name.clone(),
+        InPath::Number(p) => p.name.clone(),
+        InPath::Boolean(p) => p.name.clone(),
+        InPath::Array(p) => p.name.clone(),
+    }
+}
+
+fn in_query_name(p: &InQuery) -> String {
+    match p {
+        InQuery::String(p) => p.name.clone(),
+        InQuery::Integer(p) => p.name.clone(),
+        InQuery::Number(p) => p.name.clone(),
+        InQuery::Boolean(p) => p.name.clone(),
+        InQuery::Array(p) => p.name.clone(),
+    }
+}
+
+fn in_header_name(p: &InHeader) -> String {
+    match p {
+        InHeader::String(p) => p.name.clone(),
+        InHeader::Integer(p) => p.name.clone(),
+        InHeader::Number(p) => p.name.clone(),
+        InHeader::Boolean(p) => p.name.clone(),
+        InHeader::Array(p) => p.name.clone(),
+    }
+}
+
+fn in_form_data_name(p: &InFormData) -> String {
+    match p {
+        InFormData::String(p) => p.name.clone(),
+        InFormData::Integer(p) => p.name.clone(),
+        InFormData::Number(p) => p.name.clone(),
+        InFormData::Boolean(p) => p.name.clone(),
+        InFormData::Array(p) => p.name.clone(),
+        InFormData::File(p) => p.name.clone(),
     }
 }
 
@@ -587,20 +592,28 @@ impl MergeWithContext for Parameter {
     }
 }
 
-fn leaf_replace_in_path(a: &mut InPath, b: InPath, ctx: &mut MergeContext, path: &mut str) {
-    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+// The four `leaf_replace_in_*` helpers + Header/Items merge with
+// `ScalarOverridden` (whole-value replacement, no deep recursion).
+// `ParameterVariantMismatch` is reserved for the outer
+// `Parameter::Path × Parameter::Query` (and similar) mismatch arm
+// in `Parameter::merge_with_context` — those reflect a real
+// cross-location collision, distinct from this same-variant leaf
+// replace.
+
+fn leaf_replace_in_path(a: &mut InPath, b: InPath, ctx: &mut MergeContext, path: &str) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
         *a = b;
     }
 }
 
-fn leaf_replace_in_query(a: &mut InQuery, b: InQuery, ctx: &mut MergeContext, path: &mut str) {
-    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+fn leaf_replace_in_query(a: &mut InQuery, b: InQuery, ctx: &mut MergeContext, path: &str) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
         *a = b;
     }
 }
 
-fn leaf_replace_in_header(a: &mut InHeader, b: InHeader, ctx: &mut MergeContext, path: &mut str) {
-    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+fn leaf_replace_in_header(a: &mut InHeader, b: InHeader, ctx: &mut MergeContext, path: &str) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
         *a = b;
     }
 }
@@ -609,9 +622,9 @@ fn leaf_replace_in_form_data(
     a: &mut InFormData,
     b: InFormData,
     ctx: &mut MergeContext,
-    path: &mut str,
+    path: &str,
 ) {
-    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
         *a = b;
     }
 }
@@ -623,8 +636,7 @@ impl MergeWithContext for Header {
         if ctx.errored {
             return;
         }
-        if *self != other && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch)
-        {
+        if *self != other && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
             *self = other;
         }
     }
@@ -735,18 +747,19 @@ impl MergeWithContext for Schema {
         if ctx.errored {
             return;
         }
+        // Match on owned `other` up front so the deep-merge arm can
+        // move the inner `ObjectSchema` without re-destructuring or
+        // an `unreachable!()` guard.
         if ctx.is_option(MergeOptions::DeepMergeObjectSchemas)
             && let Schema::Object(self_obj) = self
-            && let Schema::Object(other_obj) = &other
         {
-            // Take ownership of `other` by re-matching now that we
-            // know the variant.
-            let _ = other_obj;
-            let Schema::Object(other_obj) = other else {
-                unreachable!()
-            };
-            self_obj.merge_with_context(*other_obj, ctx, path);
-            return;
+            match other {
+                Schema::Object(other_obj) => {
+                    self_obj.merge_with_context(*other_obj, ctx, path);
+                    return;
+                }
+                non_object => return leaf_replace_schema(self, non_object, ctx, path),
+            }
         }
         leaf_replace_schema(self, other, ctx, path);
     }
@@ -853,8 +866,7 @@ impl MergeWithContext for SecurityScheme {
         if ctx.errored {
             return;
         }
-        if *self != other && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch)
-        {
+        if *self != other && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
             *self = other;
         }
     }
@@ -1135,25 +1147,6 @@ impl MergeWithContext for Server {
             ".extensions",
         );
     }
-}
-
-// ----- Spec.info/swagger kept-base-or-error helper -----
-
-fn record_kept_base_or_error(
-    ctx: &mut MergeContext,
-    path: &mut String,
-    segment: &str,
-    kind: ConflictKind,
-) {
-    let original_len = path.len();
-    path.push_str(segment);
-    if ctx.is_option(MergeOptions::ErrorOnConflict) {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
-        ctx.errored = true;
-    } else {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
-    }
-    path.truncate(original_len);
 }
 
 #[cfg(test)]

--- a/crates/roas/src/v2/merge.rs
+++ b/crates/roas/src/v2/merge.rs
@@ -1,0 +1,1372 @@
+//! v2 merge: per-component `MergeWithContext<Spec>` impls plus the
+//! public `impl Merge for Spec`.
+//!
+//! Mirrors the v3.0/v3.1/v3.2 ports. v2's data model is quite a bit
+//! flatter than v3:
+//!
+//! * Top-level has `host` / `basePath` / `schemes` / `consumes` /
+//!   `produces` instead of a `servers` array.
+//! * There is no `components` wrapper; `definitions`, `parameters`,
+//!   `responses`, and `securityDefinitions` sit at the spec root as
+//!   bare maps.
+//! * Parameter / Header / Items are multi-level typed enums; for
+//!   merge we recurse one variant level (so `InQuery::String` x
+//!   `InQuery::String` merges field-wise) and treat the leaf typed
+//!   structs (`StringParameter`, `IntegerParameter`, …) as opaque —
+//!   they replace on mismatch. The typed-leaf rule keeps the file
+//!   tractable and matches how v2 callers usually compose specs
+//!   (whole-parameter replacement is the dominant pattern when the
+//!   inner shape differs).
+//! * `Schema` is leaf-replace by default; `DeepMergeObjectSchemas`
+//!   recurses into `ObjectSchema` (`properties` / `required` /
+//!   `additional_properties`).
+
+use enumset::EnumSet;
+
+use crate::common::merge::{
+    PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
+    merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
+    merge_required_scalar,
+};
+use crate::common::reference::RefOr;
+use crate::merge::{
+    ConflictKind, Merge, MergeContext, MergeError, MergeOptions, MergeReport, MergeWithContext,
+};
+
+use crate::v2::external_documentation::ExternalDocumentation;
+use crate::v2::header::Header;
+use crate::v2::info::{Contact, Info, License, Logo};
+use crate::v2::items::Items;
+use crate::v2::operation::{CodeSample, Operation};
+use crate::v2::parameter::{InFormData, InHeader, InPath, InQuery, Parameter};
+use crate::v2::path_item::{PathItem, Paths};
+use crate::v2::response::{Response, Responses};
+use crate::v2::schema::{ObjectSchema, Schema};
+use crate::v2::security_scheme::SecurityScheme;
+use crate::v2::spec::{Server, Spec, TagGroup};
+use crate::v2::tag::Tag;
+
+#[allow(clippy::ptr_arg)]
+fn key_str(s: &String, out: &mut String) {
+    out.push_str(s);
+}
+
+fn fmt_param_key(k: &(String, &'static str), out: &mut String) {
+    out.push_str(&k.0);
+    out.push(':');
+    out.push_str(k.1);
+}
+
+// ----- Public entry point -----
+
+impl Merge for Spec {
+    fn merge(
+        &mut self,
+        other: Self,
+        options: EnumSet<MergeOptions>,
+    ) -> Result<MergeReport, MergeError> {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        let mut path = String::from("#");
+
+        if options.contains(MergeOptions::ErrorOnConflict) {
+            let mut working = self.clone();
+            <Spec as MergeWithContext<()>>::merge_with_context(
+                &mut working,
+                other,
+                &mut ctx,
+                &mut path,
+            );
+            if ctx.errored {
+                return Err(MergeError {
+                    conflicts: ctx.conflicts,
+                });
+            }
+            *self = working;
+            return Ok(MergeReport {
+                conflicts: ctx.conflicts,
+            });
+        }
+
+        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
+        ctx.into()
+    }
+}
+
+// ----- Spec -----
+
+impl MergeWithContext<()> for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        // swagger version + info: same documented contract as v3.x —
+        // base wins by default; MergeInfo opts into replacement.
+        if ctx.is_option(MergeOptions::MergeInfo) {
+            merge_required_scalar(
+                &mut self.swagger,
+                other.swagger,
+                ctx,
+                path,
+                ".swagger",
+                ConflictKind::RequiredScalarOverridden,
+            );
+            {
+                let mut guard = PathGuard::new(path, ".info");
+                self.info
+                    .merge_with_context(other.info, ctx, guard.path_mut());
+            }
+        } else {
+            if self.swagger != other.swagger {
+                record_kept_base_or_error(
+                    ctx,
+                    path,
+                    ".swagger",
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
+            if !ctx.errored && self.info != other.info {
+                record_kept_base_or_error(
+                    ctx,
+                    path,
+                    ".info",
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
+        }
+        merge_opt_scalar(
+            &mut self.host,
+            other.host,
+            ctx,
+            path,
+            ".host",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.base_path,
+            other.base_path,
+            ctx,
+            path,
+            ".basePath",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_replace_list_when_nonempty(&mut self.schemes, other.schemes, ctx, path, ".schemes");
+        merge_replace_list_when_nonempty(
+            &mut self.consumes,
+            other.consumes,
+            ctx,
+            path,
+            ".consumes",
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.produces,
+            other.produces,
+            ctx,
+            path,
+            ".produces",
+        );
+        // v2 `paths` is required (not Option) — merge in place.
+        {
+            let mut guard = PathGuard::new(path, ".paths");
+            self.paths
+                .merge_with_context(other.paths, ctx, guard.path_mut());
+        }
+        merge_opt_map(
+            &mut self.definitions,
+            other.definitions,
+            ctx,
+            path,
+            ".definitions",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            path,
+            ".responses",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.security_definitions,
+            other.security_definitions,
+            ctx,
+            path,
+            ".securityDefinitions",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            path,
+            ".security",
+        );
+        merge_opt_vec_by_key(
+            &mut self.tags,
+            other.tags,
+            ctx,
+            path,
+            ".tags",
+            |t: &Tag| t.name.clone(),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.x_servers,
+            other.x_servers,
+            ctx,
+            path,
+            ".x-servers",
+        );
+        merge_opt_vec_by_key(
+            &mut self.x_tag_groups,
+            other.x_tag_groups,
+            ctx,
+            path,
+            ".x-tagGroups",
+            |g: &TagGroup| g.name.clone(),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for TagGroup {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        let mut opt_base = Some(std::mem::take(&mut self.tags));
+        merge_opt_vec_set_union(&mut opt_base, Some(other.tags), ctx, path, ".tags");
+        self.tags = opt_base.unwrap_or_default();
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Paths / PathItem / Operation -----
+
+impl MergeWithContext<()> for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        for (k, incoming) in other.paths {
+            if let Some(base_v) = self.paths.get_mut(&k) {
+                let original_len = path.len();
+                path.push('[');
+                path.push_str(&k);
+                path.push(']');
+                base_v.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.paths.insert(k, incoming);
+            }
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.reference,
+            other.reference,
+            ctx,
+            path,
+            ".$ref",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.operations,
+            other.operations,
+            ctx,
+            path,
+            "",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            fmt_param_key,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_vec_set_union(&mut self.tags, other.tags, ctx, path, ".tags");
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.operation_id,
+            other.operation_id,
+            ctx,
+            path,
+            ".operationId",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.consumes,
+            other.consumes,
+            ctx,
+            path,
+            ".consumes",
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.produces,
+            other.produces,
+            ctx,
+            path,
+            ".produces",
+        );
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            fmt_param_key,
+        );
+        {
+            let mut guard = PathGuard::new(path, ".responses");
+            self.responses
+                .merge_with_context(other.responses, ctx, guard.path_mut());
+        }
+        merge_replace_list_when_nonempty(&mut self.schemes, other.schemes, ctx, path, ".schemes");
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            path,
+            ".security",
+        );
+        merge_opt_vec_by_key(
+            &mut self.x_code_samples,
+            other.x_code_samples,
+            ctx,
+            path,
+            ".x-codeSamples",
+            |c: &CodeSample| (c.lang.clone(), c.label.clone().unwrap_or_default()),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            |k, out| {
+                out.push_str(&k.0);
+                if !k.1.is_empty() {
+                    out.push(':');
+                    out.push_str(&k.1);
+                }
+            },
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for CodeSample {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.lang,
+            other.lang,
+            ctx,
+            path,
+            ".lang",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.label,
+            other.label,
+            ctx,
+            path,
+            ".label",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.source,
+            other.source,
+            ctx,
+            path,
+            ".source",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Parameter (typed enum — leaf-replace inner structs) -----
+
+fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
+    match p {
+        RefOr::Ref(r) => (r.reference.clone(), "ref"),
+        RefOr::Item(p) => match p {
+            Parameter::Body(b) => (b.name.clone(), "body"),
+            Parameter::Path(_) => (parameter_name(p), "path"),
+            Parameter::Query(_) => (parameter_name(p), "query"),
+            Parameter::Header(_) => (parameter_name(p), "header"),
+            Parameter::FormData(_) => (parameter_name(p), "formData"),
+        },
+    }
+}
+
+fn parameter_name(p: &Parameter) -> String {
+    use crate::v2::parameter::{InFormData, InHeader, InPath, InQuery};
+    match p {
+        Parameter::Body(b) => b.name.clone(),
+        Parameter::Path(p) => match &**p {
+            InPath::String(p) => p.name.clone(),
+            InPath::Integer(p) => p.name.clone(),
+            InPath::Number(p) => p.name.clone(),
+            InPath::Boolean(p) => p.name.clone(),
+            InPath::Array(p) => p.name.clone(),
+        },
+        Parameter::Query(p) => match &**p {
+            InQuery::String(p) => p.name.clone(),
+            InQuery::Integer(p) => p.name.clone(),
+            InQuery::Number(p) => p.name.clone(),
+            InQuery::Boolean(p) => p.name.clone(),
+            InQuery::Array(p) => p.name.clone(),
+        },
+        Parameter::Header(p) => match &**p {
+            InHeader::String(p) => p.name.clone(),
+            InHeader::Integer(p) => p.name.clone(),
+            InHeader::Number(p) => p.name.clone(),
+            InHeader::Boolean(p) => p.name.clone(),
+            InHeader::Array(p) => p.name.clone(),
+        },
+        Parameter::FormData(p) => match &**p {
+            InFormData::String(p) => p.name.clone(),
+            InFormData::Integer(p) => p.name.clone(),
+            InFormData::Number(p) => p.name.clone(),
+            InFormData::Boolean(p) => p.name.clone(),
+            InFormData::Array(p) => p.name.clone(),
+            InFormData::File(p) => p.name.clone(),
+        },
+    }
+}
+
+/// `Parameter` dispatch: when both sides are the same outer variant
+/// (Body/Path/Query/Header/FormData), recurse one level into the
+/// inner enum. Mismatched outer variants replace with conflict
+/// recording.
+impl MergeWithContext<()> for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (self, other) {
+            (Parameter::Body(a), Parameter::Body(b)) => {
+                if ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
+                    *a = b;
+                }
+            }
+            (Parameter::Path(a), Parameter::Path(b)) => leaf_replace_in_path(a, *b, ctx, path),
+            (Parameter::Query(a), Parameter::Query(b)) => leaf_replace_in_query(a, *b, ctx, path),
+            (Parameter::Header(a), Parameter::Header(b)) => {
+                leaf_replace_in_header(a, *b, ctx, path)
+            }
+            (Parameter::FormData(a), Parameter::FormData(b)) => {
+                leaf_replace_in_form_data(a, *b, ctx, path)
+            }
+            (slot, incoming) => {
+                if ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+fn leaf_replace_in_path(a: &mut InPath, b: InPath, ctx: &mut MergeContext<()>, path: &mut str) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+        *a = b;
+    }
+}
+
+fn leaf_replace_in_query(a: &mut InQuery, b: InQuery, ctx: &mut MergeContext<()>, path: &mut str) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+        *a = b;
+    }
+}
+
+fn leaf_replace_in_header(
+    a: &mut InHeader,
+    b: InHeader,
+    ctx: &mut MergeContext<()>,
+    path: &mut str,
+) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+        *a = b;
+    }
+}
+
+fn leaf_replace_in_form_data(
+    a: &mut InFormData,
+    b: InFormData,
+    ctx: &mut MergeContext<()>,
+    path: &mut str,
+) {
+    if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+        *a = b;
+    }
+}
+
+// ----- Header (typed enum — leaf replace) -----
+
+impl MergeWithContext<()> for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        if *self != other && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch)
+        {
+            *self = other;
+        }
+    }
+}
+
+// ----- Items (typed enum — leaf replace) -----
+
+impl MergeWithContext<()> for Items {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        if *self != other && ctx.should_take_incoming(path, ConflictKind::ScalarOverridden) {
+            *self = other;
+        }
+    }
+}
+
+// ----- Response / Responses -----
+
+impl MergeWithContext<()> for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (&mut self.default, other.default) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".default");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            path,
+            "",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        match (&mut self.schema, other.schema) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".schema");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            path,
+            ".headers",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        // examples here is Option<BTreeMap<String, serde_json::Value>>
+        // — treat like extensions (per-key incoming wins).
+        merge_extensions(&mut self.examples, other.examples, ctx, path, ".examples");
+        merge_opt_scalar(
+            &mut self.x_summary,
+            other.x_summary,
+            ctx,
+            path,
+            ".x-summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Schema (leaf by default; ObjectSchema deep merge) -----
+
+impl MergeWithContext<()> for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        if ctx.is_option(MergeOptions::DeepMergeObjectSchemas)
+            && let Schema::Object(self_obj) = self
+            && let Schema::Object(other_obj) = &other
+        {
+            // Take ownership of `other` by re-matching now that we
+            // know the variant.
+            let _ = other_obj;
+            let Schema::Object(other_obj) = other else {
+                unreachable!()
+            };
+            self_obj.merge_with_context(*other_obj, ctx, path);
+            return;
+        }
+        leaf_replace_schema(self, other, ctx, path);
+    }
+}
+
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+    if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
+        *base = other;
+    }
+}
+
+impl MergeWithContext<()> for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            path,
+            ".title",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.properties,
+            other.properties,
+            ctx,
+            path,
+            ".properties",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_vec_set_union(&mut self.required, other.required, ctx, path, ".required");
+        merge_opt_scalar(
+            &mut self.max_properties,
+            other.max_properties,
+            ctx,
+            path,
+            ".maxProperties",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.min_properties,
+            other.min_properties,
+            ctx,
+            path,
+            ".minProperties",
+            ConflictKind::ScalarOverridden,
+        );
+        match (&mut self.additional_properties, other.additional_properties) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".additionalProperties");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_opt_scalar(
+            &mut self.read_only,
+            other.read_only,
+            ctx,
+            path,
+            ".readOnly",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- SecurityScheme (leaf replace) -----
+
+impl MergeWithContext<()> for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        if *self != other && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch)
+        {
+            *self = other;
+        }
+    }
+}
+
+// ----- Tag / Info / Contact / License / Logo / ExternalDocumentation / Server -----
+
+impl MergeWithContext<()> for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.x_display_name,
+            other.x_display_name,
+            ctx,
+            path,
+            ".x-displayName",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            path,
+            ".title",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.terms_of_service,
+            other.terms_of_service,
+            ctx,
+            path,
+            ".termsOfService",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(&mut self.contact, other.contact, ctx, path, ".contact");
+        merge_opt_struct(&mut self.license, other.license, ctx, path, ".license");
+        merge_required_scalar(
+            &mut self.version,
+            other.version,
+            ctx,
+            path,
+            ".version",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_struct(&mut self.x_logo, other.x_logo, ctx, path, ".x-logo");
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.email,
+            other.email,
+            ctx,
+            path,
+            ".email",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Logo {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.background_color,
+            other.background_color,
+            ctx,
+            path,
+            ".backgroundColor",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.alt_text,
+            other.alt_text,
+            ctx,
+            path,
+            ".altText",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.href,
+            other.href,
+            ctx,
+            path,
+            ".href",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Spec.info/swagger kept-base-or-error helper -----
+
+fn record_kept_base_or_error(
+    ctx: &mut MergeContext<()>,
+    path: &mut String,
+    segment: &str,
+    kind: ConflictKind,
+) {
+    let original_len = path.len();
+    path.push_str(segment);
+    if ctx.is_option(MergeOptions::ErrorOnConflict) {
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
+        ctx.errored = true;
+    } else {
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
+    }
+    path.truncate(original_len);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merge::{MergeOptions, Resolution};
+    use std::collections::BTreeMap;
+
+    fn root_path() -> String {
+        "#".to_owned()
+    }
+
+    fn report<S: MergeWithContext<()>>(
+        base: &mut S,
+        incoming: S,
+        opts: EnumSet<MergeOptions>,
+    ) -> Vec<crate::merge::MergeConflict> {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut path = root_path();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        ctx.conflicts
+    }
+
+    fn spec_with_info_desc(desc: &str) -> Spec {
+        Spec {
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                description: Some(desc.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    // ---- Three modes via Info.description ----
+
+    #[test]
+    fn spec_default_incoming_wins() {
+        let mut base = spec_with_info_desc("base");
+        base.merge(
+            spec_with_info_desc("incoming"),
+            MergeOptions::MergeInfo.only(),
+        )
+        .unwrap();
+        assert_eq!(base.info.description.as_deref(), Some("incoming"));
+    }
+
+    #[test]
+    fn spec_error_on_conflict_rolls_back() {
+        let mut base = spec_with_info_desc("base");
+        let result = base.merge(
+            spec_with_info_desc("incoming"),
+            MergeOptions::ErrorOnConflict | MergeOptions::MergeInfo,
+        );
+        assert!(result.is_err());
+        assert_eq!(base.info.description.as_deref(), Some("base"));
+    }
+
+    #[test]
+    fn spec_base_wins() {
+        let mut base = spec_with_info_desc("base");
+        let report = base
+            .merge(
+                spec_with_info_desc("incoming"),
+                MergeOptions::BaseWins | MergeOptions::MergeInfo,
+            )
+            .unwrap();
+        assert_eq!(base.info.description.as_deref(), Some("base"));
+        assert!(
+            report
+                .conflicts
+                .iter()
+                .any(|c| c.resolution == Resolution::Base)
+        );
+    }
+
+    // ---- Path methods coexist + per-key response merge ----
+
+    #[test]
+    fn paths_get_post_coexist() {
+        let mk_pi = |method: &str| PathItem {
+            operations: Some(BTreeMap::from([(method.to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let mut base = Spec {
+            paths: Paths {
+                paths: BTreeMap::from([("/pets".to_owned(), mk_pi("get"))]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                paths: Paths {
+                    paths: BTreeMap::from([("/pets".to_owned(), mk_pi("post"))]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        )
+        .unwrap();
+        let pi = &base.paths.paths["/pets"];
+        let ops = pi.operations.as_ref().unwrap();
+        assert!(ops.contains_key("get") && ops.contains_key("post"));
+    }
+
+    // ---- v2-specific: host / basePath / schemes / consumes / produces ----
+
+    #[test]
+    fn spec_host_base_path_and_schemes_merge() {
+        use crate::v2::spec::Scheme;
+        let mut base = Spec {
+            host: Some("base.example".into()),
+            base_path: Some("/api".into()),
+            schemes: Some(vec![Scheme::HTTPS]),
+            consumes: Some(vec!["application/json".into()]),
+            produces: Some(vec!["application/json".into()]),
+            ..Default::default()
+        };
+        let _ = base.merge(
+            Spec {
+                host: Some("inc.example".into()),
+                base_path: Some("/v2".into()),
+                schemes: Some(vec![Scheme::HTTP, Scheme::HTTPS]),
+                consumes: Some(vec!["text/plain".into()]),
+                produces: Some(vec!["application/xml".into()]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.host.as_deref(), Some("inc.example"));
+        assert_eq!(base.base_path.as_deref(), Some("/v2"));
+        assert_eq!(base.schemes.unwrap().len(), 2);
+        assert_eq!(base.consumes.unwrap(), vec!["text/plain".to_owned()]);
+    }
+
+    // ---- definitions / parameters / responses / securityDefinitions per-key ----
+
+    #[test]
+    fn spec_top_level_bags_merge_per_key() {
+        use crate::v2::schema::Schema as V2Schema;
+        let mut base = Spec {
+            definitions: Some(BTreeMap::from([("Pet".into(), V2Schema::default())])),
+            ..Default::default()
+        };
+        let _ = base.merge(
+            Spec {
+                definitions: Some(BTreeMap::from([
+                    ("Pet".into(), V2Schema::default()),
+                    ("User".into(), V2Schema::default()),
+                ])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let defs = base.definitions.unwrap();
+        assert!(defs.contains_key("Pet"));
+        assert!(defs.contains_key("User"));
+    }
+
+    // ---- Tag dedup + x_display_name ----
+
+    #[test]
+    fn tag_x_display_name_merges() {
+        let mut base = Tag {
+            name: "pets".into(),
+            x_display_name: Some("Pet API".into()),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Tag {
+                name: "pets".into(),
+                x_display_name: Some("Pets!".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.x_display_name.as_deref(), Some("Pets!"));
+    }
+
+    // ---- x_tag_groups dedup ----
+
+    #[test]
+    fn spec_x_tag_groups_dedup_and_union() {
+        let mut base = Spec {
+            x_tag_groups: Some(vec![TagGroup {
+                name: "auth".into(),
+                tags: vec!["login".into()],
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let _ = base.merge(
+            Spec {
+                x_tag_groups: Some(vec![TagGroup {
+                    name: "auth".into(),
+                    tags: vec!["logout".into()],
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let groups = base.x_tag_groups.unwrap();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].tags.len(), 2);
+    }
+}

--- a/crates/roas/src/v2/merge.rs
+++ b/crates/roas/src/v2/merge.rs
@@ -65,12 +65,12 @@ impl Merge for Spec {
         other: Self,
         options: EnumSet<MergeOptions>,
     ) -> Result<MergeReport, MergeError> {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        let mut ctx: MergeContext = MergeContext::new(options);
         let mut path = String::from("#");
 
         if options.contains(MergeOptions::ErrorOnConflict) {
             let mut working = self.clone();
-            <Spec as MergeWithContext<()>>::merge_with_context(
+            <Spec as MergeWithContext>::merge_with_context(
                 &mut working,
                 other,
                 &mut ctx,
@@ -87,15 +87,15 @@ impl Merge for Spec {
             });
         }
 
-        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
+        <Spec as MergeWithContext>::merge_with_context(self, other, &mut ctx, &mut path);
         ctx.into()
     }
 }
 
 // ----- Spec -----
 
-impl MergeWithContext<()> for Spec {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -257,8 +257,8 @@ impl MergeWithContext<()> for Spec {
     }
 }
 
-impl MergeWithContext<()> for TagGroup {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for TagGroup {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -285,8 +285,8 @@ impl MergeWithContext<()> for TagGroup {
 
 // ----- Paths / PathItem / Operation -----
 
-impl MergeWithContext<()> for Paths {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -315,8 +315,8 @@ impl MergeWithContext<()> for Paths {
     }
 }
 
-impl MergeWithContext<()> for PathItem {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -357,8 +357,8 @@ impl MergeWithContext<()> for PathItem {
     }
 }
 
-impl MergeWithContext<()> for Operation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -465,8 +465,8 @@ impl MergeWithContext<()> for Operation {
     }
 }
 
-impl MergeWithContext<()> for CodeSample {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for CodeSample {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -559,8 +559,8 @@ fn parameter_name(p: &Parameter) -> String {
 /// (Body/Path/Query/Header/FormData), recurse one level into the
 /// inner enum. Mismatched outer variants replace with conflict
 /// recording.
-impl MergeWithContext<()> for Parameter {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -587,24 +587,19 @@ impl MergeWithContext<()> for Parameter {
     }
 }
 
-fn leaf_replace_in_path(a: &mut InPath, b: InPath, ctx: &mut MergeContext<()>, path: &mut str) {
+fn leaf_replace_in_path(a: &mut InPath, b: InPath, ctx: &mut MergeContext, path: &mut str) {
     if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
         *a = b;
     }
 }
 
-fn leaf_replace_in_query(a: &mut InQuery, b: InQuery, ctx: &mut MergeContext<()>, path: &mut str) {
+fn leaf_replace_in_query(a: &mut InQuery, b: InQuery, ctx: &mut MergeContext, path: &mut str) {
     if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
         *a = b;
     }
 }
 
-fn leaf_replace_in_header(
-    a: &mut InHeader,
-    b: InHeader,
-    ctx: &mut MergeContext<()>,
-    path: &mut str,
-) {
+fn leaf_replace_in_header(a: &mut InHeader, b: InHeader, ctx: &mut MergeContext, path: &mut str) {
     if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
         *a = b;
     }
@@ -613,7 +608,7 @@ fn leaf_replace_in_header(
 fn leaf_replace_in_form_data(
     a: &mut InFormData,
     b: InFormData,
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut str,
 ) {
     if *a != b && ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
@@ -623,8 +618,8 @@ fn leaf_replace_in_form_data(
 
 // ----- Header (typed enum — leaf replace) -----
 
-impl MergeWithContext<()> for Header {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -637,8 +632,8 @@ impl MergeWithContext<()> for Header {
 
 // ----- Items (typed enum — leaf replace) -----
 
-impl MergeWithContext<()> for Items {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Items {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -650,8 +645,8 @@ impl MergeWithContext<()> for Items {
 
 // ----- Response / Responses -----
 
-impl MergeWithContext<()> for Responses {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -682,8 +677,8 @@ impl MergeWithContext<()> for Responses {
     }
 }
 
-impl MergeWithContext<()> for Response {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -735,8 +730,8 @@ impl MergeWithContext<()> for Response {
 
 // ----- Schema (leaf by default; ObjectSchema deep merge) -----
 
-impl MergeWithContext<()> for Schema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -757,14 +752,14 @@ impl MergeWithContext<()> for Schema {
     }
 }
 
-fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext, path: &str) {
     if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
         *base = other;
     }
 }
 
-impl MergeWithContext<()> for ObjectSchema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -853,8 +848,8 @@ impl MergeWithContext<()> for ObjectSchema {
 
 // ----- SecurityScheme (leaf replace) -----
 
-impl MergeWithContext<()> for SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -867,8 +862,8 @@ impl MergeWithContext<()> for SecurityScheme {
 
 // ----- Tag / Info / Contact / License / Logo / ExternalDocumentation / Server -----
 
-impl MergeWithContext<()> for Tag {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -913,8 +908,8 @@ impl MergeWithContext<()> for Tag {
     }
 }
 
-impl MergeWithContext<()> for Info {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -963,8 +958,8 @@ impl MergeWithContext<()> for Info {
     }
 }
 
-impl MergeWithContext<()> for Contact {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1002,8 +997,8 @@ impl MergeWithContext<()> for Contact {
     }
 }
 
-impl MergeWithContext<()> for License {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1033,8 +1028,8 @@ impl MergeWithContext<()> for License {
     }
 }
 
-impl MergeWithContext<()> for Logo {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Logo {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1080,8 +1075,8 @@ impl MergeWithContext<()> for Logo {
     }
 }
 
-impl MergeWithContext<()> for ExternalDocumentation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1111,8 +1106,8 @@ impl MergeWithContext<()> for ExternalDocumentation {
     }
 }
 
-impl MergeWithContext<()> for Server {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1145,7 +1140,7 @@ impl MergeWithContext<()> for Server {
 // ----- Spec.info/swagger kept-base-or-error helper -----
 
 fn record_kept_base_or_error(
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
     kind: ConflictKind,
@@ -1171,12 +1166,12 @@ mod tests {
         "#".to_owned()
     }
 
-    fn report<S: MergeWithContext<()>>(
+    fn report<S: MergeWithContext>(
         base: &mut S,
         incoming: S,
         opts: EnumSet<MergeOptions>,
     ) -> Vec<crate::merge::MergeConflict> {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut ctx: MergeContext = MergeContext::new(opts);
         let mut path = root_path();
         base.merge_with_context(incoming, &mut ctx, &mut path);
         ctx.conflicts

--- a/crates/roas/src/v3_0.rs
+++ b/crates/roas/src/v3_0.rs
@@ -23,6 +23,7 @@ pub mod header;
 pub mod info;
 pub mod link;
 pub mod media_type;
+pub mod merge;
 pub mod operation;
 pub mod parameter;
 pub mod path_item;

--- a/crates/roas/src/v3_0/merge.rs
+++ b/crates/roas/src/v3_0/merge.rs
@@ -21,7 +21,7 @@ use enumset::EnumSet;
 use crate::common::merge::{
     PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
     merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
-    merge_required_scalar,
+    merge_required_scalar, record_kept_base_or_error,
 };
 use crate::common::reference::RefOr;
 use crate::merge::{
@@ -48,7 +48,7 @@ use crate::v3_0::security_scheme::{
     HttpSecurityScheme, ImplicitOAuth2Flow, OAuth2Flows, OAuth2SecurityScheme,
     OpenIdConnectSecurityScheme, PasswordOAuth2Flow, SecurityScheme,
 };
-use crate::v3_0::server::{Server, ServerVariable};
+use crate::v3_0::server::Server;
 use crate::v3_0::spec::{Spec, TagGroup};
 use crate::v3_0::tag::Tag;
 use crate::v3_0::xml::XML;
@@ -1844,44 +1844,8 @@ impl MergeWithContext for Server {
     }
 }
 
-impl MergeWithContext for ServerVariable {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
-        if ctx.errored {
-            return;
-        }
-        merge_opt_scalar(
-            &mut self.enum_values,
-            other.enum_values,
-            ctx,
-            path,
-            ".enum",
-            ConflictKind::ScalarOverridden,
-        );
-        merge_required_scalar(
-            &mut self.default,
-            other.default,
-            ctx,
-            path,
-            ".default",
-            ConflictKind::RequiredScalarOverridden,
-        );
-        merge_opt_scalar(
-            &mut self.description,
-            other.description,
-            ctx,
-            path,
-            ".description",
-            ConflictKind::ScalarOverridden,
-        );
-        merge_extensions(
-            &mut self.extensions,
-            other.extensions,
-            ctx,
-            path,
-            ".extensions",
-        );
-    }
-}
+// `ServerVariable` merge impl lives in `v3_0/server.rs` alongside
+// the type, matching the v3.1/v3.2 convention.
 
 // ----- SecurityScheme -----
 
@@ -2206,30 +2170,6 @@ fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext,
     if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
         *base = other;
     }
-}
-
-/// Record a collision where the documented contract says "base is
-/// kept" — used for `Spec.info` / `Spec.openapi` when `MergeInfo` is
-/// off. Records `Resolution::Base` in the default / `BaseWins` modes
-/// (reflecting what actually happened), and trips
-/// `ErrorOnConflict` when set. Pushes `segment` onto `path` only
-/// when actually recording, keeping the eager-allocation
-/// regression off the non-conflict path.
-fn record_kept_base_or_error(
-    ctx: &mut MergeContext,
-    path: &mut String,
-    segment: &str,
-    kind: ConflictKind,
-) {
-    let original_len = path.len();
-    path.push_str(segment);
-    if ctx.is_option(MergeOptions::ErrorOnConflict) {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
-        ctx.errored = true;
-    } else {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
-    }
-    path.truncate(original_len);
 }
 
 impl MergeWithContext for ObjectSchema {

--- a/crates/roas/src/v3_0/merge.rs
+++ b/crates/roas/src/v3_0/merge.rs
@@ -84,7 +84,7 @@ impl Merge for Spec {
         // dereferencing happens during merge). Carrying the borrow as
         // a unit `&()` keeps the type generic without forcing the
         // caller to clone the base before merging into it.
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        let mut ctx: MergeContext = MergeContext::new(options);
         // Single owned `String` for the whole merge — every child
         // pushes/truncates segments onto it via the helper guards.
         let mut path = String::from("#");
@@ -98,7 +98,7 @@ impl Merge for Spec {
             // `ErrorOnConflict` to get. The clone cost is paid only
             // when the option is opted in.
             let mut working = self.clone();
-            <Spec as MergeWithContext<()>>::merge_with_context(
+            <Spec as MergeWithContext>::merge_with_context(
                 &mut working,
                 other,
                 &mut ctx,
@@ -118,15 +118,15 @@ impl Merge for Spec {
         // Non-strict modes mutate `self` in place — the report still
         // captures every resolution, so callers wanting "see what
         // changed" don't need the clone-and-replace overhead.
-        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
+        <Spec as MergeWithContext>::merge_with_context(self, other, &mut ctx, &mut path);
         ctx.into()
     }
 }
 
 // ----- Top-level Spec -----
 
-impl MergeWithContext<()> for Spec {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -230,8 +230,8 @@ impl MergeWithContext<()> for Spec {
     }
 }
 
-impl MergeWithContext<()> for TagGroup {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for TagGroup {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -259,8 +259,8 @@ impl MergeWithContext<()> for TagGroup {
 
 // ----- Containers -----
 
-impl MergeWithContext<()> for Components {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Components {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -355,8 +355,8 @@ impl MergeWithContext<()> for Components {
     }
 }
 
-impl MergeWithContext<()> for Paths {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -385,8 +385,8 @@ impl MergeWithContext<()> for Paths {
     }
 }
 
-impl MergeWithContext<()> for Callback {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Callback {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -415,8 +415,8 @@ impl MergeWithContext<()> for Callback {
     }
 }
 
-impl MergeWithContext<()> for PathItem {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -476,8 +476,8 @@ impl MergeWithContext<()> for PathItem {
     }
 }
 
-impl MergeWithContext<()> for Responses {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -510,8 +510,8 @@ impl MergeWithContext<()> for Responses {
     }
 }
 
-impl MergeWithContext<()> for Operation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -622,8 +622,8 @@ impl MergeWithContext<()> for Operation {
     }
 }
 
-impl MergeWithContext<()> for CodeSample {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for CodeSample {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -680,8 +680,8 @@ fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
     }
 }
 
-impl MergeWithContext<()> for Parameter {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -699,8 +699,8 @@ impl MergeWithContext<()> for Parameter {
     }
 }
 
-impl MergeWithContext<()> for InPath {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InPath {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -781,8 +781,8 @@ impl MergeWithContext<()> for InPath {
     }
 }
 
-impl MergeWithContext<()> for InQuery {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InQuery {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -879,8 +879,8 @@ impl MergeWithContext<()> for InQuery {
     }
 }
 
-impl MergeWithContext<()> for InHeader {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InHeader {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -961,8 +961,8 @@ impl MergeWithContext<()> for InHeader {
     }
 }
 
-impl MergeWithContext<()> for InCookie {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InCookie {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1050,7 +1050,7 @@ impl MergeWithContext<()> for InCookie {
 fn merge_schema_field(
     base: &mut Option<RefOr<Schema>>,
     other: Option<RefOr<Schema>>,
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut String,
     field_name: &str,
 ) {
@@ -1072,8 +1072,8 @@ fn merge_schema_field(
 
 // ----- MediaType / Encoding / Header / Response / RequestBody / Example / Link -----
 
-impl MergeWithContext<()> for MediaType {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for MediaType {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1114,8 +1114,8 @@ impl MergeWithContext<()> for MediaType {
     }
 }
 
-impl MergeWithContext<()> for Encoding {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Encoding {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1170,8 +1170,8 @@ impl MergeWithContext<()> for Encoding {
     }
 }
 
-impl MergeWithContext<()> for Header {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1252,8 +1252,8 @@ impl MergeWithContext<()> for Header {
     }
 }
 
-impl MergeWithContext<()> for Response {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1303,8 +1303,8 @@ impl MergeWithContext<()> for Response {
     }
 }
 
-impl MergeWithContext<()> for RequestBody {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for RequestBody {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1349,8 +1349,8 @@ impl MergeWithContext<()> for RequestBody {
     }
 }
 
-impl MergeWithContext<()> for Example {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Example {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1396,8 +1396,8 @@ impl MergeWithContext<()> for Example {
     }
 }
 
-impl MergeWithContext<()> for Link {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Link {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1456,8 +1456,8 @@ impl MergeWithContext<()> for Link {
 // ----- Leaves: Tag, Info, Contact, License, ExternalDocumentation,
 //                Discriminator, XML, Server, ServerVariable -----
 
-impl MergeWithContext<()> for Tag {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1502,8 +1502,8 @@ impl MergeWithContext<()> for Tag {
     }
 }
 
-impl MergeWithContext<()> for Info {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1552,8 +1552,8 @@ impl MergeWithContext<()> for Info {
     }
 }
 
-impl MergeWithContext<()> for Logo {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Logo {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1599,8 +1599,8 @@ impl MergeWithContext<()> for Logo {
     }
 }
 
-impl MergeWithContext<()> for Contact {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1638,8 +1638,8 @@ impl MergeWithContext<()> for Contact {
     }
 }
 
-impl MergeWithContext<()> for License {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1669,8 +1669,8 @@ impl MergeWithContext<()> for License {
     }
 }
 
-impl MergeWithContext<()> for ExternalDocumentation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1700,8 +1700,8 @@ impl MergeWithContext<()> for ExternalDocumentation {
     }
 }
 
-impl MergeWithContext<()> for Discriminator {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Discriminator {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1748,8 +1748,8 @@ impl MergeWithContext<()> for Discriminator {
     }
 }
 
-impl MergeWithContext<()> for XML {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for XML {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1803,8 +1803,8 @@ impl MergeWithContext<()> for XML {
     }
 }
 
-impl MergeWithContext<()> for Server {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1844,8 +1844,8 @@ impl MergeWithContext<()> for Server {
     }
 }
 
-impl MergeWithContext<()> for ServerVariable {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ServerVariable {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1885,8 +1885,8 @@ impl MergeWithContext<()> for ServerVariable {
 
 // ----- SecurityScheme -----
 
-impl MergeWithContext<()> for SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1912,8 +1912,8 @@ impl MergeWithContext<()> for SecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for ApiKeySecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ApiKeySecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1951,8 +1951,8 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for HttpSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for HttpSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1990,8 +1990,8 @@ impl MergeWithContext<()> for HttpSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OpenIdConnectSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2021,8 +2021,8 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OAuth2SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OAuth2SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2049,8 +2049,8 @@ impl MergeWithContext<()> for OAuth2SecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OAuth2Flows {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OAuth2Flows {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2085,11 +2085,11 @@ impl MergeWithContext<()> for OAuth2Flows {
 /// from sprawling.
 macro_rules! oauth_flow_merge {
     ($t:ty, $($url_field:ident => $url_path:literal),* $(,)?) => {
-        impl MergeWithContext<()> for $t {
+        impl MergeWithContext for $t {
             fn merge_with_context(
                 &mut self,
                 other: Self,
-                ctx: &mut MergeContext<()>,
+                ctx: &mut MergeContext,
                 path: &mut String,
             ) {
                 if ctx.errored { return; }
@@ -2160,8 +2160,8 @@ oauth_flow_merge!(
 
 // ----- Schema -----
 
-impl MergeWithContext<()> for Schema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2202,7 +2202,7 @@ impl MergeWithContext<()> for Schema {
     }
 }
 
-fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext, path: &str) {
     if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
         *base = other;
     }
@@ -2216,7 +2216,7 @@ fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<
 /// when actually recording, keeping the eager-allocation
 /// regression off the non-conflict path.
 fn record_kept_base_or_error(
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
     kind: ConflictKind,
@@ -2232,8 +2232,8 @@ fn record_kept_base_or_error(
     path.truncate(original_len);
 }
 
-impl MergeWithContext<()> for ObjectSchema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2346,7 +2346,7 @@ impl MergeWithContext<()> for ObjectSchema {
 }
 
 // Schema sub-types (StringSchema, IntegerSchema, …, SingleSchema)
-// don't need their own `MergeWithContext<()>` impls — `Schema`'s impl
+// don't need their own `MergeWithContext` impls — `Schema`'s impl
 // handles the entire enum at the top level via `leaf_replace_schema`
 // for any pairing other than `Single(Object(_))` × `Single(Object(_))`.
 // Nothing in the codebase holds a `RefOr<StringSchema>` or
@@ -2363,12 +2363,12 @@ mod tests {
         "#".to_owned()
     }
 
-    fn report<S: MergeWithContext<()>>(
+    fn report<S: MergeWithContext>(
         base: &mut S,
         incoming: S,
         opts: EnumSet<MergeOptions>,
     ) -> Vec<crate::merge::MergeConflict> {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut ctx: MergeContext = MergeContext::new(opts);
         let mut path = root_path();
         base.merge_with_context(incoming, &mut ctx, &mut path);
         ctx.conflicts
@@ -2711,7 +2711,7 @@ mod tests {
             description: Some("base".into()),
             ..Default::default()
         });
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         base.merge_with_context(
             RefOr::new_item(Tag {

--- a/crates/roas/src/v3_0/merge.rs
+++ b/crates/roas/src/v3_0/merge.rs
@@ -1,0 +1,2880 @@
+//! v3.0 merge: per-component `MergeWithContext<Spec>` impls plus the
+//! public `impl Merge for Spec`.
+//!
+//! Sits alongside `v3_0/validation.rs`. Every component type in v3.0
+//! gets a `merge_with_context` whose shape mirrors its
+//! `validate_with_context` neighbor: walk the fields, recurse into
+//! nested objects, dispatch through `RefOr` / `BoolOr`. Helpers from
+//! [`crate::common::merge`] do the structural plumbing
+//! (`merge_opt_scalar`, `merge_opt_map`, `merge_vec_by_key`,
+//! `merge_extensions`, ...) so each impl reads as a flat list of
+//! "field → rule" lines.
+//!
+//! Conflict policy modes (incoming-wins / base-wins / error-on-conflict),
+//! the `DeepMergeObjectSchemas` opt-in, and the `MergeInfo`
+//! /`ReplaceListsWhenEmpty` toggles all flow through
+//! [`crate::merge::MergeContext`] — the impls themselves stay
+//! policy-free.
+
+use enumset::EnumSet;
+
+use crate::common::merge::{
+    PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
+    merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
+    merge_required_scalar,
+};
+use crate::common::reference::RefOr;
+use crate::merge::{
+    ConflictKind, Merge, MergeContext, MergeError, MergeOptions, MergeReport, MergeWithContext,
+};
+
+use crate::v3_0::callback::Callback;
+use crate::v3_0::components::Components;
+use crate::v3_0::discriminator::Discriminator;
+use crate::v3_0::example::Example;
+use crate::v3_0::external_documentation::ExternalDocumentation;
+use crate::v3_0::header::Header;
+use crate::v3_0::info::{Contact, Info, License, Logo};
+use crate::v3_0::link::Link;
+use crate::v3_0::media_type::{Encoding, MediaType};
+use crate::v3_0::operation::{CodeSample, Operation};
+use crate::v3_0::parameter::{InCookie, InHeader, InPath, InQuery, Parameter};
+use crate::v3_0::path_item::{PathItem, Paths};
+use crate::v3_0::request_body::RequestBody;
+use crate::v3_0::response::{Response, Responses};
+use crate::v3_0::schema::{ObjectSchema, Schema, SingleSchema};
+use crate::v3_0::security_scheme::{
+    ApiKeySecurityScheme, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow,
+    HttpSecurityScheme, ImplicitOAuth2Flow, OAuth2Flows, OAuth2SecurityScheme,
+    OpenIdConnectSecurityScheme, PasswordOAuth2Flow, SecurityScheme,
+};
+use crate::v3_0::server::{Server, ServerVariable};
+use crate::v3_0::spec::{Spec, TagGroup};
+use crate::v3_0::tag::Tag;
+use crate::v3_0::xml::XML;
+
+// String-keyed maps appear everywhere; this is the single fmt_key
+// the helpers want. Writes the key directly into the path buffer
+// instead of allocating a fresh String — the helpers' `fmt_key`
+// signature is `Fn(&K, &mut String)` for exactly this reason.
+#[allow(clippy::ptr_arg)]
+fn key_str(s: &String, out: &mut String) {
+    out.push_str(s);
+}
+
+/// `fmt_key` for the `(name, location)` keys used by
+/// `Operation.parameters` / `PathItem.parameters`. Writes
+/// `<name>:<location>` into the path buffer.
+fn fmt_param_key(k: &(String, &'static str), out: &mut String) {
+    out.push_str(&k.0);
+    out.push(':');
+    out.push_str(k.1);
+}
+
+// ----- Public entry point -----
+
+impl Merge for Spec {
+    fn merge(
+        &mut self,
+        other: Self,
+        options: EnumSet<MergeOptions>,
+    ) -> Result<MergeReport, MergeError> {
+        // SAFETY of the `&()` trick: `MergeContext.spec` is a `&T`
+        // back-reference the impls don't currently use (no ref
+        // dereferencing happens during merge). Carrying the borrow as
+        // a unit `&()` keeps the type generic without forcing the
+        // caller to clone the base before merging into it.
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        // Single owned `String` for the whole merge — every child
+        // pushes/truncates segments onto it via the helper guards.
+        let mut path = String::from("#");
+
+        if options.contains(MergeOptions::ErrorOnConflict) {
+            // Strict-mode rollback: clone `self` into a working copy
+            // and only commit it back on success. Without this, an
+            // `Err` would leave `self` partially merged (additive
+            // steps run before the first collision flips `ctx.errored`),
+            // which contradicts the contract callers reach for
+            // `ErrorOnConflict` to get. The clone cost is paid only
+            // when the option is opted in.
+            let mut working = self.clone();
+            <Spec as MergeWithContext<()>>::merge_with_context(
+                &mut working,
+                other,
+                &mut ctx,
+                &mut path,
+            );
+            if ctx.errored {
+                return Err(MergeError {
+                    conflicts: ctx.conflicts,
+                });
+            }
+            *self = working;
+            return Ok(MergeReport {
+                conflicts: ctx.conflicts,
+            });
+        }
+
+        // Non-strict modes mutate `self` in place — the report still
+        // captures every resolution, so callers wanting "see what
+        // changed" don't need the clone-and-replace overhead.
+        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
+        ctx.into()
+    }
+}
+
+// ----- Top-level Spec -----
+
+impl MergeWithContext<()> for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        // openapi version + info: under MergeInfo, full required-scalar
+        // policy; otherwise the documented contract is "kept on base."
+        // We still want `ErrorOnConflict` to catch a real mismatch and
+        // we still want the conflict in the report (with
+        // `Resolution::Base` to reflect that base actually won),
+        // hence the explicit comparison + `record_kept_base_or_error`
+        // helper rather than routing through `should_take_incoming`
+        // (which embeds the default incoming-wins policy and would
+        // record `Resolution::Incoming` even though no mutation
+        // happened).
+        if ctx.is_option(MergeOptions::MergeInfo) {
+            merge_required_scalar(
+                &mut self.openapi,
+                other.openapi,
+                ctx,
+                path,
+                ".openapi",
+                ConflictKind::RequiredScalarOverridden,
+            );
+            {
+                let mut guard = PathGuard::new(path, ".info");
+                self.info
+                    .merge_with_context(other.info, ctx, guard.path_mut());
+            }
+        } else {
+            if self.openapi != other.openapi {
+                record_kept_base_or_error(
+                    ctx,
+                    path,
+                    ".openapi",
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
+            if !ctx.errored && self.info != other.info {
+                record_kept_base_or_error(
+                    ctx,
+                    path,
+                    ".info",
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
+        }
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
+        // v3.0 `paths` is required (not Option) — merge in place.
+        {
+            let mut guard = PathGuard::new(path, ".paths");
+            self.paths
+                .merge_with_context(other.paths, ctx, guard.path_mut());
+        }
+        merge_opt_struct(
+            &mut self.components,
+            other.components,
+            ctx,
+            path,
+            ".components",
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            path,
+            ".security",
+        );
+        merge_opt_vec_by_key(
+            &mut self.tags,
+            other.tags,
+            ctx,
+            path,
+            ".tags",
+            |t: &Tag| t.name.clone(),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_vec_by_key(
+            &mut self.x_tag_groups,
+            other.x_tag_groups,
+            ctx,
+            path,
+            ".x-tagGroups",
+            |g: &TagGroup| g.name.clone(),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for TagGroup {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        // tags is a Vec<String> — set-union semantics.
+        let mut opt_base = Some(std::mem::take(&mut self.tags));
+        merge_opt_vec_set_union(&mut opt_base, Some(other.tags), ctx, path, ".tags");
+        self.tags = opt_base.unwrap_or_default();
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Containers -----
+
+impl MergeWithContext<()> for Components {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.schemas,
+            other.schemas,
+            ctx,
+            path,
+            ".schemas",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            path,
+            ".responses",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.request_bodies,
+            other.request_bodies,
+            ctx,
+            path,
+            ".requestBodies",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            path,
+            ".headers",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.security_schemes,
+            other.security_schemes,
+            ctx,
+            path,
+            ".securitySchemes",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.links,
+            other.links,
+            ctx,
+            path,
+            ".links",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.callbacks,
+            other.callbacks,
+            ctx,
+            path,
+            ".callbacks",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        for (k, incoming) in other.paths {
+            if let Some(base_v) = self.paths.get_mut(&k) {
+                let original_len = path.len();
+                path.push('[');
+                path.push_str(&k);
+                path.push(']');
+                base_v.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.paths.insert(k, incoming);
+            }
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Callback {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        for (k, incoming) in other.paths {
+            if let Some(base_v) = self.paths.get_mut(&k) {
+                let original_len = path.len();
+                path.push('[');
+                path.push_str(&k);
+                path.push(']');
+                base_v.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.paths.insert(k, incoming);
+            }
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.reference,
+            other.reference,
+            ctx,
+            path,
+            ".$ref",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.operations,
+            other.operations,
+            ctx,
+            path,
+            // No outer segment — operations live directly under the
+            // path item (e.g. `#.paths[/pets].get`).
+            "",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            fmt_param_key,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (&mut self.default, other.default) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".default");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            path,
+            // Per-status responses live directly under Responses
+            // (e.g. `#.responses.200`).
+            "",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_vec_set_union(&mut self.tags, other.tags, ctx, path, ".tags");
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.operation_id,
+            other.operation_id,
+            ctx,
+            path,
+            ".operationId",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            fmt_param_key,
+        );
+        match (&mut self.request_body, other.request_body) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".requestBody");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        // v3.0 `responses` is required (not Option) — merge in place.
+        {
+            let mut guard = PathGuard::new(path, ".responses");
+            self.responses
+                .merge_with_context(other.responses, ctx, guard.path_mut());
+        }
+        merge_opt_map(
+            &mut self.callbacks,
+            other.callbacks,
+            ctx,
+            path,
+            ".callbacks",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            path,
+            ".security",
+        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
+        merge_opt_vec_by_key(
+            &mut self.x_code_samples,
+            other.x_code_samples,
+            ctx,
+            path,
+            ".x-codeSamples",
+            |c: &CodeSample| (c.lang.clone(), c.label.clone().unwrap_or_default()),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            |k, out| {
+                out.push_str(&k.0);
+                if !k.1.is_empty() {
+                    out.push(':');
+                    out.push_str(&k.1);
+                }
+            },
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for CodeSample {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.lang,
+            other.lang,
+            ctx,
+            path,
+            ".lang",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.label,
+            other.label,
+            ctx,
+            path,
+            ".label",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.source,
+            other.source,
+            ctx,
+            path,
+            ".source",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Parameter (enum + variants) -----
+
+/// Identity key for an operation/path-item `parameters` list:
+/// `(name, location)`. `location` is `"path"` / `"query"` / `"header"`
+/// / `"cookie"` / `"querystring"` for inline `Parameter` items, or
+/// `"ref"` for a `$ref` (the reference string then plays the role of
+/// the name to keep different refs distinct).
+fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
+    match p {
+        RefOr::Ref(r) => (r.reference.clone(), "ref"),
+        RefOr::Item(p) => match p {
+            Parameter::Path(p) => (p.name.clone(), "path"),
+            Parameter::Query(p) => (p.name.clone(), "query"),
+            Parameter::Header(p) => (p.name.clone(), "header"),
+            Parameter::Cookie(p) => (p.name.clone(), "cookie"),
+        },
+    }
+}
+
+impl MergeWithContext<()> for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (self, other) {
+            (Parameter::Path(a), Parameter::Path(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Query(a), Parameter::Query(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Header(a), Parameter::Header(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Cookie(a), Parameter::Cookie(b)) => a.merge_with_context(*b, ctx, path),
+            (slot, incoming) => {
+                if ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for InPath {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for InQuery {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.allow_empty_value,
+            other.allow_empty_value,
+            ctx,
+            path,
+            ".allowEmptyValue",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.allow_reserved,
+            other.allow_reserved,
+            ctx,
+            path,
+            ".allowReserved",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for InHeader {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for InCookie {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+/// Shared helper: merge an `Option<RefOr<Schema>>`. `field_name` is
+/// the JSONPath segment (`schema`, `itemSchema`, `propertyNames`, …)
+/// — without it, every collision was previously misreported as
+/// `.schema`.
+fn merge_schema_field(
+    base: &mut Option<RefOr<Schema>>,
+    other: Option<RefOr<Schema>>,
+    ctx: &mut MergeContext<()>,
+    path: &mut String,
+    field_name: &str,
+) {
+    if ctx.errored {
+        return;
+    }
+    match (base.as_mut(), other) {
+        (_, None) => {}
+        (None, Some(v)) => *base = Some(v),
+        (Some(b), Some(i)) => {
+            let original_len = path.len();
+            path.push('.');
+            path.push_str(field_name);
+            b.merge_with_context(i, ctx, path);
+            path.truncate(original_len);
+        }
+    }
+}
+
+// ----- MediaType / Encoding / Header / Response / RequestBody / Example / Link -----
+
+impl MergeWithContext<()> for MediaType {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.encoding,
+            other.encoding,
+            ctx,
+            path,
+            ".encoding",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Encoding {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.content_type,
+            other.content_type,
+            ctx,
+            path,
+            ".contentType",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            path,
+            ".headers",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.allow_reserved,
+            other.allow_reserved,
+            ctx,
+            path,
+            ".allowReserved",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        // v3.0 `description` is a required String (vs v3.2's Option<String>).
+        merge_required_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            path,
+            ".headers",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.links,
+            other.links,
+            ctx,
+            path,
+            ".links",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for RequestBody {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        // content is a bare BTreeMap (required).
+        for (k, incoming) in other.content {
+            if let Some(b) = self.content.get_mut(&k) {
+                let original_len = path.len();
+                path.push_str(".content.");
+                path.push_str(&k);
+                b.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.content.insert(k, incoming);
+            }
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Example {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.value,
+            other.value,
+            ctx,
+            path,
+            ".value",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.external_value,
+            other.external_value,
+            ctx,
+            path,
+            ".externalValue",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Link {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.operation_ref,
+            other.operation_ref,
+            ctx,
+            path,
+            ".operationRef",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.operation_id,
+            other.operation_id,
+            ctx,
+            path,
+            ".operationId",
+            ConflictKind::ScalarOverridden,
+        );
+        // Link.parameters is `Option<BTreeMap<String, serde_json::Value>>`
+        // — treat like extensions.
+        merge_extensions(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+        );
+        merge_opt_scalar(
+            &mut self.request_body,
+            other.request_body,
+            ctx,
+            path,
+            ".requestBody",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(&mut self.server, other.server, ctx, path, ".server");
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Leaves: Tag, Info, Contact, License, ExternalDocumentation,
+//                Discriminator, XML, Server, ServerVariable -----
+
+impl MergeWithContext<()> for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.x_display_name,
+            other.x_display_name,
+            ctx,
+            path,
+            ".x-displayName",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            path,
+            ".title",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.terms_of_service,
+            other.terms_of_service,
+            ctx,
+            path,
+            ".termsOfService",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(&mut self.contact, other.contact, ctx, path, ".contact");
+        merge_opt_struct(&mut self.license, other.license, ctx, path, ".license");
+        merge_required_scalar(
+            &mut self.version,
+            other.version,
+            ctx,
+            path,
+            ".version",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_struct(&mut self.x_logo, other.x_logo, ctx, path, ".x-logo");
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Logo {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.background_color,
+            other.background_color,
+            ctx,
+            path,
+            ".backgroundColor",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.alt_text,
+            other.alt_text,
+            ctx,
+            path,
+            ".altText",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.href,
+            other.href,
+            ctx,
+            path,
+            ".href",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.email,
+            other.email,
+            ctx,
+            path,
+            ".email",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Discriminator {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.property_name,
+            other.property_name,
+            ctx,
+            path,
+            ".propertyName",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        // mapping is Option<BTreeMap<String,String>>; per-key incoming wins.
+        if let Some(other_map) = other.mapping {
+            let base_map = self
+                .mapping
+                .get_or_insert_with(std::collections::BTreeMap::new);
+            for (k, v) in other_map {
+                match base_map.get_mut(&k) {
+                    None => {
+                        base_map.insert(k, v);
+                    }
+                    Some(existing) => {
+                        if *existing != v {
+                            let original_len = path.len();
+                            path.push_str(".mapping.");
+                            path.push_str(&k);
+                            let take =
+                                ctx.should_take_incoming(path, ConflictKind::ScalarOverridden);
+                            path.truncate(original_len);
+                            if take {
+                                *existing = v;
+                            }
+                        }
+                    }
+                }
+                // ErrorOnConflict: bail on the first collision; matches
+                // the OAuth scopes loop and the documented "first real
+                // collision triggers early error" contract.
+                if ctx.errored {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for XML {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.namespace,
+            other.namespace,
+            ctx,
+            path,
+            ".namespace",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.prefix,
+            other.prefix,
+            ctx,
+            path,
+            ".prefix",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.attribute,
+            other.attribute,
+            ctx,
+            path,
+            ".attribute",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.wrapped,
+            other.wrapped,
+            ctx,
+            path,
+            ".wrapped",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        // v3.0 Server has no `name` (added in v3.2).
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.variables,
+            other.variables,
+            ctx,
+            path,
+            ".variables",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for ServerVariable {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.enum_values,
+            other.enum_values,
+            ctx,
+            path,
+            ".enum",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.default,
+            other.default,
+            ctx,
+            path,
+            ".default",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- SecurityScheme -----
+
+impl MergeWithContext<()> for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (self, other) {
+            (SecurityScheme::ApiKey(a), SecurityScheme::ApiKey(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::HTTP(a), SecurityScheme::HTTP(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::OAuth2(a), SecurityScheme::OAuth2(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::OpenIdConnect(a), SecurityScheme::OpenIdConnect(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (slot, incoming) => {
+                if ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for ApiKeySecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.location,
+            other.location,
+            ctx,
+            path,
+            ".in",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for HttpSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.scheme,
+            other.scheme,
+            ctx,
+            path,
+            ".scheme",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.bearer_format,
+            other.bearer_format,
+            ctx,
+            path,
+            ".bearerFormat",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.open_id_connect_url,
+            other.open_id_connect_url,
+            ctx,
+            path,
+            ".openIdConnectUrl",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for OAuth2SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        {
+            let mut guard = PathGuard::new(path, ".flows");
+            self.flows
+                .merge_with_context(other.flows, ctx, guard.path_mut());
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for OAuth2Flows {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(&mut self.implicit, other.implicit, ctx, path, ".implicit");
+        merge_opt_struct(&mut self.password, other.password, ctx, path, ".password");
+        merge_opt_struct(
+            &mut self.client_credentials,
+            other.client_credentials,
+            ctx,
+            path,
+            ".clientCredentials",
+        );
+        merge_opt_struct(
+            &mut self.authorization_code,
+            other.authorization_code,
+            ctx,
+            path,
+            ".authorizationCode",
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+/// Each OAuth flow has the same shape: optional URL fields + a bare
+/// `BTreeMap<String, String>` of scopes + extensions. Macro keeps it
+/// from sprawling.
+macro_rules! oauth_flow_merge {
+    ($t:ty, $($url_field:ident => $url_path:literal),* $(,)?) => {
+        impl MergeWithContext<()> for $t {
+            fn merge_with_context(
+                &mut self,
+                other: Self,
+                ctx: &mut MergeContext<()>,
+                path: &mut String,
+            ) {
+                if ctx.errored { return; }
+                $(
+                    merge_required_scalar(
+                        &mut self.$url_field,
+                        other.$url_field,
+                        ctx,
+                        path,
+                        concat!(".", $url_path),
+                        ConflictKind::RequiredScalarOverridden,
+                    );
+                )*
+                merge_opt_scalar(
+                    &mut self.refresh_url,
+                    other.refresh_url,
+                    ctx,
+                    path,
+                    ".refreshUrl",
+                    ConflictKind::ScalarOverridden,
+                );
+                // scopes is a bare BTreeMap<String, String>.
+                for (k, v) in other.scopes {
+                    match self.scopes.get_mut(&k) {
+                        None => {
+                            self.scopes.insert(k, v);
+                        }
+                        Some(existing) => {
+                            if *existing != v {
+                                let original_len = path.len();
+                                path.push_str(".scopes.");
+                                path.push_str(&k);
+                                let take = ctx.should_take_incoming(
+                                    path,
+                                    ConflictKind::ScalarOverridden,
+                                );
+                                path.truncate(original_len);
+                                if take {
+                                    *existing = v;
+                                }
+                                if ctx.errored {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                merge_extensions(
+                    &mut self.extensions,
+                    other.extensions,
+                    ctx,
+                    path,
+                    ".extensions",
+                );
+            }
+        }
+    };
+}
+
+oauth_flow_merge!(ImplicitOAuth2Flow, authorization_url => "authorizationUrl");
+oauth_flow_merge!(PasswordOAuth2Flow, token_url => "tokenUrl");
+oauth_flow_merge!(ClientCredentialsOAuth2Flow, token_url => "tokenUrl");
+oauth_flow_merge!(
+    AuthorizationCodeOAuth2Flow,
+    authorization_url => "authorizationUrl",
+    token_url => "tokenUrl",
+);
+
+// ----- Schema -----
+
+impl MergeWithContext<()> for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        // ObjectSchema deep-merge is the one variant pairing that
+        // recurses — everything else falls back to leaf-replace.
+        //
+        // Take ownership of `other` up front so the match is on owned
+        // values, avoiding the borrow-then-re-destructure dance that
+        // previously needed three `unreachable!()` guards. If the
+        // variants don't match, the bound-once `incoming` is reused
+        // for the leaf-replace fallback below.
+        if ctx.is_option(MergeOptions::DeepMergeObjectSchemas)
+            && let Schema::Single(self_single) = self
+            && let SingleSchema::Object(self_obj) = self_single.as_mut()
+        {
+            match other {
+                Schema::Single(other_single) => match *other_single {
+                    SingleSchema::Object(other_obj) => {
+                        self_obj.merge_with_context(other_obj, ctx, path);
+                        return;
+                    }
+                    other_single_inner => {
+                        // Re-box and fall through to leaf-replace.
+                        return leaf_replace_schema(
+                            self,
+                            Schema::Single(Box::new(other_single_inner)),
+                            ctx,
+                            path,
+                        );
+                    }
+                },
+                non_single => {
+                    return leaf_replace_schema(self, non_single, ctx, path);
+                }
+            }
+        }
+        leaf_replace_schema(self, other, ctx, path);
+    }
+}
+
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+    if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
+        *base = other;
+    }
+}
+
+/// Record a collision where the documented contract says "base is
+/// kept" — used for `Spec.info` / `Spec.openapi` when `MergeInfo` is
+/// off. Records `Resolution::Base` in the default / `BaseWins` modes
+/// (reflecting what actually happened), and trips
+/// `ErrorOnConflict` when set. Pushes `segment` onto `path` only
+/// when actually recording, keeping the eager-allocation
+/// regression off the non-conflict path.
+fn record_kept_base_or_error(
+    ctx: &mut MergeContext<()>,
+    path: &mut String,
+    segment: &str,
+    kind: ConflictKind,
+) {
+    let original_len = path.len();
+    path.push_str(segment);
+    if ctx.is_option(MergeOptions::ErrorOnConflict) {
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
+        ctx.errored = true;
+    } else {
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
+    }
+    path.truncate(original_len);
+}
+
+impl MergeWithContext<()> for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            path,
+            ".title",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.properties,
+            other.properties,
+            ctx,
+            path,
+            ".properties",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_scalar(
+            &mut self.default,
+            other.default,
+            ctx,
+            path,
+            ".default",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.max_properties,
+            other.max_properties,
+            ctx,
+            path,
+            ".maxProperties",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.min_properties,
+            other.min_properties,
+            ctx,
+            path,
+            ".minProperties",
+            ConflictKind::ScalarOverridden,
+        );
+        match (&mut self.additional_properties, other.additional_properties) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".additionalProperties");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_opt_vec_set_union(&mut self.required, other.required, ctx, path, ".required");
+        merge_opt_scalar(
+            &mut self.read_only,
+            other.read_only,
+            ctx,
+            path,
+            ".readOnly",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.write_only,
+            other.write_only,
+            ctx,
+            path,
+            ".writeOnly",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(&mut self.xml, other.xml, ctx, path, ".xml");
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// Schema sub-types (StringSchema, IntegerSchema, …, SingleSchema)
+// don't need their own `MergeWithContext<()>` impls — `Schema`'s impl
+// handles the entire enum at the top level via `leaf_replace_schema`
+// for any pairing other than `Single(Object(_))` × `Single(Object(_))`.
+// Nothing in the codebase holds a `RefOr<StringSchema>` or
+// `&mut SingleSchema` directly, so the per-variant impls would be
+// dead code.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merge::{ConflictKind, MergeOptions, Resolution};
+    use std::collections::BTreeMap;
+
+    fn root_path() -> String {
+        "#".to_owned()
+    }
+
+    fn report<S: MergeWithContext<()>>(
+        base: &mut S,
+        incoming: S,
+        opts: EnumSet<MergeOptions>,
+    ) -> Vec<crate::merge::MergeConflict> {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut path = root_path();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        ctx.conflicts
+    }
+
+    fn param_path(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Path(Box::new(InPath {
+            name: name.into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn param_query(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Query(Box::new(InQuery {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn response_with(description: &str) -> RefOr<Response> {
+        RefOr::new_item(Response {
+            description: description.into(),
+            ..Default::default()
+        })
+    }
+
+    // ---- Spec roll-up: three modes via Info.description (requires MergeInfo) ----
+
+    fn spec_with_info_desc(desc: &str) -> Spec {
+        Spec {
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                description: Some(desc.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn spec_default_incoming_wins() {
+        let mut base = spec_with_info_desc("base");
+        let report = base
+            .merge(
+                spec_with_info_desc("incoming"),
+                MergeOptions::MergeInfo.only(),
+            )
+            .unwrap();
+        assert_eq!(base.info.description.as_deref(), Some("incoming"));
+        assert!(!report.conflicts.is_empty());
+    }
+
+    #[test]
+    fn spec_error_on_conflict_returns_err_and_rolls_back() {
+        let mut base = spec_with_info_desc("base");
+        let result = base.merge(
+            spec_with_info_desc("incoming"),
+            MergeOptions::ErrorOnConflict | MergeOptions::MergeInfo,
+        );
+        assert!(result.is_err());
+        assert_eq!(base.info.description.as_deref(), Some("base"));
+    }
+
+    #[test]
+    fn spec_base_wins_records_resolution_base() {
+        let mut base = spec_with_info_desc("base");
+        let report = base
+            .merge(
+                spec_with_info_desc("incoming"),
+                MergeOptions::BaseWins | MergeOptions::MergeInfo,
+            )
+            .unwrap();
+        assert_eq!(base.info.description.as_deref(), Some("base"));
+        assert!(
+            report
+                .conflicts
+                .iter()
+                .any(|c| c.resolution == Resolution::Base)
+        );
+    }
+
+    #[test]
+    fn spec_paths_deep_merge_preserves_unrelated_methods() {
+        let mk_pi = |method: &str| PathItem {
+            operations: Some(BTreeMap::from([(method.to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let mut base = Spec {
+            paths: Paths {
+                paths: BTreeMap::from([("/pets".to_owned(), mk_pi("get"))]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                paths: Paths {
+                    paths: BTreeMap::from([("/pets".to_owned(), mk_pi("post"))]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        )
+        .unwrap();
+        let pi = &base.paths.paths["/pets"];
+        let ops = pi.operations.as_ref().unwrap();
+        assert!(ops.contains_key("get"));
+        assert!(ops.contains_key("post"));
+    }
+
+    #[test]
+    fn spec_info_kept_on_base_by_default() {
+        let mut base = Spec {
+            info: Info {
+                title: "Base API".into(),
+                version: "1.0.0".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let report = base
+            .merge(
+                Spec {
+                    info: Info {
+                        title: "Incoming".into(),
+                        version: "2.0.0".into(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                MergeOptions::new(),
+            )
+            .unwrap();
+        assert_eq!(base.info.title, "Base API");
+        assert!(
+            report
+                .conflicts
+                .iter()
+                .any(|c| c.path.ends_with(".info") && c.resolution == Resolution::Base)
+        );
+    }
+
+    #[test]
+    fn spec_info_merged_under_merge_info_option() {
+        let mut base = Spec {
+            info: Info {
+                title: "Base".into(),
+                version: "1.0.0".into(),
+                description: Some("base desc".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                info: Info {
+                    title: "Base".into(),
+                    version: "1.0.0".into(),
+                    terms_of_service: Some("https://incoming/tos".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            MergeOptions::MergeInfo.only(),
+        )
+        .unwrap();
+        assert_eq!(base.info.description.as_deref(), Some("base desc"));
+        assert_eq!(
+            base.info.terms_of_service.as_deref(),
+            Some("https://incoming/tos")
+        );
+    }
+
+    // ---- v3.0-specific: x_tag_groups ----
+
+    #[test]
+    fn spec_x_tag_groups_dedup_by_name() {
+        let mut base = Spec {
+            x_tag_groups: Some(vec![TagGroup {
+                name: "auth".into(),
+                tags: vec!["login".into(), "logout".into()],
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                x_tag_groups: Some(vec![
+                    TagGroup {
+                        name: "auth".into(),
+                        tags: vec!["refresh".into()],
+                        ..Default::default()
+                    },
+                    TagGroup {
+                        name: "users".into(),
+                        tags: vec!["create".into()],
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        )
+        .unwrap();
+        let groups = base.x_tag_groups.unwrap();
+        assert_eq!(groups.len(), 2);
+        let auth = groups.iter().find(|g| g.name == "auth").unwrap();
+        // tags union: login, logout, refresh
+        assert_eq!(auth.tags.len(), 3);
+    }
+
+    // ---- v3.0-specific: x_logo on Info ----
+
+    #[test]
+    fn info_x_logo_merges_when_both_some() {
+        let mut base = Info {
+            title: "T".into(),
+            version: "1".into(),
+            x_logo: Some(Logo {
+                url: "https://a.png".into(),
+                alt_text: Some("base alt".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Info {
+                title: "T".into(),
+                version: "1".into(),
+                x_logo: Some(Logo {
+                    url: "https://b.png".into(),
+                    href: Some("https://b".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let logo = base.x_logo.unwrap();
+        assert_eq!(logo.url, "https://b.png");
+        assert_eq!(logo.alt_text.as_deref(), Some("base alt"));
+        assert_eq!(logo.href.as_deref(), Some("https://b"));
+    }
+
+    // ---- v3.0-specific: x_code_samples on Operation ----
+
+    #[test]
+    fn operation_x_code_samples_dedup_by_lang_label() {
+        let mut base = Operation {
+            x_code_samples: Some(vec![CodeSample {
+                lang: "curl".into(),
+                label: Some("basic".into()),
+                source: "curl https://a".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                x_code_samples: Some(vec![
+                    // Same (lang, label) — dedup recurses + replaces source.
+                    CodeSample {
+                        lang: "curl".into(),
+                        label: Some("basic".into()),
+                        source: "curl https://b".into(),
+                        ..Default::default()
+                    },
+                    // Different label — appended.
+                    CodeSample {
+                        lang: "curl".into(),
+                        label: Some("auth".into()),
+                        source: "curl -H ...".into(),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let samples = base.x_code_samples.unwrap();
+        assert_eq!(samples.len(), 2);
+        let basic = samples
+            .iter()
+            .find(|s| s.label.as_deref() == Some("basic"))
+            .unwrap();
+        assert_eq!(basic.source, "curl https://b");
+    }
+
+    // ---- v3.0-specific: Tag.x_display_name ----
+
+    #[test]
+    fn tag_x_display_name_merges() {
+        let mut base = Tag {
+            name: "pets".into(),
+            x_display_name: Some("Pet API".into()),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Tag {
+                name: "pets".into(),
+                x_display_name: Some("Pets!".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.x_display_name.as_deref(), Some("Pets!"));
+    }
+
+    // ---- RefOr ----
+
+    #[test]
+    fn refor_item_item_recurses() {
+        let mut base: RefOr<Tag> = RefOr::new_item(Tag {
+            name: "pets".into(),
+            description: Some("base".into()),
+            ..Default::default()
+        });
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
+        base.merge_with_context(
+            RefOr::new_item(Tag {
+                name: "pets".into(),
+                description: Some("inc".into()),
+                ..Default::default()
+            }),
+            &mut ctx,
+            &mut path,
+        );
+        match base {
+            RefOr::Item(t) => assert_eq!(t.description.as_deref(), Some("inc")),
+            _ => panic!(),
+        }
+    }
+
+    // ---- Operation: responses, parameters dedup, method coexistence ----
+
+    #[test]
+    fn operation_responses_keeps_base_status_codes() {
+        let mut base = Operation {
+            responses: Responses {
+                responses: Some(BTreeMap::from([
+                    ("200".into(), response_with("ok")),
+                    ("404".into(), response_with("missing")),
+                ])),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                responses: Responses {
+                    responses: Some(BTreeMap::from([
+                        ("200".into(), response_with("ok updated")),
+                        ("500".into(), response_with("err")),
+                    ])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let r = base.responses.responses.unwrap();
+        assert!(r.contains_key("200"));
+        assert!(r.contains_key("404"));
+        assert!(r.contains_key("500"));
+    }
+
+    #[test]
+    fn operation_parameters_dedup_by_name_in() {
+        let mut base = Operation {
+            parameters: Some(vec![param_path("id"), param_query("limit")]),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                parameters: Some(vec![param_path("id"), param_query("filter")]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.parameters.unwrap().len(), 3);
+    }
+
+    #[test]
+    fn path_item_get_and_post_coexist() {
+        let mut base = PathItem {
+            operations: Some(BTreeMap::from([("get".to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            PathItem {
+                operations: Some(BTreeMap::from([("post".to_owned(), Operation::default())])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let ops = base.operations.unwrap();
+        assert!(ops.contains_key("get") && ops.contains_key("post"));
+    }
+
+    // ---- Schema deep merge ----
+
+    #[test]
+    fn schema_object_deep_merge_under_option() {
+        let mut base = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            properties: Some(BTreeMap::from([(
+                "a".to_owned(),
+                RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                    ObjectSchema::default(),
+                )))),
+            )])),
+            required: Some(vec!["a".into()]),
+            ..Default::default()
+        })));
+        let _ = report(
+            &mut base,
+            Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+                properties: Some(BTreeMap::from([(
+                    "b".to_owned(),
+                    RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                        ObjectSchema::default(),
+                    )))),
+                )])),
+                required: Some(vec!["b".into()]),
+                ..Default::default()
+            }))),
+            MergeOptions::DeepMergeObjectSchemas.only(),
+        );
+        let Schema::Single(box_s) = &base else {
+            panic!()
+        };
+        let SingleSchema::Object(obj) = &**box_s else {
+            panic!()
+        };
+        let props = obj.properties.as_ref().unwrap();
+        assert!(props.contains_key("a") && props.contains_key("b"));
+        let req = obj.required.as_ref().unwrap();
+        assert!(req.contains(&"a".to_owned()) && req.contains(&"b".to_owned()));
+    }
+
+    // ---- Parameter variant mismatch ----
+
+    #[test]
+    fn parameter_variant_mismatch_replaces() {
+        let mut base = Parameter::Path(Box::new(InPath {
+            name: "id".into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }));
+        let conflicts = report(
+            &mut base,
+            Parameter::Query(Box::new(InQuery {
+                name: "id".into(),
+                description: None,
+                required: None,
+                deprecated: None,
+                allow_empty_value: None,
+                style: None,
+                explode: None,
+                allow_reserved: None,
+                schema: None,
+                example: None,
+                examples: None,
+                content: None,
+                extensions: None,
+            })),
+            MergeOptions::new(),
+        );
+        assert!(matches!(base, Parameter::Query(_)));
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].kind, ConflictKind::ParameterVariantMismatch);
+    }
+}

--- a/crates/roas/src/v3_0/server.rs
+++ b/crates/roas/src/v3_0/server.rs
@@ -146,6 +146,52 @@ impl ValidateWithContext<Spec> for ServerVariable {
     }
 }
 
+impl crate::merge::MergeWithContext for ServerVariable {
+    fn merge_with_context(
+        &mut self,
+        other: Self,
+        ctx: &mut crate::merge::MergeContext,
+        path: &mut String,
+    ) {
+        if ctx.errored {
+            return;
+        }
+        use crate::common::merge::{merge_extensions, merge_opt_scalar, merge_required_scalar};
+        use crate::merge::ConflictKind;
+        merge_opt_scalar(
+            &mut self.enum_values,
+            other.enum_values,
+            ctx,
+            path,
+            ".enum",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.default,
+            other.default,
+            ctx,
+            path,
+            ".default",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/roas/src/v3_1.rs
+++ b/crates/roas/src/v3_1.rs
@@ -13,6 +13,7 @@ pub mod header;
 pub mod info;
 pub mod link;
 pub mod media_type;
+pub mod merge;
 pub mod operation;
 pub mod parameter;
 pub mod path_item;

--- a/crates/roas/src/v3_1/merge.rs
+++ b/crates/roas/src/v3_1/merge.rs
@@ -84,7 +84,7 @@ impl Merge for Spec {
         // dereferencing happens during merge). Carrying the borrow as
         // a unit `&()` keeps the type generic without forcing the
         // caller to clone the base before merging into it.
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        let mut ctx: MergeContext = MergeContext::new(options);
         // Single owned `String` for the whole merge — every child
         // pushes/truncates segments onto it via the helper guards.
         let mut path = String::from("#");
@@ -98,7 +98,7 @@ impl Merge for Spec {
             // `ErrorOnConflict` to get. The clone cost is paid only
             // when the option is opted in.
             let mut working = self.clone();
-            <Spec as MergeWithContext<()>>::merge_with_context(
+            <Spec as MergeWithContext>::merge_with_context(
                 &mut working,
                 other,
                 &mut ctx,
@@ -118,15 +118,15 @@ impl Merge for Spec {
         // Non-strict modes mutate `self` in place — the report still
         // captures every resolution, so callers wanting "see what
         // changed" don't need the clone-and-replace overhead.
-        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
+        <Spec as MergeWithContext>::merge_with_context(self, other, &mut ctx, &mut path);
         ctx.into()
     }
 }
 
 // ----- Top-level Spec -----
 
-impl MergeWithContext<()> for Spec {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -234,8 +234,8 @@ impl MergeWithContext<()> for Spec {
     }
 }
 
-impl MergeWithContext<()> for TagGroup {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for TagGroup {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -263,8 +263,8 @@ impl MergeWithContext<()> for TagGroup {
 
 // ----- Containers -----
 
-impl MergeWithContext<()> for Components {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Components {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -368,8 +368,8 @@ impl MergeWithContext<()> for Components {
     }
 }
 
-impl MergeWithContext<()> for Paths {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -398,8 +398,8 @@ impl MergeWithContext<()> for Paths {
     }
 }
 
-impl MergeWithContext<()> for Callback {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Callback {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -428,8 +428,8 @@ impl MergeWithContext<()> for Callback {
     }
 }
 
-impl MergeWithContext<()> for PathItem {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -489,8 +489,8 @@ impl MergeWithContext<()> for PathItem {
     }
 }
 
-impl MergeWithContext<()> for Responses {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -523,8 +523,8 @@ impl MergeWithContext<()> for Responses {
     }
 }
 
-impl MergeWithContext<()> for Operation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -637,8 +637,8 @@ impl MergeWithContext<()> for Operation {
     }
 }
 
-impl MergeWithContext<()> for CodeSample {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for CodeSample {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -695,8 +695,8 @@ fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
     }
 }
 
-impl MergeWithContext<()> for Parameter {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -714,8 +714,8 @@ impl MergeWithContext<()> for Parameter {
     }
 }
 
-impl MergeWithContext<()> for InPath {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InPath {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -796,8 +796,8 @@ impl MergeWithContext<()> for InPath {
     }
 }
 
-impl MergeWithContext<()> for InQuery {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InQuery {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -894,8 +894,8 @@ impl MergeWithContext<()> for InQuery {
     }
 }
 
-impl MergeWithContext<()> for InHeader {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InHeader {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -976,8 +976,8 @@ impl MergeWithContext<()> for InHeader {
     }
 }
 
-impl MergeWithContext<()> for InCookie {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InCookie {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1065,7 +1065,7 @@ impl MergeWithContext<()> for InCookie {
 fn merge_schema_field(
     base: &mut Option<RefOr<Schema>>,
     other: Option<RefOr<Schema>>,
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut String,
     field_name: &str,
 ) {
@@ -1087,8 +1087,8 @@ fn merge_schema_field(
 
 // ----- MediaType / Encoding / Header / Response / RequestBody / Example / Link -----
 
-impl MergeWithContext<()> for MediaType {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for MediaType {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1129,8 +1129,8 @@ impl MergeWithContext<()> for MediaType {
     }
 }
 
-impl MergeWithContext<()> for Encoding {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Encoding {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1185,8 +1185,8 @@ impl MergeWithContext<()> for Encoding {
     }
 }
 
-impl MergeWithContext<()> for Header {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1267,8 +1267,8 @@ impl MergeWithContext<()> for Header {
     }
 }
 
-impl MergeWithContext<()> for Response {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1318,8 +1318,8 @@ impl MergeWithContext<()> for Response {
     }
 }
 
-impl MergeWithContext<()> for RequestBody {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for RequestBody {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1364,8 +1364,8 @@ impl MergeWithContext<()> for RequestBody {
     }
 }
 
-impl MergeWithContext<()> for Example {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Example {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1411,8 +1411,8 @@ impl MergeWithContext<()> for Example {
     }
 }
 
-impl MergeWithContext<()> for Link {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Link {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1471,8 +1471,8 @@ impl MergeWithContext<()> for Link {
 // ----- Leaves: Tag, Info, Contact, License, ExternalDocumentation,
 //                Discriminator, XML, Server, ServerVariable -----
 
-impl MergeWithContext<()> for Tag {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1517,8 +1517,8 @@ impl MergeWithContext<()> for Tag {
     }
 }
 
-impl MergeWithContext<()> for Info {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1575,8 +1575,8 @@ impl MergeWithContext<()> for Info {
     }
 }
 
-impl MergeWithContext<()> for Logo {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Logo {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1622,8 +1622,8 @@ impl MergeWithContext<()> for Logo {
     }
 }
 
-impl MergeWithContext<()> for Contact {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1661,8 +1661,8 @@ impl MergeWithContext<()> for Contact {
     }
 }
 
-impl MergeWithContext<()> for License {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1700,8 +1700,8 @@ impl MergeWithContext<()> for License {
     }
 }
 
-impl MergeWithContext<()> for ExternalDocumentation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1731,8 +1731,8 @@ impl MergeWithContext<()> for ExternalDocumentation {
     }
 }
 
-impl MergeWithContext<()> for Discriminator {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Discriminator {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1779,8 +1779,8 @@ impl MergeWithContext<()> for Discriminator {
     }
 }
 
-impl MergeWithContext<()> for XML {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for XML {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1834,8 +1834,8 @@ impl MergeWithContext<()> for XML {
     }
 }
 
-impl MergeWithContext<()> for Server {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1877,8 +1877,8 @@ impl MergeWithContext<()> for Server {
 
 // ----- SecurityScheme -----
 
-impl MergeWithContext<()> for SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1907,8 +1907,8 @@ impl MergeWithContext<()> for SecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for ApiKeySecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ApiKeySecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1946,8 +1946,8 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for HttpSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for HttpSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1985,8 +1985,8 @@ impl MergeWithContext<()> for HttpSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for MutualTLSSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for MutualTLSSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2008,8 +2008,8 @@ impl MergeWithContext<()> for MutualTLSSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OpenIdConnectSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2039,8 +2039,8 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OAuth2SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OAuth2SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2067,8 +2067,8 @@ impl MergeWithContext<()> for OAuth2SecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OAuth2Flows {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OAuth2Flows {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2103,11 +2103,11 @@ impl MergeWithContext<()> for OAuth2Flows {
 /// from sprawling.
 macro_rules! oauth_flow_merge {
     ($t:ty, $($url_field:ident => $url_path:literal),* $(,)?) => {
-        impl MergeWithContext<()> for $t {
+        impl MergeWithContext for $t {
             fn merge_with_context(
                 &mut self,
                 other: Self,
-                ctx: &mut MergeContext<()>,
+                ctx: &mut MergeContext,
                 path: &mut String,
             ) {
                 if ctx.errored { return; }
@@ -2178,8 +2178,8 @@ oauth_flow_merge!(
 
 // ----- Schema -----
 
-impl MergeWithContext<()> for Schema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2220,7 +2220,7 @@ impl MergeWithContext<()> for Schema {
     }
 }
 
-fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext, path: &str) {
     if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
         *base = other;
     }
@@ -2234,7 +2234,7 @@ fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<
 /// when actually recording, keeping the eager-allocation
 /// regression off the non-conflict path.
 fn record_kept_base_or_error(
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
     kind: ConflictKind,
@@ -2250,8 +2250,8 @@ fn record_kept_base_or_error(
     path.truncate(original_len);
 }
 
-impl MergeWithContext<()> for ObjectSchema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2399,7 +2399,7 @@ impl MergeWithContext<()> for ObjectSchema {
 }
 
 // Schema sub-types (StringSchema, IntegerSchema, …, SingleSchema)
-// don't need their own `MergeWithContext<()>` impls — `Schema`'s impl
+// don't need their own `MergeWithContext` impls — `Schema`'s impl
 // handles the entire enum at the top level via `leaf_replace_schema`
 // for any pairing other than `Single(Object(_))` × `Single(Object(_))`.
 // Nothing in the codebase holds a `RefOr<StringSchema>` or
@@ -2416,12 +2416,12 @@ mod tests {
         "#".to_owned()
     }
 
-    fn report<S: MergeWithContext<()>>(
+    fn report<S: MergeWithContext>(
         base: &mut S,
         incoming: S,
         opts: EnumSet<MergeOptions>,
     ) -> Vec<crate::merge::MergeConflict> {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut ctx: MergeContext = MergeContext::new(opts);
         let mut path = root_path();
         base.merge_with_context(incoming, &mut ctx, &mut path);
         ctx.conflicts
@@ -2780,7 +2780,7 @@ mod tests {
             description: Some("base".into()),
             ..Default::default()
         });
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         base.merge_with_context(
             RefOr::new_item(Tag {

--- a/crates/roas/src/v3_1/merge.rs
+++ b/crates/roas/src/v3_1/merge.rs
@@ -21,7 +21,7 @@ use enumset::EnumSet;
 use crate::common::merge::{
     PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
     merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
-    merge_required_scalar,
+    merge_required_scalar, record_kept_base_or_error,
 };
 use crate::common::reference::RefOr;
 use crate::merge::{
@@ -2224,30 +2224,6 @@ fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext,
     if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
         *base = other;
     }
-}
-
-/// Record a collision where the documented contract says "base is
-/// kept" — used for `Spec.info` / `Spec.openapi` when `MergeInfo` is
-/// off. Records `Resolution::Base` in the default / `BaseWins` modes
-/// (reflecting what actually happened), and trips
-/// `ErrorOnConflict` when set. Pushes `segment` onto `path` only
-/// when actually recording, keeping the eager-allocation
-/// regression off the non-conflict path.
-fn record_kept_base_or_error(
-    ctx: &mut MergeContext,
-    path: &mut String,
-    segment: &str,
-    kind: ConflictKind,
-) {
-    let original_len = path.len();
-    path.push_str(segment);
-    if ctx.is_option(MergeOptions::ErrorOnConflict) {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
-        ctx.errored = true;
-    } else {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
-    }
-    path.truncate(original_len);
 }
 
 impl MergeWithContext for ObjectSchema {

--- a/crates/roas/src/v3_1/merge.rs
+++ b/crates/roas/src/v3_1/merge.rs
@@ -1,0 +1,2949 @@
+//! v3.1 merge: per-component `MergeWithContext<Spec>` impls plus the
+//! public `impl Merge for Spec`.
+//!
+//! Sits alongside `v3_1/validation.rs`. Every component type in v3.1
+//! gets a `merge_with_context` whose shape mirrors its
+//! `validate_with_context` neighbor: walk the fields, recurse into
+//! nested objects, dispatch through `RefOr` / `BoolOr`. Helpers from
+//! [`crate::common::merge`] do the structural plumbing
+//! (`merge_opt_scalar`, `merge_opt_map`, `merge_vec_by_key`,
+//! `merge_extensions`, ...) so each impl reads as a flat list of
+//! "field → rule" lines.
+//!
+//! Conflict policy modes (incoming-wins / base-wins / error-on-conflict),
+//! the `DeepMergeObjectSchemas` opt-in, and the `MergeInfo`
+//! /`ReplaceListsWhenEmpty` toggles all flow through
+//! [`crate::merge::MergeContext`] — the impls themselves stay
+//! policy-free.
+
+use enumset::EnumSet;
+
+use crate::common::merge::{
+    PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
+    merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
+    merge_required_scalar,
+};
+use crate::common::reference::RefOr;
+use crate::merge::{
+    ConflictKind, Merge, MergeContext, MergeError, MergeOptions, MergeReport, MergeWithContext,
+};
+
+use crate::v3_1::callback::Callback;
+use crate::v3_1::components::Components;
+use crate::v3_1::discriminator::Discriminator;
+use crate::v3_1::example::Example;
+use crate::v3_1::external_documentation::ExternalDocumentation;
+use crate::v3_1::header::Header;
+use crate::v3_1::info::{Contact, Info, License, Logo};
+use crate::v3_1::link::Link;
+use crate::v3_1::media_type::{Encoding, MediaType};
+use crate::v3_1::operation::{CodeSample, Operation};
+use crate::v3_1::parameter::{InCookie, InHeader, InPath, InQuery, Parameter};
+use crate::v3_1::path_item::{PathItem, Paths};
+use crate::v3_1::request_body::RequestBody;
+use crate::v3_1::response::{Response, Responses};
+use crate::v3_1::schema::{ObjectSchema, Schema, SingleSchema};
+use crate::v3_1::security_scheme::{
+    ApiKeySecurityScheme, AuthorizationCodeOAuth2Flow, ClientCredentialsOAuth2Flow,
+    HttpSecurityScheme, ImplicitOAuth2Flow, MutualTLSSecurityScheme, OAuth2Flows,
+    OAuth2SecurityScheme, OpenIdConnectSecurityScheme, PasswordOAuth2Flow, SecurityScheme,
+};
+use crate::v3_1::server::Server;
+use crate::v3_1::spec::{Spec, TagGroup};
+use crate::v3_1::tag::Tag;
+use crate::v3_1::xml::XML;
+
+// String-keyed maps appear everywhere; this is the single fmt_key
+// the helpers want. Writes the key directly into the path buffer
+// instead of allocating a fresh String — the helpers' `fmt_key`
+// signature is `Fn(&K, &mut String)` for exactly this reason.
+#[allow(clippy::ptr_arg)]
+fn key_str(s: &String, out: &mut String) {
+    out.push_str(s);
+}
+
+/// `fmt_key` for the `(name, location)` keys used by
+/// `Operation.parameters` / `PathItem.parameters`. Writes
+/// `<name>:<location>` into the path buffer.
+fn fmt_param_key(k: &(String, &'static str), out: &mut String) {
+    out.push_str(&k.0);
+    out.push(':');
+    out.push_str(k.1);
+}
+
+// ----- Public entry point -----
+
+impl Merge for Spec {
+    fn merge(
+        &mut self,
+        other: Self,
+        options: EnumSet<MergeOptions>,
+    ) -> Result<MergeReport, MergeError> {
+        // SAFETY of the `&()` trick: `MergeContext.spec` is a `&T`
+        // back-reference the impls don't currently use (no ref
+        // dereferencing happens during merge). Carrying the borrow as
+        // a unit `&()` keeps the type generic without forcing the
+        // caller to clone the base before merging into it.
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        // Single owned `String` for the whole merge — every child
+        // pushes/truncates segments onto it via the helper guards.
+        let mut path = String::from("#");
+
+        if options.contains(MergeOptions::ErrorOnConflict) {
+            // Strict-mode rollback: clone `self` into a working copy
+            // and only commit it back on success. Without this, an
+            // `Err` would leave `self` partially merged (additive
+            // steps run before the first collision flips `ctx.errored`),
+            // which contradicts the contract callers reach for
+            // `ErrorOnConflict` to get. The clone cost is paid only
+            // when the option is opted in.
+            let mut working = self.clone();
+            <Spec as MergeWithContext<()>>::merge_with_context(
+                &mut working,
+                other,
+                &mut ctx,
+                &mut path,
+            );
+            if ctx.errored {
+                return Err(MergeError {
+                    conflicts: ctx.conflicts,
+                });
+            }
+            *self = working;
+            return Ok(MergeReport {
+                conflicts: ctx.conflicts,
+            });
+        }
+
+        // Non-strict modes mutate `self` in place — the report still
+        // captures every resolution, so callers wanting "see what
+        // changed" don't need the clone-and-replace overhead.
+        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
+        ctx.into()
+    }
+}
+
+// ----- Top-level Spec -----
+
+impl MergeWithContext<()> for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        // openapi version + info: under MergeInfo, full required-scalar
+        // policy; otherwise the documented contract is "kept on base."
+        // We still want `ErrorOnConflict` to catch a real mismatch and
+        // we still want the conflict in the report (with
+        // `Resolution::Base` to reflect that base actually won),
+        // hence the explicit comparison + `record_kept_base_or_error`
+        // helper rather than routing through `should_take_incoming`
+        // (which embeds the default incoming-wins policy and would
+        // record `Resolution::Incoming` even though no mutation
+        // happened).
+        if ctx.is_option(MergeOptions::MergeInfo) {
+            merge_required_scalar(
+                &mut self.openapi,
+                other.openapi,
+                ctx,
+                path,
+                ".openapi",
+                ConflictKind::RequiredScalarOverridden,
+            );
+            {
+                let mut guard = PathGuard::new(path, ".info");
+                self.info
+                    .merge_with_context(other.info, ctx, guard.path_mut());
+            }
+        } else {
+            if self.openapi != other.openapi {
+                record_kept_base_or_error(
+                    ctx,
+                    path,
+                    ".openapi",
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
+            if !ctx.errored && self.info != other.info {
+                record_kept_base_or_error(
+                    ctx,
+                    path,
+                    ".info",
+                    ConflictKind::RequiredScalarOverridden,
+                );
+            }
+        }
+        merge_opt_scalar(
+            &mut self.json_schema_dialect,
+            other.json_schema_dialect,
+            ctx,
+            path,
+            ".jsonSchemaDialect",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
+        merge_opt_struct(&mut self.paths, other.paths, ctx, path, ".paths");
+        merge_opt_struct(&mut self.webhooks, other.webhooks, ctx, path, ".webhooks");
+        merge_opt_struct(
+            &mut self.components,
+            other.components,
+            ctx,
+            path,
+            ".components",
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            path,
+            ".security",
+        );
+        merge_opt_vec_by_key(
+            &mut self.tags,
+            other.tags,
+            ctx,
+            path,
+            ".tags",
+            |t: &Tag| t.name.clone(),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_vec_by_key(
+            &mut self.x_tag_groups,
+            other.x_tag_groups,
+            ctx,
+            path,
+            ".x-tagGroups",
+            |g: &TagGroup| g.name.clone(),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for TagGroup {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        // tags is a Vec<String> — set-union semantics.
+        let mut opt_base = Some(std::mem::take(&mut self.tags));
+        merge_opt_vec_set_union(&mut opt_base, Some(other.tags), ctx, path, ".tags");
+        self.tags = opt_base.unwrap_or_default();
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Containers -----
+
+impl MergeWithContext<()> for Components {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_map(
+            &mut self.schemas,
+            other.schemas,
+            ctx,
+            path,
+            ".schemas",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            path,
+            ".responses",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.request_bodies,
+            other.request_bodies,
+            ctx,
+            path,
+            ".requestBodies",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            path,
+            ".headers",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.security_schemes,
+            other.security_schemes,
+            ctx,
+            path,
+            ".securitySchemes",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.links,
+            other.links,
+            ctx,
+            path,
+            ".links",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.callbacks,
+            other.callbacks,
+            ctx,
+            path,
+            ".callbacks",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.path_items,
+            other.path_items,
+            ctx,
+            path,
+            ".pathItems",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        for (k, incoming) in other.paths {
+            if let Some(base_v) = self.paths.get_mut(&k) {
+                let original_len = path.len();
+                path.push('[');
+                path.push_str(&k);
+                path.push(']');
+                base_v.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.paths.insert(k, incoming);
+            }
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Callback {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        for (k, incoming) in other.paths {
+            if let Some(base_v) = self.paths.get_mut(&k) {
+                let original_len = path.len();
+                path.push('[');
+                path.push_str(&k);
+                path.push(']');
+                base_v.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.paths.insert(k, incoming);
+            }
+        }
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.reference,
+            other.reference,
+            ctx,
+            path,
+            ".$ref",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.operations,
+            other.operations,
+            ctx,
+            path,
+            // No outer segment — operations live directly under the
+            // path item (e.g. `#.paths[/pets].get`).
+            "",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            fmt_param_key,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (&mut self.default, other.default) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".default");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_opt_map(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            path,
+            // Per-status responses live directly under Responses
+            // (e.g. `#.responses.200`).
+            "",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_vec_set_union(&mut self.tags, other.tags, ctx, path, ".tags");
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.operation_id,
+            other.operation_id,
+            ctx,
+            path,
+            ".operationId",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_vec_by_key(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+            parameter_ref_key,
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            fmt_param_key,
+        );
+        match (&mut self.request_body, other.request_body) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".requestBody");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_opt_struct(
+            &mut self.responses,
+            other.responses,
+            ctx,
+            path,
+            ".responses",
+        );
+        merge_opt_map(
+            &mut self.callbacks,
+            other.callbacks,
+            ctx,
+            path,
+            ".callbacks",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_replace_list_when_nonempty(
+            &mut self.security,
+            other.security,
+            ctx,
+            path,
+            ".security",
+        );
+        merge_replace_list_when_nonempty(&mut self.servers, other.servers, ctx, path, ".servers");
+        merge_opt_vec_by_key(
+            &mut self.x_code_samples,
+            other.x_code_samples,
+            ctx,
+            path,
+            ".x-codeSamples",
+            |c: &CodeSample| (c.lang.clone(), c.label.clone().unwrap_or_default()),
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            |k, out| {
+                out.push_str(&k.0);
+                if !k.1.is_empty() {
+                    out.push(':');
+                    out.push_str(&k.1);
+                }
+            },
+        );
+        merge_opt_vec_set_union(&mut self.x_tags, other.x_tags, ctx, path, ".x-tags");
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for CodeSample {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.lang,
+            other.lang,
+            ctx,
+            path,
+            ".lang",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.label,
+            other.label,
+            ctx,
+            path,
+            ".label",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.source,
+            other.source,
+            ctx,
+            path,
+            ".source",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Parameter (enum + variants) -----
+
+/// Identity key for an operation/path-item `parameters` list:
+/// `(name, location)`. `location` is `"path"` / `"query"` / `"header"`
+/// / `"cookie"` / `"querystring"` for inline `Parameter` items, or
+/// `"ref"` for a `$ref` (the reference string then plays the role of
+/// the name to keep different refs distinct).
+fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
+    match p {
+        RefOr::Ref(r) => (r.reference.clone(), "ref"),
+        RefOr::Item(p) => match p {
+            Parameter::Path(p) => (p.name.clone(), "path"),
+            Parameter::Query(p) => (p.name.clone(), "query"),
+            Parameter::Header(p) => (p.name.clone(), "header"),
+            Parameter::Cookie(p) => (p.name.clone(), "cookie"),
+        },
+    }
+}
+
+impl MergeWithContext<()> for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (self, other) {
+            (Parameter::Path(a), Parameter::Path(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Query(a), Parameter::Query(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Header(a), Parameter::Header(b)) => a.merge_with_context(*b, ctx, path),
+            (Parameter::Cookie(a), Parameter::Cookie(b)) => a.merge_with_context(*b, ctx, path),
+            (slot, incoming) => {
+                if ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for InPath {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for InQuery {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.allow_empty_value,
+            other.allow_empty_value,
+            ctx,
+            path,
+            ".allowEmptyValue",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.allow_reserved,
+            other.allow_reserved,
+            ctx,
+            path,
+            ".allowReserved",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for InHeader {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for InCookie {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+/// Shared helper: merge an `Option<RefOr<Schema>>`. `field_name` is
+/// the JSONPath segment (`schema`, `itemSchema`, `propertyNames`, …)
+/// — without it, every collision was previously misreported as
+/// `.schema`.
+fn merge_schema_field(
+    base: &mut Option<RefOr<Schema>>,
+    other: Option<RefOr<Schema>>,
+    ctx: &mut MergeContext<()>,
+    path: &mut String,
+    field_name: &str,
+) {
+    if ctx.errored {
+        return;
+    }
+    match (base.as_mut(), other) {
+        (_, None) => {}
+        (None, Some(v)) => *base = Some(v),
+        (Some(b), Some(i)) => {
+            let original_len = path.len();
+            path.push('.');
+            path.push_str(field_name);
+            b.merge_with_context(i, ctx, path);
+            path.truncate(original_len);
+        }
+    }
+}
+
+// ----- MediaType / Encoding / Header / Response / RequestBody / Example / Link -----
+
+impl MergeWithContext<()> for MediaType {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.encoding,
+            other.encoding,
+            ctx,
+            path,
+            ".encoding",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Encoding {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.content_type,
+            other.content_type,
+            ctx,
+            path,
+            ".contentType",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            path,
+            ".headers",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.allow_reserved,
+            other.allow_reserved,
+            ctx,
+            path,
+            ".allowReserved",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.style,
+            other.style,
+            ctx,
+            path,
+            ".style",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.explode,
+            other.explode,
+            ctx,
+            path,
+            ".explode",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_schema_field(&mut self.schema, other.schema, ctx, path, "schema");
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        // v3.1 `description` is a required String (vs v3.2's Option<String>).
+        merge_required_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.headers,
+            other.headers,
+            ctx,
+            path,
+            ".headers",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.content,
+            other.content,
+            ctx,
+            path,
+            ".content",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.links,
+            other.links,
+            ctx,
+            path,
+            ".links",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for RequestBody {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        // content is a bare BTreeMap (required).
+        for (k, incoming) in other.content {
+            if let Some(b) = self.content.get_mut(&k) {
+                let original_len = path.len();
+                path.push_str(".content.");
+                path.push_str(&k);
+                b.merge_with_context(incoming, ctx, path);
+                path.truncate(original_len);
+                if ctx.errored {
+                    return;
+                }
+            } else {
+                self.content.insert(k, incoming);
+            }
+        }
+        merge_opt_scalar(
+            &mut self.required,
+            other.required,
+            ctx,
+            path,
+            ".required",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Example {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.value,
+            other.value,
+            ctx,
+            path,
+            ".value",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.external_value,
+            other.external_value,
+            ctx,
+            path,
+            ".externalValue",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Link {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.operation_ref,
+            other.operation_ref,
+            ctx,
+            path,
+            ".operationRef",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.operation_id,
+            other.operation_id,
+            ctx,
+            path,
+            ".operationId",
+            ConflictKind::ScalarOverridden,
+        );
+        // Link.parameters is `Option<BTreeMap<String, serde_json::Value>>`
+        // — treat like extensions.
+        merge_extensions(
+            &mut self.parameters,
+            other.parameters,
+            ctx,
+            path,
+            ".parameters",
+        );
+        merge_opt_scalar(
+            &mut self.request_body,
+            other.request_body,
+            ctx,
+            path,
+            ".requestBody",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(&mut self.server, other.server, ctx, path, ".server");
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- Leaves: Tag, Info, Contact, License, ExternalDocumentation,
+//                Discriminator, XML, Server, ServerVariable -----
+
+impl MergeWithContext<()> for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.x_display_name,
+            other.x_display_name,
+            ctx,
+            path,
+            ".x-displayName",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            path,
+            ".title",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.summary,
+            other.summary,
+            ctx,
+            path,
+            ".summary",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.terms_of_service,
+            other.terms_of_service,
+            ctx,
+            path,
+            ".termsOfService",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(&mut self.contact, other.contact, ctx, path, ".contact");
+        merge_opt_struct(&mut self.license, other.license, ctx, path, ".license");
+        merge_required_scalar(
+            &mut self.version,
+            other.version,
+            ctx,
+            path,
+            ".version",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_struct(&mut self.x_logo, other.x_logo, ctx, path, ".x-logo");
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Logo {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.background_color,
+            other.background_color,
+            ctx,
+            path,
+            ".backgroundColor",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.alt_text,
+            other.alt_text,
+            ctx,
+            path,
+            ".altText",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.href,
+            other.href,
+            ctx,
+            path,
+            ".href",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.email,
+            other.email,
+            ctx,
+            path,
+            ".email",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.identifier,
+            other.identifier,
+            ctx,
+            path,
+            ".identifier",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Discriminator {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.property_name,
+            other.property_name,
+            ctx,
+            path,
+            ".propertyName",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        // mapping is Option<BTreeMap<String,String>>; per-key incoming wins.
+        if let Some(other_map) = other.mapping {
+            let base_map = self
+                .mapping
+                .get_or_insert_with(std::collections::BTreeMap::new);
+            for (k, v) in other_map {
+                match base_map.get_mut(&k) {
+                    None => {
+                        base_map.insert(k, v);
+                    }
+                    Some(existing) => {
+                        if *existing != v {
+                            let original_len = path.len();
+                            path.push_str(".mapping.");
+                            path.push_str(&k);
+                            let take =
+                                ctx.should_take_incoming(path, ConflictKind::ScalarOverridden);
+                            path.truncate(original_len);
+                            if take {
+                                *existing = v;
+                            }
+                        }
+                    }
+                }
+                // ErrorOnConflict: bail on the first collision; matches
+                // the OAuth scopes loop and the documented "first real
+                // collision triggers early error" contract.
+                if ctx.errored {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for XML {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.namespace,
+            other.namespace,
+            ctx,
+            path,
+            ".namespace",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.prefix,
+            other.prefix,
+            ctx,
+            path,
+            ".prefix",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.attribute,
+            other.attribute,
+            ctx,
+            path,
+            ".attribute",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.wrapped,
+            other.wrapped,
+            ctx,
+            path,
+            ".wrapped",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.url,
+            other.url,
+            ctx,
+            path,
+            ".url",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        // v3.1 Server has no `name` (added in v3.2).
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.variables,
+            other.variables,
+            ctx,
+            path,
+            ".variables",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// ----- SecurityScheme -----
+
+impl MergeWithContext<()> for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        match (self, other) {
+            (SecurityScheme::ApiKey(a), SecurityScheme::ApiKey(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::HTTP(a), SecurityScheme::HTTP(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::OAuth2(a), SecurityScheme::OAuth2(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::OpenIdConnect(a), SecurityScheme::OpenIdConnect(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (SecurityScheme::MutualTLS(a), SecurityScheme::MutualTLS(b)) => {
+                a.merge_with_context(*b, ctx, path)
+            }
+            (slot, incoming) => {
+                if ctx.should_take_incoming(path, ConflictKind::ParameterVariantMismatch) {
+                    *slot = incoming;
+                }
+            }
+        }
+    }
+}
+
+impl MergeWithContext<()> for ApiKeySecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.name,
+            other.name,
+            ctx,
+            path,
+            ".name",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.location,
+            other.location,
+            ctx,
+            path,
+            ".in",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for HttpSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.scheme,
+            other.scheme,
+            ctx,
+            path,
+            ".scheme",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.bearer_format,
+            other.bearer_format,
+            ctx,
+            path,
+            ".bearerFormat",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for MutualTLSSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_required_scalar(
+            &mut self.open_id_connect_url,
+            other.open_id_connect_url,
+            ctx,
+            path,
+            ".openIdConnectUrl",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for OAuth2SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        {
+            let mut guard = PathGuard::new(path, ".flows");
+            self.flows
+                .merge_with_context(other.flows, ctx, guard.path_mut());
+        }
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+impl MergeWithContext<()> for OAuth2Flows {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_struct(&mut self.implicit, other.implicit, ctx, path, ".implicit");
+        merge_opt_struct(&mut self.password, other.password, ctx, path, ".password");
+        merge_opt_struct(
+            &mut self.client_credentials,
+            other.client_credentials,
+            ctx,
+            path,
+            ".clientCredentials",
+        );
+        merge_opt_struct(
+            &mut self.authorization_code,
+            other.authorization_code,
+            ctx,
+            path,
+            ".authorizationCode",
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+/// Each OAuth flow has the same shape: optional URL fields + a bare
+/// `BTreeMap<String, String>` of scopes + extensions. Macro keeps it
+/// from sprawling.
+macro_rules! oauth_flow_merge {
+    ($t:ty, $($url_field:ident => $url_path:literal),* $(,)?) => {
+        impl MergeWithContext<()> for $t {
+            fn merge_with_context(
+                &mut self,
+                other: Self,
+                ctx: &mut MergeContext<()>,
+                path: &mut String,
+            ) {
+                if ctx.errored { return; }
+                $(
+                    merge_required_scalar(
+                        &mut self.$url_field,
+                        other.$url_field,
+                        ctx,
+                        path,
+                        concat!(".", $url_path),
+                        ConflictKind::RequiredScalarOverridden,
+                    );
+                )*
+                merge_opt_scalar(
+                    &mut self.refresh_url,
+                    other.refresh_url,
+                    ctx,
+                    path,
+                    ".refreshUrl",
+                    ConflictKind::ScalarOverridden,
+                );
+                // scopes is a bare BTreeMap<String, String>.
+                for (k, v) in other.scopes {
+                    match self.scopes.get_mut(&k) {
+                        None => {
+                            self.scopes.insert(k, v);
+                        }
+                        Some(existing) => {
+                            if *existing != v {
+                                let original_len = path.len();
+                                path.push_str(".scopes.");
+                                path.push_str(&k);
+                                let take = ctx.should_take_incoming(
+                                    path,
+                                    ConflictKind::ScalarOverridden,
+                                );
+                                path.truncate(original_len);
+                                if take {
+                                    *existing = v;
+                                }
+                                if ctx.errored {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                merge_extensions(
+                    &mut self.extensions,
+                    other.extensions,
+                    ctx,
+                    path,
+                    ".extensions",
+                );
+            }
+        }
+    };
+}
+
+oauth_flow_merge!(ImplicitOAuth2Flow, authorization_url => "authorizationUrl");
+oauth_flow_merge!(PasswordOAuth2Flow, token_url => "tokenUrl");
+oauth_flow_merge!(ClientCredentialsOAuth2Flow, token_url => "tokenUrl");
+oauth_flow_merge!(
+    AuthorizationCodeOAuth2Flow,
+    authorization_url => "authorizationUrl",
+    token_url => "tokenUrl",
+);
+
+// ----- Schema -----
+
+impl MergeWithContext<()> for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        // ObjectSchema deep-merge is the one variant pairing that
+        // recurses — everything else falls back to leaf-replace.
+        //
+        // Take ownership of `other` up front so the match is on owned
+        // values, avoiding the borrow-then-re-destructure dance that
+        // previously needed three `unreachable!()` guards. If the
+        // variants don't match, the bound-once `incoming` is reused
+        // for the leaf-replace fallback below.
+        if ctx.is_option(MergeOptions::DeepMergeObjectSchemas)
+            && let Schema::Single(self_single) = self
+            && let SingleSchema::Object(self_obj) = self_single.as_mut()
+        {
+            match other {
+                Schema::Single(other_single) => match *other_single {
+                    SingleSchema::Object(other_obj) => {
+                        self_obj.merge_with_context(other_obj, ctx, path);
+                        return;
+                    }
+                    other_single_inner => {
+                        // Re-box and fall through to leaf-replace.
+                        return leaf_replace_schema(
+                            self,
+                            Schema::Single(Box::new(other_single_inner)),
+                            ctx,
+                            path,
+                        );
+                    }
+                },
+                non_single => {
+                    return leaf_replace_schema(self, non_single, ctx, path);
+                }
+            }
+        }
+        leaf_replace_schema(self, other, ctx, path);
+    }
+}
+
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+    if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
+        *base = other;
+    }
+}
+
+/// Record a collision where the documented contract says "base is
+/// kept" — used for `Spec.info` / `Spec.openapi` when `MergeInfo` is
+/// off. Records `Resolution::Base` in the default / `BaseWins` modes
+/// (reflecting what actually happened), and trips
+/// `ErrorOnConflict` when set. Pushes `segment` onto `path` only
+/// when actually recording, keeping the eager-allocation
+/// regression off the non-conflict path.
+fn record_kept_base_or_error(
+    ctx: &mut MergeContext<()>,
+    path: &mut String,
+    segment: &str,
+    kind: ConflictKind,
+) {
+    let original_len = path.len();
+    path.push_str(segment);
+    if ctx.is_option(MergeOptions::ErrorOnConflict) {
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
+        ctx.errored = true;
+    } else {
+        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
+    }
+    path.truncate(original_len);
+}
+
+impl MergeWithContext<()> for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+        if ctx.errored {
+            return;
+        }
+        merge_opt_scalar(
+            &mut self.title,
+            other.title,
+            ctx,
+            path,
+            ".title",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_map(
+            &mut self.properties,
+            other.properties,
+            ctx,
+            path,
+            ".properties",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_map(
+            &mut self.pattern_properties,
+            other.pattern_properties,
+            ctx,
+            path,
+            ".patternProperties",
+            |b, i, c, p| b.merge_with_context(i, c, p),
+            key_str,
+        );
+        merge_opt_scalar(
+            &mut self.default,
+            other.default,
+            ctx,
+            path,
+            ".default",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.max_properties,
+            other.max_properties,
+            ctx,
+            path,
+            ".maxProperties",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.min_properties,
+            other.min_properties,
+            ctx,
+            path,
+            ".minProperties",
+            ConflictKind::ScalarOverridden,
+        );
+        match (&mut self.additional_properties, other.additional_properties) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".additionalProperties");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        match (
+            &mut self.unevaluated_properties,
+            other.unevaluated_properties,
+        ) {
+            (_, None) => {}
+            (slot @ None, Some(v)) => *slot = Some(v),
+            (Some(b), Some(i)) => {
+                let mut guard = PathGuard::new(path, ".unevaluatedProperties");
+                b.merge_with_context(i, ctx, guard.path_mut());
+            }
+        }
+        merge_schema_field(
+            &mut self.property_names,
+            other.property_names,
+            ctx,
+            path,
+            "propertyNames",
+        );
+        merge_opt_vec_set_union(&mut self.required, other.required, ctx, path, ".required");
+        merge_opt_scalar(
+            &mut self.read_only,
+            other.read_only,
+            ctx,
+            path,
+            ".readOnly",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.write_only,
+            other.write_only,
+            ctx,
+            path,
+            ".writeOnly",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.deprecated,
+            other.deprecated,
+            ctx,
+            path,
+            ".deprecated",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_struct(&mut self.xml, other.xml, ctx, path, ".xml");
+        merge_opt_struct(
+            &mut self.external_docs,
+            other.external_docs,
+            ctx,
+            path,
+            ".externalDocs",
+        );
+        merge_opt_scalar(
+            &mut self.example,
+            other.example,
+            ctx,
+            path,
+            ".example",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.examples,
+            other.examples,
+            ctx,
+            path,
+            ".examples",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
+// Schema sub-types (StringSchema, IntegerSchema, …, SingleSchema)
+// don't need their own `MergeWithContext<()>` impls — `Schema`'s impl
+// handles the entire enum at the top level via `leaf_replace_schema`
+// for any pairing other than `Single(Object(_))` × `Single(Object(_))`.
+// Nothing in the codebase holds a `RefOr<StringSchema>` or
+// `&mut SingleSchema` directly, so the per-variant impls would be
+// dead code.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merge::{ConflictKind, MergeOptions, Resolution};
+    use std::collections::BTreeMap;
+
+    fn root_path() -> String {
+        "#".to_owned()
+    }
+
+    fn report<S: MergeWithContext<()>>(
+        base: &mut S,
+        incoming: S,
+        opts: EnumSet<MergeOptions>,
+    ) -> Vec<crate::merge::MergeConflict> {
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut path = root_path();
+        base.merge_with_context(incoming, &mut ctx, &mut path);
+        ctx.conflicts
+    }
+
+    fn param_path(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Path(Box::new(InPath {
+            name: name.into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn param_query(name: &str) -> RefOr<Parameter> {
+        RefOr::new_item(Parameter::Query(Box::new(InQuery {
+            name: name.into(),
+            description: None,
+            required: None,
+            deprecated: None,
+            allow_empty_value: None,
+            style: None,
+            explode: None,
+            allow_reserved: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        })))
+    }
+
+    fn response_with(description: &str) -> RefOr<Response> {
+        RefOr::new_item(Response {
+            description: description.into(),
+            ..Default::default()
+        })
+    }
+
+    // ---- Spec roll-up ----
+
+    #[test]
+    fn spec_default_incoming_wins() {
+        let mut base = Spec {
+            json_schema_dialect: Some("base".into()),
+            ..Default::default()
+        };
+        let report = base
+            .merge(
+                Spec {
+                    json_schema_dialect: Some("incoming".into()),
+                    ..Default::default()
+                },
+                MergeOptions::new(),
+            )
+            .unwrap();
+        assert_eq!(base.json_schema_dialect.as_deref(), Some("incoming"));
+        assert!(!report.conflicts.is_empty());
+    }
+
+    #[test]
+    fn spec_error_on_conflict_returns_err_and_rolls_back() {
+        let mut base = Spec {
+            json_schema_dialect: Some("base".into()),
+            ..Default::default()
+        };
+        let result = base.merge(
+            Spec {
+                json_schema_dialect: Some("incoming".into()),
+                ..Default::default()
+            },
+            MergeOptions::ErrorOnConflict.only(),
+        );
+        assert!(result.is_err());
+        assert_eq!(base.json_schema_dialect.as_deref(), Some("base"));
+    }
+
+    #[test]
+    fn spec_base_wins_records_resolution_base() {
+        let mut base = Spec {
+            json_schema_dialect: Some("base".into()),
+            ..Default::default()
+        };
+        let report = base
+            .merge(
+                Spec {
+                    json_schema_dialect: Some("incoming".into()),
+                    ..Default::default()
+                },
+                MergeOptions::BaseWins.only(),
+            )
+            .unwrap();
+        assert_eq!(base.json_schema_dialect.as_deref(), Some("base"));
+        assert_eq!(report.conflicts[0].resolution, Resolution::Base);
+    }
+
+    #[test]
+    fn spec_paths_deep_merge_preserves_unrelated_methods() {
+        let mk_pi = |method: &str| PathItem {
+            operations: Some(BTreeMap::from([(method.to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let mut base = Spec {
+            paths: Some(Paths {
+                paths: BTreeMap::from([("/pets".to_owned(), mk_pi("get"))]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                paths: Some(Paths {
+                    paths: BTreeMap::from([("/pets".to_owned(), mk_pi("post"))]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        )
+        .unwrap();
+        let pi = &base.paths.unwrap().paths["/pets"];
+        let ops = pi.operations.as_ref().unwrap();
+        assert!(ops.contains_key("get"));
+        assert!(ops.contains_key("post"));
+    }
+
+    #[test]
+    fn spec_info_kept_on_base_by_default() {
+        let mut base = Spec {
+            info: Info {
+                title: "Base API".into(),
+                version: "1.0.0".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let report = base
+            .merge(
+                Spec {
+                    info: Info {
+                        title: "Incoming".into(),
+                        version: "2.0.0".into(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                MergeOptions::new(),
+            )
+            .unwrap();
+        assert_eq!(base.info.title, "Base API");
+        assert!(
+            report
+                .conflicts
+                .iter()
+                .any(|c| c.path.ends_with(".info") && c.resolution == Resolution::Base)
+        );
+    }
+
+    #[test]
+    fn spec_info_merged_under_merge_info_option() {
+        let mut base = Spec {
+            info: Info {
+                title: "Base".into(),
+                version: "1.0.0".into(),
+                description: Some("base desc".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                info: Info {
+                    title: "Base".into(),
+                    version: "1.0.0".into(),
+                    summary: Some("from incoming".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            MergeOptions::MergeInfo.only(),
+        )
+        .unwrap();
+        assert_eq!(base.info.description.as_deref(), Some("base desc"));
+        assert_eq!(base.info.summary.as_deref(), Some("from incoming"));
+    }
+
+    // ---- v3.1-specific: x_tag_groups ----
+
+    #[test]
+    fn spec_x_tag_groups_dedup_by_name() {
+        let mut base = Spec {
+            x_tag_groups: Some(vec![TagGroup {
+                name: "auth".into(),
+                tags: vec!["login".into(), "logout".into()],
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        base.merge(
+            Spec {
+                x_tag_groups: Some(vec![
+                    TagGroup {
+                        name: "auth".into(),
+                        tags: vec!["refresh".into()],
+                        ..Default::default()
+                    },
+                    TagGroup {
+                        name: "users".into(),
+                        tags: vec!["create".into()],
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        )
+        .unwrap();
+        let groups = base.x_tag_groups.unwrap();
+        assert_eq!(groups.len(), 2);
+        let auth = groups.iter().find(|g| g.name == "auth").unwrap();
+        // tags union: login, logout, refresh
+        assert_eq!(auth.tags.len(), 3);
+    }
+
+    // ---- v3.1-specific: x_logo on Info ----
+
+    #[test]
+    fn info_x_logo_merges_when_both_some() {
+        let mut base = Info {
+            title: "T".into(),
+            version: "1".into(),
+            x_logo: Some(Logo {
+                url: "https://a.png".into(),
+                alt_text: Some("base alt".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Info {
+                title: "T".into(),
+                version: "1".into(),
+                x_logo: Some(Logo {
+                    url: "https://b.png".into(),
+                    href: Some("https://b".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let logo = base.x_logo.unwrap();
+        assert_eq!(logo.url, "https://b.png");
+        assert_eq!(logo.alt_text.as_deref(), Some("base alt"));
+        assert_eq!(logo.href.as_deref(), Some("https://b"));
+    }
+
+    // ---- v3.1-specific: x_code_samples on Operation ----
+
+    #[test]
+    fn operation_x_code_samples_dedup_by_lang_label() {
+        let mut base = Operation {
+            x_code_samples: Some(vec![CodeSample {
+                lang: "curl".into(),
+                label: Some("basic".into()),
+                source: "curl https://a".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                x_code_samples: Some(vec![
+                    // Same (lang, label) — dedup recurses + replaces source.
+                    CodeSample {
+                        lang: "curl".into(),
+                        label: Some("basic".into()),
+                        source: "curl https://b".into(),
+                        ..Default::default()
+                    },
+                    // Different label — appended.
+                    CodeSample {
+                        lang: "curl".into(),
+                        label: Some("auth".into()),
+                        source: "curl -H ...".into(),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let samples = base.x_code_samples.unwrap();
+        assert_eq!(samples.len(), 2);
+        let basic = samples
+            .iter()
+            .find(|s| s.label.as_deref() == Some("basic"))
+            .unwrap();
+        assert_eq!(basic.source, "curl https://b");
+    }
+
+    #[test]
+    fn operation_x_tags_set_union() {
+        let mut base = Operation {
+            x_tags: Some(vec!["a".into(), "b".into()]),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                x_tags: Some(vec!["b".into(), "c".into()]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let tags = base.x_tags.unwrap();
+        assert_eq!(tags, vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]);
+    }
+
+    // ---- v3.1-specific: Tag.x_display_name ----
+
+    #[test]
+    fn tag_x_display_name_merges() {
+        let mut base = Tag {
+            name: "pets".into(),
+            x_display_name: Some("Pet API".into()),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Tag {
+                name: "pets".into(),
+                x_display_name: Some("Pets!".into()),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.x_display_name.as_deref(), Some("Pets!"));
+    }
+
+    // ---- RefOr ----
+
+    #[test]
+    fn refor_item_item_recurses() {
+        let mut base: RefOr<Tag> = RefOr::new_item(Tag {
+            name: "pets".into(),
+            description: Some("base".into()),
+            ..Default::default()
+        });
+        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut path = root_path();
+        base.merge_with_context(
+            RefOr::new_item(Tag {
+                name: "pets".into(),
+                description: Some("inc".into()),
+                ..Default::default()
+            }),
+            &mut ctx,
+            &mut path,
+        );
+        match base {
+            RefOr::Item(t) => assert_eq!(t.description.as_deref(), Some("inc")),
+            _ => panic!(),
+        }
+    }
+
+    // ---- Operation: responses, parameters dedup, method coexistence ----
+
+    #[test]
+    fn operation_responses_keeps_base_status_codes() {
+        let mut base = Operation {
+            responses: Some(Responses {
+                responses: Some(BTreeMap::from([
+                    ("200".into(), response_with("ok")),
+                    ("404".into(), response_with("missing")),
+                ])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                responses: Some(Responses {
+                    responses: Some(BTreeMap::from([
+                        ("200".into(), response_with("ok updated")),
+                        ("500".into(), response_with("err")),
+                    ])),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let r = base.responses.unwrap().responses.unwrap();
+        assert!(r.contains_key("200"));
+        assert!(r.contains_key("404"));
+        assert!(r.contains_key("500"));
+    }
+
+    #[test]
+    fn operation_parameters_dedup_by_name_in() {
+        let mut base = Operation {
+            parameters: Some(vec![param_path("id"), param_query("limit")]),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            Operation {
+                parameters: Some(vec![param_path("id"), param_query("filter")]),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        assert_eq!(base.parameters.unwrap().len(), 3);
+    }
+
+    #[test]
+    fn path_item_get_and_post_coexist() {
+        let mut base = PathItem {
+            operations: Some(BTreeMap::from([("get".to_owned(), Operation::default())])),
+            ..Default::default()
+        };
+        let _ = report(
+            &mut base,
+            PathItem {
+                operations: Some(BTreeMap::from([("post".to_owned(), Operation::default())])),
+                ..Default::default()
+            },
+            MergeOptions::new(),
+        );
+        let ops = base.operations.unwrap();
+        assert!(ops.contains_key("get") && ops.contains_key("post"));
+    }
+
+    // ---- Schema deep merge ----
+
+    #[test]
+    fn schema_object_deep_merge_under_option() {
+        let mut base = Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+            properties: Some(BTreeMap::from([(
+                "a".to_owned(),
+                RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                    ObjectSchema::default(),
+                )))),
+            )])),
+            required: Some(vec!["a".into()]),
+            ..Default::default()
+        })));
+        let _ = report(
+            &mut base,
+            Schema::Single(Box::new(SingleSchema::Object(ObjectSchema {
+                properties: Some(BTreeMap::from([(
+                    "b".to_owned(),
+                    RefOr::new_item(Schema::Single(Box::new(SingleSchema::Object(
+                        ObjectSchema::default(),
+                    )))),
+                )])),
+                required: Some(vec!["b".into()]),
+                ..Default::default()
+            }))),
+            MergeOptions::DeepMergeObjectSchemas.only(),
+        );
+        let Schema::Single(box_s) = &base else {
+            panic!()
+        };
+        let SingleSchema::Object(obj) = &**box_s else {
+            panic!()
+        };
+        let props = obj.properties.as_ref().unwrap();
+        assert!(props.contains_key("a") && props.contains_key("b"));
+        let req = obj.required.as_ref().unwrap();
+        assert!(req.contains(&"a".to_owned()) && req.contains(&"b".to_owned()));
+    }
+
+    // ---- Parameter variant mismatch ----
+
+    #[test]
+    fn parameter_variant_mismatch_replaces() {
+        let mut base = Parameter::Path(Box::new(InPath {
+            name: "id".into(),
+            description: None,
+            required: true,
+            deprecated: None,
+            style: None,
+            explode: None,
+            schema: None,
+            example: None,
+            examples: None,
+            content: None,
+            extensions: None,
+        }));
+        let conflicts = report(
+            &mut base,
+            Parameter::Query(Box::new(InQuery {
+                name: "id".into(),
+                description: None,
+                required: None,
+                deprecated: None,
+                allow_empty_value: None,
+                style: None,
+                explode: None,
+                allow_reserved: None,
+                schema: None,
+                example: None,
+                examples: None,
+                content: None,
+                extensions: None,
+            })),
+            MergeOptions::new(),
+        );
+        assert!(matches!(base, Parameter::Query(_)));
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].kind, ConflictKind::ParameterVariantMismatch);
+    }
+}

--- a/crates/roas/src/v3_1/server.rs
+++ b/crates/roas/src/v3_1/server.rs
@@ -145,6 +145,52 @@ impl ValidateWithContext<Spec> for ServerVariable {
     }
 }
 
+impl crate::merge::MergeWithContext<()> for ServerVariable {
+    fn merge_with_context(
+        &mut self,
+        other: Self,
+        ctx: &mut crate::merge::MergeContext<()>,
+        path: &mut String,
+    ) {
+        if ctx.errored {
+            return;
+        }
+        use crate::common::merge::{merge_extensions, merge_opt_scalar, merge_required_scalar};
+        use crate::merge::ConflictKind;
+        merge_opt_scalar(
+            &mut self.enum_values,
+            other.enum_values,
+            ctx,
+            path,
+            ".enum",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_required_scalar(
+            &mut self.default,
+            other.default,
+            ctx,
+            path,
+            ".default",
+            ConflictKind::RequiredScalarOverridden,
+        );
+        merge_opt_scalar(
+            &mut self.description,
+            other.description,
+            ctx,
+            path,
+            ".description",
+            ConflictKind::ScalarOverridden,
+        );
+        merge_extensions(
+            &mut self.extensions,
+            other.extensions,
+            ctx,
+            path,
+            ".extensions",
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/roas/src/v3_1/server.rs
+++ b/crates/roas/src/v3_1/server.rs
@@ -145,11 +145,11 @@ impl ValidateWithContext<Spec> for ServerVariable {
     }
 }
 
-impl crate::merge::MergeWithContext<()> for ServerVariable {
+impl crate::merge::MergeWithContext for ServerVariable {
     fn merge_with_context(
         &mut self,
         other: Self,
-        ctx: &mut crate::merge::MergeContext<()>,
+        ctx: &mut crate::merge::MergeContext,
         path: &mut String,
     ) {
         if ctx.errored {

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -21,7 +21,7 @@ use enumset::EnumSet;
 use crate::common::merge::{
     PathGuard, merge_extensions, merge_opt_map, merge_opt_scalar, merge_opt_struct,
     merge_opt_vec_by_key, merge_opt_vec_set_union, merge_replace_list_when_nonempty,
-    merge_required_scalar,
+    merge_required_scalar, record_kept_base_or_error,
 };
 use crate::common::reference::RefOr;
 use crate::merge::{
@@ -2362,30 +2362,6 @@ fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext,
     if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
         *base = other;
     }
-}
-
-/// Record a collision where the documented contract says "base is
-/// kept" — used for `Spec.info` / `Spec.openapi` when `MergeInfo` is
-/// off. Records `Resolution::Base` in the default / `BaseWins` modes
-/// (reflecting what actually happened), and trips
-/// `ErrorOnConflict` when set. Pushes `segment` onto `path` only
-/// when actually recording, keeping the eager-allocation
-/// regression off the non-conflict path.
-fn record_kept_base_or_error(
-    ctx: &mut MergeContext,
-    path: &mut String,
-    segment: &str,
-    kind: ConflictKind,
-) {
-    let original_len = path.len();
-    path.push_str(segment);
-    if ctx.is_option(MergeOptions::ErrorOnConflict) {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Errored);
-        ctx.errored = true;
-    } else {
-        ctx.record(path.clone(), kind, crate::merge::Resolution::Base);
-    }
-    path.truncate(original_len);
 }
 
 impl MergeWithContext for ObjectSchema {

--- a/crates/roas/src/v3_2/merge.rs
+++ b/crates/roas/src/v3_2/merge.rs
@@ -85,7 +85,7 @@ impl Merge for Spec {
         // dereferencing happens during merge). Carrying the borrow as
         // a unit `&()` keeps the type generic without forcing the
         // caller to clone the base before merging into it.
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), options);
+        let mut ctx: MergeContext = MergeContext::new(options);
         // Single owned `String` for the whole merge — every child
         // pushes/truncates segments onto it via the helper guards.
         let mut path = String::from("#");
@@ -99,7 +99,7 @@ impl Merge for Spec {
             // `ErrorOnConflict` to get. The clone cost is paid only
             // when the option is opted in.
             let mut working = self.clone();
-            <Spec as MergeWithContext<()>>::merge_with_context(
+            <Spec as MergeWithContext>::merge_with_context(
                 &mut working,
                 other,
                 &mut ctx,
@@ -119,15 +119,15 @@ impl Merge for Spec {
         // Non-strict modes mutate `self` in place — the report still
         // captures every resolution, so callers wanting "see what
         // changed" don't need the clone-and-replace overhead.
-        <Spec as MergeWithContext<()>>::merge_with_context(self, other, &mut ctx, &mut path);
+        <Spec as MergeWithContext>::merge_with_context(self, other, &mut ctx, &mut path);
         ctx.into()
     }
 }
 
 // ----- Top-level Spec -----
 
-impl MergeWithContext<()> for Spec {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Spec {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -235,8 +235,8 @@ impl MergeWithContext<()> for Spec {
 
 // ----- Containers -----
 
-impl MergeWithContext<()> for Components {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Components {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -349,8 +349,8 @@ impl MergeWithContext<()> for Components {
     }
 }
 
-impl MergeWithContext<()> for Paths {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Paths {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -379,8 +379,8 @@ impl MergeWithContext<()> for Paths {
     }
 }
 
-impl MergeWithContext<()> for Callback {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Callback {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -409,8 +409,8 @@ impl MergeWithContext<()> for Callback {
     }
 }
 
-impl MergeWithContext<()> for PathItem {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for PathItem {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -479,8 +479,8 @@ impl MergeWithContext<()> for PathItem {
     }
 }
 
-impl MergeWithContext<()> for Responses {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Responses {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -513,8 +513,8 @@ impl MergeWithContext<()> for Responses {
     }
 }
 
-impl MergeWithContext<()> for Operation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Operation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -630,8 +630,8 @@ fn parameter_ref_key(p: &RefOr<Parameter>) -> (String, &'static str) {
     }
 }
 
-impl MergeWithContext<()> for Parameter {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Parameter {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -652,8 +652,8 @@ impl MergeWithContext<()> for Parameter {
     }
 }
 
-impl MergeWithContext<()> for InPath {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InPath {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -734,8 +734,8 @@ impl MergeWithContext<()> for InPath {
     }
 }
 
-impl MergeWithContext<()> for InQuery {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InQuery {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -832,8 +832,8 @@ impl MergeWithContext<()> for InQuery {
     }
 }
 
-impl MergeWithContext<()> for InHeader {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InHeader {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -914,8 +914,8 @@ impl MergeWithContext<()> for InHeader {
     }
 }
 
-impl MergeWithContext<()> for InCookie {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InCookie {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -996,8 +996,8 @@ impl MergeWithContext<()> for InCookie {
     }
 }
 
-impl MergeWithContext<()> for InQuerystring {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for InQuerystring {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1074,7 +1074,7 @@ impl MergeWithContext<()> for InQuerystring {
 fn merge_schema_field(
     base: &mut Option<RefOr<Schema>>,
     other: Option<RefOr<Schema>>,
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut String,
     field_name: &str,
 ) {
@@ -1096,8 +1096,8 @@ fn merge_schema_field(
 
 // ----- MediaType / Encoding / Header / Response / RequestBody / Example / Link -----
 
-impl MergeWithContext<()> for MediaType {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for MediaType {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1169,8 +1169,8 @@ impl MergeWithContext<()> for MediaType {
     }
 }
 
-impl MergeWithContext<()> for Encoding {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Encoding {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1249,8 +1249,8 @@ impl MergeWithContext<()> for Encoding {
     }
 }
 
-impl MergeWithContext<()> for Header {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Header {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1331,8 +1331,8 @@ impl MergeWithContext<()> for Header {
     }
 }
 
-impl MergeWithContext<()> for Response {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Response {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1389,8 +1389,8 @@ impl MergeWithContext<()> for Response {
     }
 }
 
-impl MergeWithContext<()> for RequestBody {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for RequestBody {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1435,8 +1435,8 @@ impl MergeWithContext<()> for RequestBody {
     }
 }
 
-impl MergeWithContext<()> for Example {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Example {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1498,8 +1498,8 @@ impl MergeWithContext<()> for Example {
     }
 }
 
-impl MergeWithContext<()> for Link {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Link {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1558,8 +1558,8 @@ impl MergeWithContext<()> for Link {
 // ----- Leaves: Tag, Info, Contact, License, ExternalDocumentation,
 //                Discriminator, XML, Server, ServerVariable -----
 
-impl MergeWithContext<()> for Tag {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Tag {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1620,8 +1620,8 @@ impl MergeWithContext<()> for Tag {
     }
 }
 
-impl MergeWithContext<()> for Info {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Info {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1677,8 +1677,8 @@ impl MergeWithContext<()> for Info {
     }
 }
 
-impl MergeWithContext<()> for Contact {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Contact {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1716,8 +1716,8 @@ impl MergeWithContext<()> for Contact {
     }
 }
 
-impl MergeWithContext<()> for License {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for License {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1755,8 +1755,8 @@ impl MergeWithContext<()> for License {
     }
 }
 
-impl MergeWithContext<()> for ExternalDocumentation {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ExternalDocumentation {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1786,8 +1786,8 @@ impl MergeWithContext<()> for ExternalDocumentation {
     }
 }
 
-impl MergeWithContext<()> for Discriminator {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Discriminator {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1842,8 +1842,8 @@ impl MergeWithContext<()> for Discriminator {
     }
 }
 
-impl MergeWithContext<()> for XML {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for XML {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1905,8 +1905,8 @@ impl MergeWithContext<()> for XML {
     }
 }
 
-impl MergeWithContext<()> for Server {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Server {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1955,8 +1955,8 @@ impl MergeWithContext<()> for Server {
 
 // ----- SecurityScheme -----
 
-impl MergeWithContext<()> for SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -1985,8 +1985,8 @@ impl MergeWithContext<()> for SecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for ApiKeySecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ApiKeySecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2032,8 +2032,8 @@ impl MergeWithContext<()> for ApiKeySecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for HttpSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for HttpSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2079,8 +2079,8 @@ impl MergeWithContext<()> for HttpSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for MutualTLSSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for MutualTLSSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2110,8 +2110,8 @@ impl MergeWithContext<()> for MutualTLSSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OpenIdConnectSecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2149,8 +2149,8 @@ impl MergeWithContext<()> for OpenIdConnectSecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OAuth2SecurityScheme {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OAuth2SecurityScheme {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2193,8 +2193,8 @@ impl MergeWithContext<()> for OAuth2SecurityScheme {
     }
 }
 
-impl MergeWithContext<()> for OAuth2Flows {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for OAuth2Flows {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2236,11 +2236,11 @@ impl MergeWithContext<()> for OAuth2Flows {
 /// from sprawling.
 macro_rules! oauth_flow_merge {
     ($t:ty, $($url_field:ident => $url_path:literal),* $(,)?) => {
-        impl MergeWithContext<()> for $t {
+        impl MergeWithContext for $t {
             fn merge_with_context(
                 &mut self,
                 other: Self,
-                ctx: &mut MergeContext<()>,
+                ctx: &mut MergeContext,
                 path: &mut String,
             ) {
                 if ctx.errored { return; }
@@ -2316,8 +2316,8 @@ oauth_flow_merge!(
 
 // ----- Schema -----
 
-impl MergeWithContext<()> for Schema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for Schema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2358,7 +2358,7 @@ impl MergeWithContext<()> for Schema {
     }
 }
 
-fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<()>, path: &str) {
+fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext, path: &str) {
     if *base != other && ctx.should_take_incoming(path, ConflictKind::SchemaLeafReplaced) {
         *base = other;
     }
@@ -2372,7 +2372,7 @@ fn leaf_replace_schema(base: &mut Schema, other: Schema, ctx: &mut MergeContext<
 /// when actually recording, keeping the eager-allocation
 /// regression off the non-conflict path.
 fn record_kept_base_or_error(
-    ctx: &mut MergeContext<()>,
+    ctx: &mut MergeContext,
     path: &mut String,
     segment: &str,
     kind: ConflictKind,
@@ -2388,8 +2388,8 @@ fn record_kept_base_or_error(
     path.truncate(original_len);
 }
 
-impl MergeWithContext<()> for ObjectSchema {
-    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext<()>, path: &mut String) {
+impl MergeWithContext for ObjectSchema {
+    fn merge_with_context(&mut self, other: Self, ctx: &mut MergeContext, path: &mut String) {
         if ctx.errored {
             return;
         }
@@ -2537,7 +2537,7 @@ impl MergeWithContext<()> for ObjectSchema {
 }
 
 // Schema sub-types (StringSchema, IntegerSchema, …, SingleSchema)
-// don't need their own `MergeWithContext<()>` impls — `Schema`'s impl
+// don't need their own `MergeWithContext` impls — `Schema`'s impl
 // handles the entire enum at the top level via `leaf_replace_schema`
 // for any pairing other than `Single(Object(_))` × `Single(Object(_))`.
 // Nothing in the codebase holds a `RefOr<StringSchema>` or
@@ -2613,7 +2613,7 @@ mod tests {
             summary: Some("from incoming".into()),
             ..Default::default()
         });
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.tags[pets]");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         match base {
@@ -2637,7 +2637,7 @@ mod tests {
             summary: None,
             description: Some("new desc".into()),
         }));
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         match base {
@@ -2654,7 +2654,7 @@ mod tests {
     fn refor_ref_ref_different_target_replaces_and_records() {
         let mut base: RefOr<Tag> = RefOr::Ref(Box::new(Ref::new("#/components/tags/A")));
         let incoming: RefOr<Tag> = RefOr::Ref(Box::new(Ref::new("#/components/tags/B")));
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.tags[0]");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         match base {
@@ -2673,7 +2673,7 @@ mod tests {
             name: "x".into(),
             ..Default::default()
         });
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         assert!(matches!(base, RefOr::Item(_)));
@@ -2705,7 +2705,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.op");
         base.merge_with_context(incoming, &mut ctx, &mut path);
 
@@ -2733,7 +2733,7 @@ mod tests {
             parameters: Some(vec![param_path("id"), param_query("filter")]),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.op");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         let params = base.parameters.unwrap();
@@ -2752,7 +2752,7 @@ mod tests {
             operations: Some(BTreeMap::from([("post".to_owned(), Operation::default())])),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.paths[/pets]");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         let ops = base.operations.unwrap();
@@ -2772,7 +2772,7 @@ mod tests {
             required: Some(vec!["b".into()]),
             ..Default::default()
         })));
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.s");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         // Replaced — `required` is now from incoming.
@@ -2809,8 +2809,7 @@ mod tests {
             required: Some(vec!["b".into()]),
             ..Default::default()
         })));
-        let mut ctx: MergeContext<()> =
-            MergeContext::new(&(), MergeOptions::DeepMergeObjectSchemas.only());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::DeepMergeObjectSchemas.only());
         let mut path = String::from("#.s");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         let Schema::Single(box_single) = &base else {
@@ -2889,8 +2888,7 @@ mod tests {
             ])),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> =
-            MergeContext::new(&(), MergeOptions::ErrorOnConflict.only());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::ErrorOnConflict.only());
         let mut path = String::from("#.d");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         assert!(ctx.errored, "first mapping collision must trip errored");
@@ -3180,7 +3178,7 @@ mod tests {
             item_schema: Some(RefOr::new_item(s2)),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.mt");
         base.merge_with_context(incoming, &mut ctx, &mut path);
         // Conflict path should mention itemSchema, not schema.
@@ -3225,7 +3223,7 @@ mod tests {
             variables: Some(BTreeMap::from([("ver".to_owned(), incoming_var)])),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = String::from("#.srv");
         base_server.merge_with_context(incoming_server, &mut ctx, &mut path);
         let merged = base_server.variables.unwrap();
@@ -3339,19 +3337,19 @@ mod tests {
         "#".to_owned()
     }
 
-    fn run<S: MergeWithContext<()>>(mut base: S, incoming: S, opts: EnumSet<MergeOptions>) -> S {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+    fn run<S: MergeWithContext>(mut base: S, incoming: S, opts: EnumSet<MergeOptions>) -> S {
+        let mut ctx: MergeContext = MergeContext::new(opts);
         let mut path = root_path();
         base.merge_with_context(incoming, &mut ctx, &mut path);
         base
     }
 
-    fn report<S: MergeWithContext<()>>(
+    fn report<S: MergeWithContext>(
         base: &mut S,
         incoming: S,
         opts: EnumSet<MergeOptions>,
     ) -> Vec<crate::merge::MergeConflict> {
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), opts);
+        let mut ctx: MergeContext = MergeContext::new(opts);
         let mut path = root_path();
         base.merge_with_context(incoming, &mut ctx, &mut path);
         ctx.conflicts
@@ -4273,7 +4271,7 @@ mod tests {
             additional_properties: Some(BoolOr::Bool(false)),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         base.merge_with_context(incoming, &mut ctx, &mut path);
         assert!(matches!(
@@ -4293,7 +4291,7 @@ mod tests {
             unevaluated_properties: Some(BoolOr::Bool(false)),
             ..Default::default()
         };
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         let mut path = root_path();
         base.merge_with_context(incoming, &mut ctx, &mut path);
         assert!(matches!(
@@ -4862,7 +4860,7 @@ mod tests {
         // `if ctx.errored { return; }`. Pre-flip the flag, call the
         // impl, and confirm nothing mutated. Covers the entry-guard
         // return branches that otherwise sit dead.
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::new());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::new());
         ctx.errored = true;
         let mut path = root_path();
 
@@ -5251,7 +5249,7 @@ mod tests {
     fn base_wins_keeps_base_value_in_extensions() {
         let mut base: Option<BTreeMap<String, serde_json::Value>> =
             Some(BTreeMap::from([("x-a".into(), serde_json::json!(1))]));
-        let mut ctx: MergeContext<()> = MergeContext::new(&(), MergeOptions::BaseWins.only());
+        let mut ctx: MergeContext = MergeContext::new(MergeOptions::BaseWins.only());
         let mut path = root_path();
         crate::common::merge::merge_extensions(
             &mut base,

--- a/crates/roas/src/v3_2/server.rs
+++ b/crates/roas/src/v3_2/server.rs
@@ -162,11 +162,11 @@ impl ValidateWithContext<Spec> for ServerVariable {
 // alongside the type until those fields are exposed (or until we
 // move every component impl into its component file in a future
 // reorganization).
-impl crate::merge::MergeWithContext<()> for ServerVariable {
+impl crate::merge::MergeWithContext for ServerVariable {
     fn merge_with_context(
         &mut self,
         other: Self,
-        ctx: &mut crate::merge::MergeContext<()>,
+        ctx: &mut crate::merge::MergeContext,
         path: &mut String,
     ) {
         if ctx.errored {


### PR DESCRIPTION
Replicates the v3.2 `Spec::merge` to the other three spec versions. Same recursive `MergeWithContext` shape, three conflict modes (`IncomingWins` / `BaseWins` / `ErrorOnConflict`), clone-and-replace rollback for strict mode, `DeepMergeObjectSchemas` opt-in.

Per the dedup memory, per-version files stay duplicated — each version has its own `merge.rs` adapted to that version's actual shape.

### v3.1 (closest to v3.2)
Removes: `additional_operations`, `Parameter::Querystring`, `MediaType.item_schema` / `item_encoding` / `prefix_encoding`, `media_types` in Components, `pattern_properties` / `unevaluated_properties` / `property_names` on `ObjectSchema`, `DeviceAuthorizationOAuth2Flow`, `Tag.parent` / `Tag.kind` / `Tag.summary`, `Server.name`, `SecurityScheme.deprecated`, `OAuth2SecurityScheme.oauth2_metadata_url`, `Schema::Bool` / `Multi` / `Empty`.
Adds: `x_tag_groups`, `Info.x_logo` (`Logo` struct merge), `Operation.x_code_samples` (`CodeSample` struct merge), `Operation.x_tags`, `Tag.x_display_name`.

### v3.0
Above changes plus: `paths` is required (not `Option<Paths>`), no `webhooks`, no `json_schema_dialect`, no `path_items` in Components, no `MutualTLSSecurityScheme`, `Operation.responses` is required (not `Option<Responses>`), no `Info.summary`, no `License.identifier`. Adds `Response.x_summary`, `Operation.x_badges`, `Operation.x_examples`.

### v2 (largest divergence — written from scratch)
- `swagger` not `openapi`; `host` / `basePath` / `schemes` / `consumes` / `produces` instead of `servers`.
- No `components` — `definitions` / `parameters` / `responses` / `securityDefinitions` are top-level bare maps.
- Multi-level typed `Parameter` enum (`Body` / `Path` / `Query` / `Header` / `FormData`, each non-Body wrapping a typed inner enum). Outer dispatch recurses; inner typed structs leaf-replace.
- `Header` / `Items` are typed enums (leaf-replace).
- `Schema` without `Single` indirection; `ObjectSchema` deep-merge supported.
- Adds `x_servers`, `Operation.consumes` / `produces` / `schemes`, `Operation.x_code_samples`.

**1655 tests pass across all features**, clippy clean. Tests are per-version focused (~12-15 each) covering the three modes, component-impl roll-up, and version-specific fields.