### PR TITLE
chore(roas): bump to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "roas"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas/Cargo.toml
+++ b/crates/roas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Picks up the v2 / v3.0 / v3.1 `Spec::merge` ports from #186 — new public API surface on each per-version Spec.