### PR TITLE
feat(roas-overlay): add Overlay v1.0 parse / validate / apply

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -47,6 +47,10 @@ component_management:
       name: roas-http-fetcher
       paths:
         - crates/roas-http-fetcher/**
+    - component_id: roas-overlay
+      name: roas-overlay
+      paths:
+        - crates/roas-overlay/**
 
     # ---- per OpenAPI spec version (within the `roas` crate) ----
     - component_id: common
@@ -82,3 +86,17 @@ component_management:
         - crates/roas/src/v3_2.rs
         - crates/roas/src/v3_2/**
         - crates/roas/tests/v3_2_test.rs
+
+    # ---- per Overlay version (within the `roas-overlay` crate) ----
+    - component_id: overlay-common
+      name: overlay-common
+      paths:
+        - crates/roas-overlay/src/lib.rs
+        - crates/roas-overlay/src/apply.rs
+        - crates/roas-overlay/src/validation.rs
+        - crates/roas-overlay/src/common/**
+    - component_id: overlay-v1_0
+      name: overlay-v1.0
+      paths:
+        - crates/roas-overlay/src/v1_0/**
+        - crates/roas-overlay/tests/v1_0_test.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,12 +1296,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "enumset",
- "lazy-regex",
  "serde",
  "serde_json",
  "serde_json_path",
  "serde_yaml_ng",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +971,16 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify"
@@ -1266,6 +1291,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "roas-overlay"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "enumset",
+ "lazy-regex",
+ "serde",
+ "serde_json",
+ "serde_json_path",
+ "serde_yaml_ng",
+ "thiserror",
+]
+
+[[package]]
 name = "roff"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1441,56 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_path"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33"
+dependencies = [
+ "inventory",
+ "nom",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_json_path_core",
+ "serde_json_path_macros",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_json_path_core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc"
+dependencies = [
+ "inventory",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_json_path_macros"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8"
+dependencies = [
+ "inventory",
+ "serde_json_path_core",
+ "serde_json_path_macros_internal",
+]
+
+[[package]]
+name = "serde_json_path_macros_internal"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ regex = "1.11.2"
 reqwest = { version = "0.13.3", default-features = false, features = ["blocking", "native-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
+serde_json_path = "0.7.2"
 serde_yaml_ng = "0.10.0"
 thiserror = "2.0.16"
 notify = "8.2"

--- a/crates/roas-overlay/Cargo.toml
+++ b/crates/roas-overlay/Cargo.toml
@@ -27,11 +27,9 @@ clap = ["dep:clap"]
 [dependencies]
 clap = { workspace = true, optional = true }
 enumset.workspace = true
-lazy-regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_path.workspace = true
-thiserror.workspace = true
 
 [dev-dependencies]
 serde_yaml_ng.workspace = true

--- a/crates/roas-overlay/Cargo.toml
+++ b/crates/roas-overlay/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "roas-overlay"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+description = "Rust implementation of the OpenAPI Overlay Specification v1.0 / v1.1 — parse, validate, and apply"
+readme = "README.md"
+categories = ["web-programming", "parser-implementations"]
+include = ["src", "Cargo.toml", "README.md"]
+publish = true
+
+[features]
+default = ["v1_0"]
+# Support for OpenAPI Overlay v1.0.x
+v1_0 = []
+# Support for OpenAPI Overlay v1.1.x (not yet implemented)
+v1_1 = []
+
+# `clap::ValueEnum` impls for `apply::ApplyOptions` and
+# `validation::ValidationOptions`, for downstream CLIs.
+clap = ["dep:clap"]
+
+[dependencies]
+clap = { workspace = true, optional = true }
+enumset.workspace = true
+lazy-regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_json_path.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_yaml_ng.workspace = true

--- a/crates/roas-overlay/README.md
+++ b/crates/roas-overlay/README.md
@@ -10,10 +10,10 @@ This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed pa
 
 ## Versions
 
-| Overlay version | Feature flag | Status |
-|-----------------|--------------|--------|
-| 1.0             | `v1_0` (default) | ✅ implemented |
-| 1.1             | `v1_1`       | planned (next PR) |
+| Overlay version | Feature flag     | Status            |
+|-----------------|------------------|-------------------|
+| 1.0             | `v1_0` (default) | ✅ implemented     |
+| 1.1             | `v1_1`           | planned (next PR) |
 
 ## Quick start
 
@@ -55,10 +55,11 @@ For each action in declaration order, against the *current* working copy of the 
 1. Compile the `target` JSONPath. Syntax errors abort the merge with `InvalidJsonPath`.
 2. Resolve matching nodes via [`serde_json_path`](https://crates.io/crates/serde_json_path).
 3. Zero matches → silent no-op (or `ZeroMatch` error under `ApplyOptions::ErrorOnZeroMatch`).
-4. `remove: true` → drop each matched node from its container. Sibling array indices are preserved by processing matches in reverse.
-5. Otherwise, if `update` is set:
-   - Targets must be objects or arrays (spec §4.4); primitives or `null` raise `UpdateOnPrimitiveTarget`.
-   - Merge the `update` value into each matched node per [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules): objects merge per key (recursively), arrays concatenate, anything else replaces.
+4. Targets must be objects or arrays for *every* action (spec §4.4); primitives or `null` raise `PrimitiveActionTarget`.
+5. `remove: true` → drop each matched node from its container. Sibling array indices are preserved by processing matches in reverse.
+6. Otherwise, if `update` is set, the behavior depends on the matched node's kind:
+   - **Array target** → `update` is appended as a single new element, regardless of its shape (spec §4.4: *"an entry to append to the array"*).
+   - **Object target** → recursive merge per [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules): keys present in both sides recurse (objects), or use the merge rules (primitives replace, arrays concatenate at the property level).
 
 On any error the target document is left **untouched** — `Overlay::apply` operates on a clone and commits only on success.
 
@@ -67,12 +68,11 @@ On any error the target document is left **untouched** — `Overlay::apply` oper
 `ApplyOptions` (EnumSet):
 
 - `ErrorOnZeroMatch` — fail when an action's `target` selects zero nodes (default: silent no-op).
-- `ErrorOnMixedKindMatch` — fail when an `update`/`copy` selects nodes of mixed kind (some objects, some arrays). The v1.1 spec calls this out normatively; this option lets v1.0 callers opt in.
+- `ErrorOnMixedKindMatch` — fail when an `update` selects nodes of mixed kind (some objects, some arrays). The v1.1 spec calls this out normatively; this option lets v1.0 callers opt in.
 
 `ValidationOptions` (EnumSet):
 
 - `IgnoreEmptyInfoTitle`, `IgnoreEmptyInfoVersion` — allow `info.title` / `info.version` to be empty.
-- `IgnoreExtendsFormat` — skip the format check on `extends`.
 
 Behind the `clap` feature, both enums implement `clap::ValueEnum` so downstream CLIs (such as `roas-cli`) can surface them directly.
 

--- a/crates/roas-overlay/README.md
+++ b/crates/roas-overlay/README.md
@@ -1,0 +1,85 @@
+# roas-overlay
+
+Rust implementation of the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html): parse, validate, and apply Overlay documents to OpenAPI specs.
+
+[![crates.io](https://img.shields.io/crates/v/roas-overlay.svg)](https://crates.io/crates/roas-overlay)
+
+An *Overlay* is a sidecar document whose ordered list of *actions* — each a [RFC 9535 JSONPath](https://www.rfc-editor.org/rfc/rfc9535) `target` plus an `update`, `remove`, or v1.1 `copy` instruction — transforms a target OpenAPI document. Common uses: layering environment-specific changes over a base API, adding vendor extensions without forking, removing internal endpoints from a public bundle.
+
+This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed parser / validator / merger for OpenAPI 2.0–3.2). It operates on `serde_json::Value` so a single implementation works across every OpenAPI version, and so overlays that produce intermediate states the typed model would reject (drop a required field then add it back) still apply cleanly.
+
+## Versions
+
+| Overlay version | Feature flag | Status |
+|-----------------|--------------|--------|
+| 1.0             | `v1_0` (default) | ✅ implemented |
+| 1.1             | `v1_1`       | planned (next PR) |
+
+## Quick start
+
+```rust
+use enumset::EnumSet;
+use roas_overlay::apply::Apply;
+use roas_overlay::v1_0::Overlay;
+use roas_overlay::validation::Validate;
+
+let overlay: Overlay = serde_json::from_str(r#"{
+    "overlay": "1.0.0",
+    "info": { "title": "Example", "version": "1.0.0" },
+    "actions": [
+        { "target": "$.info", "update": { "description": "Patched." } },
+        { "target": "$.paths['/internal/metrics']", "remove": true }
+    ]
+}"#).unwrap();
+
+overlay.validate(EnumSet::empty()).expect("overlay is well-formed");
+
+let mut target: serde_json::Value = serde_json::from_str(r#"{
+    "openapi": "3.1.0",
+    "info": { "title": "API", "version": "1.0.0" },
+    "paths": { "/internal/metrics": { "get": {} } }
+}"#).unwrap();
+
+let report = overlay.apply(&mut target, EnumSet::empty()).unwrap();
+assert_eq!(report.actions.len(), 2);
+assert_eq!(target["info"]["description"], "Patched.");
+assert!(target["paths"].as_object().unwrap().is_empty());
+```
+
+YAML overlays work the same way — parse with `serde_yaml_ng` (or any other YAML crate) into `Overlay`.
+
+## Apply algorithm
+
+For each action in declaration order, against the *current* working copy of the target:
+
+1. Compile the `target` JSONPath. Syntax errors abort the merge with `InvalidJsonPath`.
+2. Resolve matching nodes via [`serde_json_path`](https://crates.io/crates/serde_json_path).
+3. Zero matches → silent no-op (or `ZeroMatch` error under `ApplyOptions::ErrorOnZeroMatch`).
+4. `remove: true` → drop each matched node from its container. Sibling array indices are preserved by processing matches in reverse.
+5. Otherwise, if `update` is set:
+   - Targets must be objects or arrays (spec §4.4); primitives or `null` raise `UpdateOnPrimitiveTarget`.
+   - Merge the `update` value into each matched node per [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules): objects merge per key (recursively), arrays concatenate, anything else replaces.
+
+On any error the target document is left **untouched** — `Overlay::apply` operates on a clone and commits only on success.
+
+## Options
+
+`ApplyOptions` (EnumSet):
+
+- `ErrorOnZeroMatch` — fail when an action's `target` selects zero nodes (default: silent no-op).
+- `ErrorOnMixedKindMatch` — fail when an `update`/`copy` selects nodes of mixed kind (some objects, some arrays). The v1.1 spec calls this out normatively; this option lets v1.0 callers opt in.
+
+`ValidationOptions` (EnumSet):
+
+- `IgnoreEmptyInfoTitle`, `IgnoreEmptyInfoVersion` — allow `info.title` / `info.version` to be empty.
+- `IgnoreExtendsFormat` — skip the format check on `extends`.
+
+Behind the `clap` feature, both enums implement `clap::ValueEnum` so downstream CLIs (such as `roas-cli`) can surface them directly.
+
+## Validation
+
+`Validate::validate` returns every diagnostic it finds rather than failing on the first one. Diagnostics carry a JSONPath-flavor `path` (e.g. `#.actions[3].target`).
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.

--- a/crates/roas-overlay/src/apply.rs
+++ b/crates/roas-overlay/src/apply.rs
@@ -1,0 +1,224 @@
+//! Public surface for applying an Overlay to a target JSON document.
+//!
+//! See [`Apply::apply`] for the entry point. The trait is implemented
+//! for each per-version `Overlay` type ([`crate::v1_0::Overlay`] today;
+//! `v1_1::Overlay` once that feature lands).
+
+use enumset::{EnumSet, EnumSetType};
+use std::fmt::{self, Display};
+
+/// Apply an overlay document to a target JSON value in place.
+///
+/// On error the target is left untouched: implementors are expected
+/// to operate on a clone and commit only on success.
+pub trait Apply {
+    fn apply(
+        &self,
+        target: &mut serde_json::Value,
+        options: EnumSet<ApplyOptions>,
+    ) -> Result<ApplyReport, ApplyError>;
+}
+
+/// Per-call apply toggles.
+#[derive(EnumSetType, Debug)]
+pub enum ApplyOptions {
+    /// Treat a zero-match `target` JSONPath as an error rather than a
+    /// no-op. Default behavior (option absent) follows
+    /// [§4.4](https://spec.openapis.org/overlay/v1.1.0.html#action-object):
+    /// "the action succeeds without changing the target document".
+    ErrorOnZeroMatch,
+    /// Reject `update`/`copy` actions whose `target` selects nodes of
+    /// mixed kind (some objects, some arrays, some primitives). The
+    /// v1.1 spec calls this out normatively; v1.0 doesn't, so this
+    /// option lets v1.0 callers opt into the stricter check.
+    ErrorOnMixedKindMatch,
+}
+
+#[cfg(feature = "clap")]
+impl clap::ValueEnum for ApplyOptions {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            ApplyOptions::ErrorOnZeroMatch,
+            ApplyOptions::ErrorOnMixedKindMatch,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        let (name, help) = match self {
+            ApplyOptions::ErrorOnZeroMatch => (
+                "error-on-zero-match",
+                "Fail when an action's `target` selects zero nodes",
+            ),
+            ApplyOptions::ErrorOnMixedKindMatch => (
+                "error-on-mixed-kind-match",
+                "Fail when `update`/`copy` selects a mix of objects, arrays, and primitives",
+            ),
+        };
+        Some(clap::builder::PossibleValue::new(name).help(help))
+    }
+}
+
+/// One entry per applied action, in declaration order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActionOutcome {
+    pub index: usize,
+    pub target: String,
+    pub operation: Operation,
+    pub matched: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    Update,
+    Remove,
+    /// v1.1 only.
+    Copy,
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Operation::Update => "update",
+            Operation::Remove => "remove",
+            Operation::Copy => "copy",
+        })
+    }
+}
+
+/// Report returned by a successful [`Apply::apply`] call.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ApplyReport {
+    pub actions: Vec<ActionOutcome>,
+}
+
+/// Failure returned by [`Apply::apply`]. The `target` document is
+/// guaranteed untouched on error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyError {
+    pub action_index: usize,
+    pub target: String,
+    pub kind: ApplyErrorKind,
+}
+
+impl Display for ApplyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "actions[{}] (target {:?}): {}",
+            self.action_index, self.target, self.kind
+        )
+    }
+}
+
+impl std::error::Error for ApplyError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyErrorKind {
+    /// `target` is not a syntactically valid RFC 9535 JSONPath query.
+    InvalidJsonPath(String),
+    /// No node matched and [`ApplyOptions::ErrorOnZeroMatch`] is set.
+    ZeroMatch,
+    /// Target matched nodes of mixed kinds and
+    /// [`ApplyOptions::ErrorOnMixedKindMatch`] is set.
+    MixedKindMatch,
+    /// `update` is set but `target` resolves to a primitive or `null`,
+    /// which the spec
+    /// [§4.4](https://spec.openapis.org/overlay/v1.1.0.html#action-object)
+    /// disallows.
+    UpdateOnPrimitiveTarget,
+    /// v1.1 only: `copy` source JSONPath is syntactically valid but
+    /// matched no node.
+    CopySourceNotFound(String),
+    /// v1.1 only: `copy` source matched multiple nodes; the spec
+    /// requires exactly one.
+    CopySourceMultiple(String),
+}
+
+impl Display for ApplyErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApplyErrorKind::InvalidJsonPath(msg) => write!(f, "invalid JSONPath: {msg}"),
+            ApplyErrorKind::ZeroMatch => {
+                f.write_str("target matched zero nodes (error-on-zero-match)")
+            }
+            ApplyErrorKind::MixedKindMatch => f.write_str(
+                "target matched nodes of mixed kind (objects, arrays, primitives) — \
+                 error-on-mixed-kind-match",
+            ),
+            ApplyErrorKind::UpdateOnPrimitiveTarget => f.write_str(
+                "`update` requires target nodes to be objects or arrays, \
+                 not primitives or null",
+            ),
+            ApplyErrorKind::CopySourceNotFound(s) => {
+                write!(f, "`copy` source {s:?} matched no node")
+            }
+            ApplyErrorKind::CopySourceMultiple(s) => write!(
+                f,
+                "`copy` source {s:?} matched multiple nodes; exactly one is required",
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_display_uses_lowercase_words() {
+        assert_eq!(Operation::Update.to_string(), "update");
+        assert_eq!(Operation::Remove.to_string(), "remove");
+        assert_eq!(Operation::Copy.to_string(), "copy");
+    }
+
+    #[test]
+    fn apply_error_display_includes_index_target_and_reason() {
+        let e = ApplyError {
+            action_index: 2,
+            target: "$.foo".into(),
+            kind: ApplyErrorKind::ZeroMatch,
+        };
+        let s = e.to_string();
+        assert!(s.contains("actions[2]"));
+        assert!(s.contains("$.foo"));
+        assert!(s.contains("zero nodes"));
+    }
+
+    #[test]
+    fn apply_error_kind_display_covers_every_variant() {
+        let cases = [
+            ApplyErrorKind::InvalidJsonPath("bad path".into()),
+            ApplyErrorKind::ZeroMatch,
+            ApplyErrorKind::MixedKindMatch,
+            ApplyErrorKind::UpdateOnPrimitiveTarget,
+            ApplyErrorKind::CopySourceNotFound("$.src".into()),
+            ApplyErrorKind::CopySourceMultiple("$.src".into()),
+        ];
+        for k in cases {
+            assert!(
+                !k.to_string().is_empty(),
+                "Display impl for {k:?} produced empty string",
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "clap"))]
+mod clap_tests {
+    use super::*;
+    use clap::ValueEnum;
+
+    #[test]
+    fn apply_options_value_enum_round_trips_through_kebab_case() {
+        for v in <ApplyOptions as ValueEnum>::value_variants() {
+            let pv = v.to_possible_value().expect("possible value");
+            let name = pv.get_name();
+            let parsed = <ApplyOptions as ValueEnum>::from_str(name, false).expect("parses");
+            assert_eq!(parsed, *v);
+            assert!(
+                name.bytes().all(|b| b.is_ascii_lowercase() || b == b'-'),
+                "name `{name}` must be kebab-case",
+            );
+        }
+    }
+}

--- a/crates/roas-overlay/src/apply.rs
+++ b/crates/roas-overlay/src/apply.rs
@@ -24,13 +24,13 @@ pub trait Apply {
 pub enum ApplyOptions {
     /// Treat a zero-match `target` JSONPath as an error rather than a
     /// no-op. Default behavior (option absent) follows
-    /// [§4.4](https://spec.openapis.org/overlay/v1.1.0.html#action-object):
+    /// [§4.4](https://spec.openapis.org/overlay/v1.0.0.html#action-object):
     /// "the action succeeds without changing the target document".
     ErrorOnZeroMatch,
-    /// Reject `update`/`copy` actions whose `target` selects nodes of
-    /// mixed kind (some objects, some arrays, some primitives). The
-    /// v1.1 spec calls this out normatively; v1.0 doesn't, so this
-    /// option lets v1.0 callers opt into the stricter check.
+    /// Reject `update` actions whose `target` selects nodes of mixed
+    /// kind (some objects, some arrays). The v1.1 spec calls this out
+    /// normatively; v1.0 doesn't, so this option lets v1.0 callers
+    /// opt into the stricter check.
     ErrorOnMixedKindMatch,
 }
 
@@ -51,7 +51,7 @@ impl clap::ValueEnum for ApplyOptions {
             ),
             ApplyOptions::ErrorOnMixedKindMatch => (
                 "error-on-mixed-kind-match",
-                "Fail when `update`/`copy` selects a mix of objects, arrays, and primitives",
+                "Fail when `update` selects a mix of objects and arrays",
             ),
         };
         Some(clap::builder::PossibleValue::new(name).help(help))
@@ -60,6 +60,7 @@ impl clap::ValueEnum for ApplyOptions {
 
 /// One entry per applied action, in declaration order.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ActionOutcome {
     pub index: usize,
     pub target: String,
@@ -68,11 +69,10 @@ pub struct ActionOutcome {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Operation {
     Update,
     Remove,
-    /// v1.1 only.
-    Copy,
 }
 
 impl Display for Operation {
@@ -80,13 +80,13 @@ impl Display for Operation {
         f.write_str(match self {
             Operation::Update => "update",
             Operation::Remove => "remove",
-            Operation::Copy => "copy",
         })
     }
 }
 
 /// Report returned by a successful [`Apply::apply`] call.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub struct ApplyReport {
     pub actions: Vec<ActionOutcome>,
 }
@@ -94,6 +94,7 @@ pub struct ApplyReport {
 /// Failure returned by [`Apply::apply`]. The `target` document is
 /// guaranteed untouched on error.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ApplyError {
     pub action_index: usize,
     pub target: String,
@@ -113,6 +114,7 @@ impl Display for ApplyError {
 impl std::error::Error for ApplyError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ApplyErrorKind {
     /// `target` is not a syntactically valid RFC 9535 JSONPath query.
     InvalidJsonPath(String),
@@ -121,17 +123,11 @@ pub enum ApplyErrorKind {
     /// Target matched nodes of mixed kinds and
     /// [`ApplyOptions::ErrorOnMixedKindMatch`] is set.
     MixedKindMatch,
-    /// `update` is set but `target` resolves to a primitive or `null`,
-    /// which the spec
-    /// [§4.4](https://spec.openapis.org/overlay/v1.1.0.html#action-object)
-    /// disallows.
-    UpdateOnPrimitiveTarget,
-    /// v1.1 only: `copy` source JSONPath is syntactically valid but
-    /// matched no node.
-    CopySourceNotFound(String),
-    /// v1.1 only: `copy` source matched multiple nodes; the spec
-    /// requires exactly one.
-    CopySourceMultiple(String),
+    /// `target` resolves to a primitive or `null`. The spec
+    /// [§4.4](https://spec.openapis.org/overlay/v1.0.0.html#action-object)
+    /// requires action targets to be objects or arrays, for both
+    /// `update` and `remove` actions.
+    PrimitiveActionTarget,
 }
 
 impl Display for ApplyErrorKind {
@@ -142,19 +138,12 @@ impl Display for ApplyErrorKind {
                 f.write_str("target matched zero nodes (error-on-zero-match)")
             }
             ApplyErrorKind::MixedKindMatch => f.write_str(
-                "target matched nodes of mixed kind (objects, arrays, primitives) — \
+                "target matched nodes of mixed kind (objects and arrays) — \
                  error-on-mixed-kind-match",
             ),
-            ApplyErrorKind::UpdateOnPrimitiveTarget => f.write_str(
-                "`update` requires target nodes to be objects or arrays, \
+            ApplyErrorKind::PrimitiveActionTarget => f.write_str(
+                "action `target` must resolve to objects or arrays, \
                  not primitives or null",
-            ),
-            ApplyErrorKind::CopySourceNotFound(s) => {
-                write!(f, "`copy` source {s:?} matched no node")
-            }
-            ApplyErrorKind::CopySourceMultiple(s) => write!(
-                f,
-                "`copy` source {s:?} matched multiple nodes; exactly one is required",
             ),
         }
     }
@@ -168,7 +157,6 @@ mod tests {
     fn operation_display_uses_lowercase_words() {
         assert_eq!(Operation::Update.to_string(), "update");
         assert_eq!(Operation::Remove.to_string(), "remove");
-        assert_eq!(Operation::Copy.to_string(), "copy");
     }
 
     #[test]
@@ -190,9 +178,7 @@ mod tests {
             ApplyErrorKind::InvalidJsonPath("bad path".into()),
             ApplyErrorKind::ZeroMatch,
             ApplyErrorKind::MixedKindMatch,
-            ApplyErrorKind::UpdateOnPrimitiveTarget,
-            ApplyErrorKind::CopySourceNotFound("$.src".into()),
-            ApplyErrorKind::CopySourceMultiple("$.src".into()),
+            ApplyErrorKind::PrimitiveActionTarget,
         ];
         for k in cases {
             assert!(

--- a/crates/roas-overlay/src/common/apply.rs
+++ b/crates/roas-overlay/src/common/apply.rs
@@ -1,0 +1,207 @@
+//! Version-agnostic apply helpers: JSON merging per the Overlay
+//! [§4.4.3.1 merging rules](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules)
+//! and a thin wrapper around [`serde_json_path`].
+
+use serde_json::Value;
+use serde_json_path::JsonPath;
+
+/// Compile a JSONPath query string into a typed [`JsonPath`]. Returns
+/// the underlying parser error as a string so callers can surface it
+/// in [`ApplyError`](crate::apply::ApplyError) without leaking the
+/// `serde_json_path` types from their public API.
+pub fn compile_path(s: &str) -> Result<JsonPath, String> {
+    JsonPath::parse(s).map_err(|e| e.to_string())
+}
+
+/// Evaluate a compiled JSONPath against `doc` and return matched
+/// locations as RFC 6901 JSON Pointers, in document order.
+///
+/// The returned pointers are owned strings; the caller is free to
+/// keep mutating `doc` afterwards without lifetime conflicts with the
+/// borrow taken by `query_located`.
+pub fn locate(doc: &Value, path: &JsonPath) -> Vec<String> {
+    path.query_located(doc)
+        .into_iter()
+        .map(|n| n.location().to_json_pointer())
+        .collect()
+}
+
+/// Recursively merge `update` into `target`, per Overlay
+/// [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules):
+///
+/// - Both objects → per-key recursive merge (keys only in `update`
+///   inserted, keys only in `target` kept, shared keys recurse).
+/// - Both arrays  → concatenate (`update` items appended to `target`).
+/// - Anything else (shape mismatch, both primitives, `null` on either
+///   side) → replace `target` with a clone of `update`.
+pub fn merge_json(target: &mut Value, update: &Value) {
+    match (target, update) {
+        (Value::Object(t), Value::Object(u)) => {
+            for (k, v) in u {
+                match t.get_mut(k) {
+                    Some(existing) => merge_json(existing, v),
+                    None => {
+                        t.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+        }
+        (Value::Array(t), Value::Array(u)) => {
+            t.extend(u.iter().cloned());
+        }
+        (slot, other) => {
+            *slot = other.clone();
+        }
+    }
+}
+
+/// Remove the value at `pointer` from `doc` (RFC 6901). Returns
+/// `true` if the value was removed, `false` if the pointer didn't
+/// resolve to a removable child (root, missing key, out-of-range
+/// index).
+pub fn remove_at(doc: &mut Value, pointer: &str) -> bool {
+    if pointer.is_empty() {
+        // Removing the document root is undefined; treat as no-op so
+        // a malformed action doesn't accidentally clobber the input.
+        return false;
+    }
+    let (parent_ptr, last_segment) = match pointer.rsplit_once('/') {
+        Some(pair) => pair,
+        None => return false,
+    };
+    let key = unescape_pointer_segment(last_segment);
+    let Some(parent) = doc.pointer_mut(parent_ptr) else {
+        return false;
+    };
+    match parent {
+        Value::Object(map) => map.remove(&key).is_some(),
+        Value::Array(vec) => {
+            let Ok(idx) = key.parse::<usize>() else {
+                return false;
+            };
+            if idx >= vec.len() {
+                return false;
+            }
+            vec.remove(idx);
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Unescape a single JSON Pointer segment per
+/// [RFC 6901 §4](https://www.rfc-editor.org/rfc/rfc6901#section-4):
+/// `~1` → `/`, `~0` → `~`. The order matters — unescape `~1` first.
+fn unescape_pointer_segment(seg: &str) -> String {
+    seg.replace("~1", "/").replace("~0", "~")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn merge_objects_recurse_per_key() {
+        let mut target = json!({ "a": 1, "nested": { "x": "old", "kept": true } });
+        let update = json!({ "b": 2, "nested": { "x": "new", "added": 42 } });
+        merge_json(&mut target, &update);
+        assert_eq!(
+            target,
+            json!({
+                "a": 1,
+                "b": 2,
+                "nested": { "x": "new", "kept": true, "added": 42 }
+            }),
+        );
+    }
+
+    #[test]
+    fn merge_arrays_concatenate() {
+        let mut target = json!([1, 2, 3]);
+        merge_json(&mut target, &json!([4, 5]));
+        assert_eq!(target, json!([1, 2, 3, 4, 5]));
+    }
+
+    #[test]
+    fn merge_primitive_replaces() {
+        let mut target = json!("old");
+        merge_json(&mut target, &json!("new"));
+        assert_eq!(target, json!("new"));
+    }
+
+    #[test]
+    fn merge_shape_mismatch_replaces() {
+        let mut target = json!({ "a": 1 });
+        merge_json(&mut target, &json!([1, 2]));
+        assert_eq!(target, json!([1, 2]));
+
+        let mut target = json!([1, 2]);
+        merge_json(&mut target, &json!({ "a": 1 }));
+        assert_eq!(target, json!({ "a": 1 }));
+    }
+
+    #[test]
+    fn merge_null_replaces() {
+        let mut target = json!({ "a": 1 });
+        merge_json(&mut target, &json!(null));
+        assert_eq!(target, json!(null));
+    }
+
+    #[test]
+    fn locate_returns_pointers_in_document_order() {
+        let doc = json!({
+            "info": { "title": "x" },
+            "paths": {
+                "/pets": { "get": { "summary": "list" } },
+                "/users": { "get": { "summary": "list" } }
+            }
+        });
+        let path = compile_path("$.paths.*.get").unwrap();
+        let mut ptrs = locate(&doc, &path);
+        ptrs.sort();
+        assert_eq!(ptrs, vec!["/paths/~1pets/get", "/paths/~1users/get"]);
+    }
+
+    #[test]
+    fn compile_path_returns_error_for_invalid_syntax() {
+        let err = compile_path("not a path").unwrap_err();
+        assert!(!err.is_empty(), "expected non-empty parser error");
+    }
+
+    #[test]
+    fn remove_at_object_key_returns_true() {
+        let mut doc = json!({ "a": 1, "b": 2 });
+        assert!(remove_at(&mut doc, "/a"));
+        assert_eq!(doc, json!({ "b": 2 }));
+    }
+
+    #[test]
+    fn remove_at_array_index_returns_true_and_shifts() {
+        let mut doc = json!([10, 20, 30]);
+        assert!(remove_at(&mut doc, "/1"));
+        assert_eq!(doc, json!([10, 30]));
+    }
+
+    #[test]
+    fn remove_at_handles_escaped_segments() {
+        let mut doc = json!({ "paths": { "/pets": { "get": {} } } });
+        assert!(remove_at(&mut doc, "/paths/~1pets"));
+        assert_eq!(doc, json!({ "paths": {} }));
+    }
+
+    #[test]
+    fn remove_at_returns_false_for_unknown_pointer() {
+        let mut doc = json!({ "a": 1 });
+        assert!(!remove_at(&mut doc, "/missing"));
+        assert!(!remove_at(&mut doc, "/a/deeper"));
+        assert!(!remove_at(&mut doc, "")); // root
+    }
+
+    #[test]
+    fn remove_at_out_of_range_array_index_returns_false() {
+        let mut doc = json!([1, 2, 3]);
+        assert!(!remove_at(&mut doc, "/9"));
+        assert!(!remove_at(&mut doc, "/notnum"));
+    }
+}

--- a/crates/roas-overlay/src/common/extensions.rs
+++ b/crates/roas-overlay/src/common/extensions.rs
@@ -1,0 +1,173 @@
+//! Serde helpers for `x-*` extension fields, matching the Overlay
+//! specification's
+//! [§3.7 Specification Extensions](https://spec.openapis.org/overlay/v1.0.0.html#specification-extensions).
+//!
+//! Mirrors the analogous helper in the sibling `roas` crate; kept
+//! local so this crate is dependency-free against `roas` itself.
+//!
+//! Only entries whose key starts with `x-` are deserialised / serialised.
+//! Any non-`x-` key encountered during deserialization is silently
+//! dropped (serde's `#[serde(flatten)]` ensures the typed fields claim
+//! their keys first, so this only sees genuinely unknown ones).
+//!
+//! ### Usage
+//!
+//! ```rust
+//! use std::collections::BTreeMap;
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+//! pub struct WithExtensions {
+//!     pub foo: String,
+//!     #[serde(flatten)]
+//!     #[serde(with = "roas_overlay::common::extensions")]
+//!     #[serde(skip_serializing_if = "Option::is_none")]
+//!     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+//! }
+//! ```
+
+use serde::de::{Error, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
+
+pub fn deserialize<'de, D>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<String, serde_json::Value>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ExtensionsVisitor;
+    impl<'de> Visitor<'de> for ExtensionsVisitor {
+        type Value = BTreeMap<String, serde_json::Value>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("extensions: Option<BTreeMap<String, serde_json::Value>>")
+        }
+
+        fn visit_map<V>(self, mut map: V) -> Result<BTreeMap<String, serde_json::Value>, V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            let mut ext: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                if key.starts_with("x-") {
+                    if ext.contains_key(key.as_str()) {
+                        return Err(Error::custom(format_args!("duplicate field `{key}`")));
+                    }
+                    let value: serde_json::Value = map.next_value()?;
+                    ext.insert(key, value);
+                }
+            }
+            Ok(ext)
+        }
+    }
+
+    let map = deserializer.deserialize_map(ExtensionsVisitor)?;
+    Ok(if map.is_empty() { None } else { Some(map) })
+}
+
+pub fn serialize<S>(
+    ext: &Option<BTreeMap<String, serde_json::Value>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(ext) = ext {
+        let mut map = serializer.serialize_map(Some(ext.len()))?;
+        for (k, v) in ext {
+            if k.starts_with("x-") {
+                map.serialize_entry(k, v)?;
+            }
+        }
+        map.end()
+    } else {
+        None::<BTreeMap<String, serde_json::Value>>.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+    struct TestExtensions {
+        pub foo: String,
+        #[serde(flatten)]
+        #[serde(with = "super")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+    }
+
+    #[test]
+    fn deserialize_filters_non_x_dash_keys() {
+        let parsed: TestExtensions = serde_json::from_value(serde_json::json!({
+            "foo": "bar",
+            "skipped": 1,
+            "x-added": 2,
+        }))
+        .unwrap();
+        let mut expected_ext = BTreeMap::new();
+        expected_ext.insert("x-added".to_owned(), serde_json::json!(2));
+        assert_eq!(
+            parsed,
+            TestExtensions {
+                foo: "bar".into(),
+                extensions: Some(expected_ext),
+            },
+        );
+    }
+
+    #[test]
+    fn deserialize_no_extensions_returns_none() {
+        let parsed: TestExtensions =
+            serde_json::from_value(serde_json::json!({ "foo": "bar" })).unwrap();
+        assert_eq!(
+            parsed,
+            TestExtensions {
+                foo: "bar".into(),
+                extensions: None,
+            },
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_duplicate_extension_keys() {
+        let err =
+            serde_json::from_str::<TestExtensions>(r#"{"foo":"bar","x-a":1,"x-a":2}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate field `x-a`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn serialize_only_x_dash_keys_are_emitted() {
+        let mut ext = BTreeMap::new();
+        ext.insert("x-added".to_owned(), serde_json::json!(1));
+        ext.insert("skipped".to_owned(), serde_json::json!(2));
+        let v = serde_json::to_value(TestExtensions {
+            foo: "bar".into(),
+            extensions: Some(ext),
+        })
+        .unwrap();
+        assert_eq!(v, serde_json::json!({ "foo": "bar", "x-added": 1 }));
+    }
+
+    #[test]
+    fn serialize_none_emits_null() {
+        let none: Option<BTreeMap<String, serde_json::Value>> = None;
+        let out = super::serialize(&none, serde_json::value::Serializer).unwrap();
+        assert_eq!(out, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn visitor_expecting_invoked_on_type_mismatch() {
+        let mut de = serde_json::Deserializer::from_str(r#""not-a-map""#);
+        let err = super::deserialize(&mut de).unwrap_err();
+        assert!(err.to_string().contains("map") || err.to_string().contains("expected"));
+    }
+}

--- a/crates/roas-overlay/src/common/mod.rs
+++ b/crates/roas-overlay/src/common/mod.rs
@@ -1,0 +1,4 @@
+//! Version-agnostic helpers shared across overlay versions.
+
+pub mod apply;
+pub mod extensions;

--- a/crates/roas-overlay/src/lib.rs
+++ b/crates/roas-overlay/src/lib.rs
@@ -1,0 +1,55 @@
+//! OpenAPI Overlay Specification — parser, validator, and applier.
+//!
+//! Implements the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html):
+//! a sidecar document format that transforms OpenAPI documents through
+//! an ordered list of [JSONPath](https://www.rfc-editor.org/rfc/rfc9535)
+//! actions (`update`, `remove`, and v1.1's `copy`).
+//!
+//! ## Modules
+//!
+//! - [`common`] — version-agnostic helpers: `x-` extensions serde
+//!   helpers, RFC 9535 JSONPath wrapper, the
+//!   [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules)
+//!   recursive merge.
+//! - [`validation`] — [`Validate`](validation::Validate) trait,
+//!   [`ValidationOptions`](validation::ValidationOptions) flag set,
+//!   `Context` / `ValidationError` types.
+//! - [`apply`] — [`Apply`](apply::Apply) trait, [`ApplyOptions`](apply::ApplyOptions),
+//!   [`ApplyReport`](apply::ApplyReport), [`ApplyError`](apply::ApplyError).
+//! - [`v1_0`] — Overlay v1.0 document model + `Validate` / `Apply` impls.
+//!
+//! ## Applying an overlay
+//!
+//! ```no_run
+//! use enumset::EnumSet;
+//! use roas_overlay::apply::Apply;
+//! use roas_overlay::v1_0::Overlay;
+//!
+//! // Parse the overlay document (JSON or YAML).
+//! let overlay: Overlay = serde_json::from_str(r#"{
+//!     "overlay": "1.0.0",
+//!     "info": { "title": "Example", "version": "1.0.0" },
+//!     "actions": [
+//!         { "target": "$.info", "update": { "description": "Patched." } }
+//!     ]
+//! }"#).unwrap();
+//!
+//! // Parse the target OpenAPI document as untyped JSON.
+//! let mut target: serde_json::Value = serde_json::from_str(r#"{
+//!     "openapi": "3.1.0",
+//!     "info": { "title": "API", "version": "1.0.0" },
+//!     "paths": {}
+//! }"#).unwrap();
+//!
+//! // Apply the overlay in-place.
+//! let report = overlay.apply(&mut target, EnumSet::empty()).unwrap();
+//! assert_eq!(report.actions.len(), 1);
+//! assert_eq!(target["info"]["description"], "Patched.");
+//! ```
+
+pub mod apply;
+pub mod common;
+pub mod validation;
+
+#[cfg(feature = "v1_0")]
+pub mod v1_0;

--- a/crates/roas-overlay/src/v1_0/action.rs
+++ b/crates/roas-overlay/src/v1_0/action.rs
@@ -1,0 +1,185 @@
+//! Overlay v1.0 `Action` object.
+//!
+//! See [§3.3 Action Object](https://spec.openapis.org/overlay/v1.0.0.html#action-object).
+//! Each action selects a set of nodes in the target document via the
+//! RFC 9535 JSONPath in `target` and then either merges `update` into
+//! each match or removes them.
+
+use crate::common::apply::compile_path;
+use crate::v1_0::overlay::Overlay;
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Action {
+    /// **Required** RFC 9535 JSONPath selecting the nodes to act on.
+    pub target: String,
+
+    /// CommonMark-flavored description of the action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Value (object, array, or primitive) merged into the selected
+    /// nodes. Has no effect when `remove` is `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update: Option<serde_json::Value>,
+
+    /// When `true`, removes the selected nodes from their container.
+    /// Takes precedence over `update`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub remove: Option<bool>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Action {
+    /// Returns `true` if this action's `remove` field is set to `true`.
+    pub fn is_remove(&self) -> bool {
+        self.remove == Some(true)
+    }
+}
+
+impl ValidateWithContext<Overlay> for Action {
+    fn validate_with_context(&self, ctx: &mut Context<Overlay>, path: String) {
+        validate_required_string(&self.target, ctx, format!("{path}.target"));
+        if !self.target.is_empty()
+            && let Err(msg) = compile_path(&self.target)
+        {
+            ctx.error(
+                format!("{path}.target"),
+                format!("invalid JSONPath query: {msg}"),
+            );
+        }
+        // `remove: true` and `update` are mutually exclusive — the
+        // spec says `update` "has no impact if the `remove` field of
+        // this action object is `true`", but at validation time we
+        // reject the combo because it almost certainly indicates an
+        // authoring mistake.
+        if self.is_remove() && self.update.is_some() {
+            ctx.error(path, "`remove: true` and `update` are mutually exclusive");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(action: &Action) -> Vec<String> {
+        let mut ctx: Context<Overlay> = Context::new(EnumSet::empty());
+        action.validate_with_context(&mut ctx, "#.actions[0]".into());
+        ctx.errors.iter().map(|e| e.to_string()).collect()
+    }
+
+    #[test]
+    fn deserialize_update_action_round_trips() {
+        let a: Action = serde_json::from_value(json!({
+            "target": "$.info",
+            "update": { "description": "patched" }
+        }))
+        .unwrap();
+        assert_eq!(a.target, "$.info");
+        assert_eq!(
+            a.update.as_ref().unwrap(),
+            &json!({ "description": "patched" })
+        );
+        assert!(a.remove.is_none());
+
+        let v = serde_json::to_value(&a).unwrap();
+        assert_eq!(
+            v,
+            json!({ "target": "$.info", "update": { "description": "patched" } })
+        );
+    }
+
+    #[test]
+    fn deserialize_remove_action() {
+        let a: Action =
+            serde_json::from_value(json!({ "target": "$.paths['/x']", "remove": true })).unwrap();
+        assert!(a.is_remove());
+        assert!(a.update.is_none());
+    }
+
+    #[test]
+    fn deserialize_keeps_x_dash_extensions() {
+        let a: Action = serde_json::from_value(json!({
+            "target": "$",
+            "x-author": "me",
+        }))
+        .unwrap();
+        assert!(a.extensions.as_ref().unwrap().contains_key("x-author"));
+    }
+
+    #[test]
+    fn validate_empty_target_errors() {
+        let errs = validate(&Action::default());
+        assert!(
+            errs.iter()
+                .any(|s| s == "#.actions[0].target: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_invalid_jsonpath_errors() {
+        let a = Action {
+            target: "not a path".into(),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(
+            errs.iter().any(|s| s.contains("invalid JSONPath")),
+            "expected invalid-JSONPath diagnostic, got: {errs:?}",
+        );
+    }
+
+    #[test]
+    fn validate_remove_and_update_together_errors() {
+        let a = Action {
+            target: "$.foo".into(),
+            update: Some(json!({})),
+            remove: Some(true),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(
+            errs.iter().any(|s| s.contains("mutually exclusive")),
+            "expected mutually-exclusive diagnostic, got: {errs:?}",
+        );
+    }
+
+    #[test]
+    fn validate_remove_false_with_update_is_ok() {
+        let a = Action {
+            target: "$.foo".into(),
+            update: Some(json!({})),
+            remove: Some(false),
+            ..Default::default()
+        };
+        assert!(validate(&a).is_empty());
+    }
+
+    #[test]
+    fn is_remove_only_true_when_remove_set_to_true() {
+        let a = Action::default();
+        assert!(!a.is_remove());
+
+        let a = Action {
+            remove: Some(false),
+            ..Default::default()
+        };
+        assert!(!a.is_remove());
+
+        let a = Action {
+            remove: Some(true),
+            ..Default::default()
+        };
+        assert!(a.is_remove());
+    }
+}

--- a/crates/roas-overlay/src/v1_0/action.rs
+++ b/crates/roas-overlay/src/v1_0/action.rs
@@ -6,7 +6,6 @@
 //! each match or removes them.
 
 use crate::common::apply::compile_path;
-use crate::v1_0::overlay::Overlay;
 use crate::validation::{Context, ValidateWithContext, validate_required_string};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -44,8 +43,8 @@ impl Action {
     }
 }
 
-impl ValidateWithContext<Overlay> for Action {
-    fn validate_with_context(&self, ctx: &mut Context<Overlay>, path: String) {
+impl ValidateWithContext for Action {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
         validate_required_string(&self.target, ctx, format!("{path}.target"));
         if !self.target.is_empty()
             && let Err(msg) = compile_path(&self.target)
@@ -55,13 +54,24 @@ impl ValidateWithContext<Overlay> for Action {
                 format!("invalid JSONPath query: {msg}"),
             );
         }
-        // `remove: true` and `update` are mutually exclusive — the
-        // spec says `update` "has no impact if the `remove` field of
-        // this action object is `true`", but at validation time we
+        // The spec says `update` "has no impact if the `remove` field
+        // of this action object is `true`", but at validation time we
         // reject the combo because it almost certainly indicates an
         // authoring mistake.
         if self.is_remove() && self.update.is_some() {
-            ctx.error(path, "`remove: true` and `update` are mutually exclusive");
+            ctx.error(
+                path.clone(),
+                "`remove: true` and `update` are mutually exclusive",
+            );
+        }
+        // Catch the silent-no-op authoring bug: an action that does
+        // nothing is overwhelmingly a typo (e.g. forgot the `update`
+        // payload) rather than a deliberate placeholder.
+        if !self.is_remove() && self.update.is_none() {
+            ctx.error(
+                path,
+                "action must specify either `update` or `remove: true`",
+            );
         }
     }
 }
@@ -73,7 +83,7 @@ mod tests {
     use serde_json::json;
 
     fn validate(action: &Action) -> Vec<String> {
-        let mut ctx: Context<Overlay> = Context::new(EnumSet::empty());
+        let mut ctx = Context::new(EnumSet::empty());
         action.validate_with_context(&mut ctx, "#.actions[0]".into());
         ctx.errors.iter().map(|e| e.to_string()).collect()
     }

--- a/crates/roas-overlay/src/v1_0/info.rs
+++ b/crates/roas-overlay/src/v1_0/info.rs
@@ -4,7 +4,6 @@
 //! a minimal metadata block with required `title` and `version`,
 //! extensible via `x-` fields.
 
-use crate::v1_0::overlay::Overlay;
 use crate::validation::{
     Context, ValidateWithContext, ValidationOptions, validate_required_string,
 };
@@ -26,8 +25,8 @@ pub struct Info {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-impl ValidateWithContext<Overlay> for Info {
-    fn validate_with_context(&self, ctx: &mut Context<Overlay>, path: String) {
+impl ValidateWithContext for Info {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
         if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle) {
             validate_required_string(&self.title, ctx, format!("{path}.title"));
         }
@@ -43,7 +42,7 @@ mod tests {
     use enumset::EnumSet;
     use serde_json::json;
 
-    fn ctx() -> Context<Overlay> {
+    fn ctx() -> Context {
         Context::new(EnumSet::empty())
     }
 
@@ -93,7 +92,7 @@ mod tests {
     fn validate_ignore_options_suppress_diagnostics() {
         let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle)
             | ValidationOptions::IgnoreEmptyInfoVersion;
-        let mut c: Context<Overlay> = Context::new(opts);
+        let mut c = Context::new(opts);
         let info = Info::default();
         info.validate_with_context(&mut c, "#.info".into());
         assert!(c.errors.is_empty());

--- a/crates/roas-overlay/src/v1_0/info.rs
+++ b/crates/roas-overlay/src/v1_0/info.rs
@@ -1,0 +1,101 @@
+//! Overlay v1.0 `Info` object.
+//!
+//! Per [§3.2 Info Object](https://spec.openapis.org/overlay/v1.0.0.html#info-object):
+//! a minimal metadata block with required `title` and `version`,
+//! extensible via `x-` fields.
+
+use crate::v1_0::overlay::Overlay;
+use crate::validation::{
+    Context, ValidateWithContext, ValidationOptions, validate_required_string,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Info {
+    /// **Required** A human-readable description of the purpose of the overlay.
+    pub title: String,
+
+    /// **Required** A version identifier for changes to the Overlay document.
+    pub version: String,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext<Overlay> for Info {
+    fn validate_with_context(&self, ctx: &mut Context<Overlay>, path: String) {
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle) {
+            validate_required_string(&self.title, ctx, format!("{path}.title"));
+        }
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion) {
+            validate_required_string(&self.version, ctx, format!("{path}.version"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn ctx() -> Context<Overlay> {
+        Context::new(EnumSet::empty())
+    }
+
+    #[test]
+    fn deserialize_minimal_info_round_trips() {
+        let info: Info = serde_json::from_value(json!({ "title": "T", "version": "1.0" })).unwrap();
+        assert_eq!(info.title, "T");
+        assert_eq!(info.version, "1.0");
+        assert!(info.extensions.is_none());
+
+        let v = serde_json::to_value(&info).unwrap();
+        assert_eq!(v, json!({ "title": "T", "version": "1.0" }));
+    }
+
+    #[test]
+    fn deserialize_keeps_x_dash_extensions_and_drops_others() {
+        let info: Info = serde_json::from_value(json!({
+            "title": "T",
+            "version": "1.0",
+            "x-team": "platform",
+            "ignored": 42,
+        }))
+        .unwrap();
+        let ext = info.extensions.as_ref().unwrap();
+        assert_eq!(ext.get("x-team").unwrap(), &json!("platform"));
+        assert!(!ext.contains_key("ignored"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_title_and_version() {
+        let mut c = ctx();
+        let info = Info::default();
+        info.validate_with_context(&mut c, "#.info".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.info.title: must not be empty")
+        );
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.info.version: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_ignore_options_suppress_diagnostics() {
+        let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle)
+            | ValidationOptions::IgnoreEmptyInfoVersion;
+        let mut c: Context<Overlay> = Context::new(opts);
+        let info = Info::default();
+        info.validate_with_context(&mut c, "#.info".into());
+        assert!(c.errors.is_empty());
+    }
+}

--- a/crates/roas-overlay/src/v1_0/mod.rs
+++ b/crates/roas-overlay/src/v1_0/mod.rs
@@ -1,0 +1,15 @@
+//! OpenAPI Overlay v1.0 — see
+//! <https://spec.openapis.org/overlay/v1.0.0.html>.
+//!
+//! Authoritative JSON Schema:
+//! <https://spec.openapis.org/overlay/1.0/schema/2026-04-01>.
+
+pub mod action;
+pub mod info;
+pub mod overlay;
+pub mod version;
+
+pub use action::Action;
+pub use info::Info;
+pub use overlay::Overlay;
+pub use version::Version;

--- a/crates/roas-overlay/src/v1_0/overlay.rs
+++ b/crates/roas-overlay/src/v1_0/overlay.rs
@@ -7,9 +7,7 @@ use crate::common::apply::{compile_path, locate, merge_json, remove_at};
 use crate::v1_0::action::Action;
 use crate::v1_0::info::Info;
 use crate::v1_0::version::Version;
-use crate::validation::{
-    Context, Error, Validate, ValidateWithContext, ValidationOptions, validate_required_string,
-};
+use crate::validation::{Context, Error, Validate, ValidateWithContext, ValidationOptions};
 use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -44,7 +42,7 @@ pub struct Overlay {
 
 impl Overlay {
     fn validate_inner(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
-        let mut ctx: Context<Overlay> = Context::new(options);
+        let mut ctx = Context::new(options);
         let path = "#".to_owned();
 
         self.info
@@ -55,12 +53,6 @@ impl Overlay {
         }
         for (i, action) in self.actions.iter().enumerate() {
             action.validate_with_context(&mut ctx, format!("{path}.actions[{i}]"));
-        }
-
-        if let Some(extends) = &self.extends
-            && !ctx.is_option(ValidationOptions::IgnoreExtendsFormat)
-        {
-            validate_required_string(extends, &mut ctx, format!("{path}.extends"));
         }
 
         ctx.into_result()
@@ -100,27 +92,55 @@ fn apply_action(
     doc: &mut Value,
     options: EnumSet<ApplyOptions>,
 ) -> Result<ActionOutcome, ApplyError> {
-    let path = compile_path(&action.target).map_err(|msg| ApplyError {
+    let err = |kind| ApplyError {
         action_index: index,
         target: action.target.clone(),
-        kind: ApplyErrorKind::InvalidJsonPath(msg),
-    })?;
+        kind,
+    };
 
+    let path =
+        compile_path(&action.target).map_err(|msg| err(ApplyErrorKind::InvalidJsonPath(msg)))?;
     let pointers = locate(doc, &path);
+
+    // Validate ensures every action has either `update` or `remove: true`,
+    // so the only meaningful action shapes here are remove (`is_remove`)
+    // and update (`update.is_some()`). The pre-validate fall-through
+    // (action with neither) is treated as a true no-op at apply time:
+    // we report `matched: 0` so the report doesn't claim work that
+    // didn't happen.
+    let operation = if action.is_remove() {
+        Operation::Remove
+    } else {
+        Operation::Update
+    };
+    let no_effect = !action.is_remove() && action.update.is_none();
 
     if pointers.is_empty() {
         if options.contains(ApplyOptions::ErrorOnZeroMatch) {
-            return Err(ApplyError {
-                action_index: index,
-                target: action.target.clone(),
-                kind: ApplyErrorKind::ZeroMatch,
-            });
+            return Err(err(ApplyErrorKind::ZeroMatch));
         }
-        let operation = if action.is_remove() {
-            Operation::Remove
-        } else {
-            Operation::Update
-        };
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation,
+            matched: 0,
+        });
+    }
+
+    // Spec §4.4: `target` MUST resolve to objects or arrays for every
+    // action — checked up front so a failure leaves the working copy
+    // untouched.
+    let kinds: Vec<NodeKind> = pointers.iter().map(|p| classify(doc, p)).collect();
+    if kinds.iter().any(|k| matches!(k, NodeKind::Primitive)) {
+        return Err(err(ApplyErrorKind::PrimitiveActionTarget));
+    }
+    if options.contains(ApplyOptions::ErrorOnMixedKindMatch) && !uniform_kinds(&kinds) {
+        return Err(err(ApplyErrorKind::MixedKindMatch));
+    }
+
+    if no_effect {
+        // Action with neither `update` nor `remove: true` — see the
+        // comment above. Validation catches this; apply is defensive.
         return Ok(ActionOutcome {
             index,
             target: action.target.clone(),
@@ -131,59 +151,53 @@ fn apply_action(
 
     if action.is_remove() {
         // Process in reverse to preserve earlier pointer validity
-        // when siblings live in the same array.
+        // when siblings live in the same array. `remove_at` returns
+        // false for stale or unsupported pointers (e.g. the document
+        // root); count only the removes that actually took effect.
+        let mut removed = 0;
         for ptr in pointers.iter().rev() {
-            remove_at(doc, ptr);
-        }
-        return Ok(ActionOutcome {
-            index,
-            target: action.target.clone(),
-            operation: Operation::Remove,
-            matched: pointers.len(),
-        });
-    }
-
-    if let Some(update) = &action.update {
-        // §4.4: when `update` is set, targets must be objects or arrays.
-        // We check kinds up front so failure leaves the working copy
-        // unchanged for this action.
-        let kinds: Vec<NodeKind> = pointers.iter().map(|p| classify(doc, p)).collect();
-
-        if kinds.iter().any(|k| matches!(k, NodeKind::Primitive)) {
-            return Err(ApplyError {
-                action_index: index,
-                target: action.target.clone(),
-                kind: ApplyErrorKind::UpdateOnPrimitiveTarget,
-            });
-        }
-
-        if options.contains(ApplyOptions::ErrorOnMixedKindMatch) && !uniform_kinds(&kinds) {
-            return Err(ApplyError {
-                action_index: index,
-                target: action.target.clone(),
-                kind: ApplyErrorKind::MixedKindMatch,
-            });
-        }
-
-        for ptr in &pointers {
-            if let Some(node) = doc.pointer_mut(ptr) {
-                merge_json(node, update);
+            if remove_at(doc, ptr) {
+                removed += 1;
             }
         }
         return Ok(ActionOutcome {
             index,
             target: action.target.clone(),
-            operation: Operation::Update,
-            matched: pointers.len(),
+            operation,
+            matched: removed,
         });
     }
 
-    // `remove: false` (or absent) and no `update`: silently no-op
-    // (the spec doesn't forbid an action that does nothing).
+    // Update path. Per spec §4.4: when the matched node is an array,
+    // `update` is "an entry to append" — push it as a single element
+    // regardless of its kind. When the matched node is an object,
+    // recurse per §4.4.3.1.
+    let update = action
+        .update
+        .as_ref()
+        .expect("no_effect path covers the None case");
+    for (ptr, kind) in pointers.iter().zip(kinds.iter()) {
+        if let Some(node) = doc.pointer_mut(ptr) {
+            match kind {
+                NodeKind::Array => {
+                    if let Value::Array(arr) = node {
+                        arr.push(update.clone());
+                    }
+                }
+                NodeKind::Object => merge_json(node, update),
+                NodeKind::Primitive | NodeKind::Missing => {
+                    // Primitives were rejected above; Missing happens
+                    // only if a prior action invalidated the pointer
+                    // (impossible here because pointers were just
+                    // located against the current doc).
+                }
+            }
+        }
+    }
     Ok(ActionOutcome {
         index,
         target: action.target.clone(),
-        operation: Operation::Update,
+        operation,
         matched: pointers.len(),
     })
 }
@@ -351,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_extends_must_not_be_empty_unless_ignored() {
+    fn validate_flags_action_with_no_effect() {
         let o = Overlay {
             overlay: Version::V1_0_0(),
             info: Info {
@@ -360,21 +374,18 @@ mod tests {
                 ..Default::default()
             },
             actions: vec![Action {
-                target: "$".into(),
+                target: "$.foo".into(),
+                // No `update`, no `remove: true` — likely a typo.
                 ..Default::default()
             }],
-            extends: Some(String::new()),
+            extends: None,
             extensions: None,
         };
         let err = o.validate(EnumSet::empty()).unwrap_err();
         assert!(
-            err.errors
-                .iter()
-                .any(|e| e == "#.extends: must not be empty")
+            err.errors.iter().any(|e| e.contains("must specify either")),
+            "got: {err}",
         );
-
-        let ok = o.validate(ValidationOptions::IgnoreExtendsFormat.into());
-        assert!(ok.is_ok());
     }
 
     fn ovl(actions: Vec<Action>) -> Overlay {
@@ -490,8 +501,76 @@ mod tests {
         let mut doc = json!({ "info": { "title": "API" } });
         let snapshot = doc.clone();
         let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
-        assert_eq!(err.kind, ApplyErrorKind::UpdateOnPrimitiveTarget);
+        assert_eq!(err.kind, ApplyErrorKind::PrimitiveActionTarget);
         assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_remove_on_primitive_target_errors() {
+        // Spec §4.4: target must resolve to objects or arrays for *every*
+        // action, including `remove`. Primitive targets fail before any
+        // mutation lands.
+        let o = ovl(vec![Action {
+            target: "$.info.title".into(),
+            remove: Some(true),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "info": { "title": "API" } });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        assert_eq!(err.kind, ApplyErrorKind::PrimitiveActionTarget);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_update_against_array_target_appends_single_entry() {
+        // Spec §4.4: "If the `target` selects an array, the value of
+        // this field MUST be an entry to append to the array." So the
+        // *object*-typed update becomes one new array element — the
+        // existing array contents are preserved.
+        let o = ovl(vec![Action {
+            target: "$.paths['/pets'].get.parameters".into(),
+            update: Some(json!({ "name": "limit", "in": "query" })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "paths": {
+                "/pets": {
+                    "get": {
+                        "parameters": [
+                            { "name": "page", "in": "query" }
+                        ]
+                    }
+                }
+            }
+        });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(
+            doc["paths"]["/pets"]["get"]["parameters"],
+            json!([
+                { "name": "page", "in": "query" },
+                { "name": "limit", "in": "query" }
+            ]),
+        );
+    }
+
+    #[test]
+    fn apply_update_against_array_target_appends_array_as_single_element() {
+        // Even when `update` itself is an array, the spec says it is
+        // "an entry to append" — so the whole array becomes one new
+        // element, *not* element-wise concatenation.
+        let o = ovl(vec![Action {
+            target: "$.tags".into(),
+            update: Some(json!(["new-a", "new-b"])),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "tags": ["existing"] });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(
+            doc["tags"],
+            json!(["existing", ["new-a", "new-b"]]),
+            "the update array must be appended as a single nested element",
+        );
     }
 
     #[test]
@@ -552,7 +631,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_mixed_kind_lax_silently_merges_uniformly() {
+    fn apply_mixed_kind_lax_treats_each_match_per_its_kind() {
         let o = ovl(vec![Action {
             target: "$.choices[*]".into(),
             update: Some(json!({ "z": 1 })),
@@ -561,26 +640,45 @@ mod tests {
         let mut doc = json!({
             "choices": [ { "a": 1 }, [ 1, 2 ] ]
         });
-        // Without ErrorOnMixedKindMatch, no error; per-node merge runs.
-        // Object gets the new key; array (shape mismatch with update
-        // object) gets replaced by the update value.
+        // Without ErrorOnMixedKindMatch: object recurses (gets the
+        // new key); array appends the update value as a single new
+        // element (spec §4.4).
         o.apply(&mut doc, EnumSet::empty()).unwrap();
         assert_eq!(doc["choices"][0], json!({ "a": 1, "z": 1 }));
-        assert_eq!(doc["choices"][1], json!({ "z": 1 }));
+        assert_eq!(doc["choices"][1], json!([1, 2, { "z": 1 }]));
     }
 
     #[test]
-    fn apply_remove_only_no_update_runs_clean() {
+    fn apply_action_with_no_effect_reports_matched_zero_and_does_not_touch_doc() {
+        // Defensive: validate flags actions with neither `update` nor
+        // `remove: true`, but if one reaches apply (caller skipped
+        // validate), it's a true no-op — `matched: 0` reflects the
+        // (lack of) effect.
         let o = ovl(vec![Action {
             target: "$.foo".into(),
-            // Neither remove nor update — should be a clean no-op
-            // with matched > 0.
             ..Default::default()
         }]);
         let mut doc = json!({ "foo": { "a": 1 } });
+        let snapshot = doc.clone();
         let r = o.apply(&mut doc, EnumSet::empty()).unwrap();
-        assert_eq!(r.actions[0].operation, Operation::Update);
-        assert_eq!(r.actions[0].matched, 1);
-        assert_eq!(doc, json!({ "foo": { "a": 1 } }));
+        assert_eq!(r.actions[0].matched, 0);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_remove_at_root_does_not_count_as_match() {
+        // Removing the document root is undefined — `remove_at("")`
+        // returns false. `matched` reflects what actually changed,
+        // not the JSONPath match count.
+        let o = ovl(vec![Action {
+            target: "$".into(),
+            remove: Some(true),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "foo": 1 });
+        let snapshot = doc.clone();
+        let r = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(r.actions[0].matched, 0);
+        assert_eq!(doc, snapshot);
     }
 }

--- a/crates/roas-overlay/src/v1_0/overlay.rs
+++ b/crates/roas-overlay/src/v1_0/overlay.rs
@@ -1,0 +1,586 @@
+//! Overlay v1.0 root document.
+
+use crate::apply::{
+    ActionOutcome, Apply, ApplyError, ApplyErrorKind, ApplyOptions, ApplyReport, Operation,
+};
+use crate::common::apply::{compile_path, locate, merge_json, remove_at};
+use crate::v1_0::action::Action;
+use crate::v1_0::info::Info;
+use crate::v1_0::version::Version;
+use crate::validation::{
+    Context, Error, Validate, ValidateWithContext, ValidationOptions, validate_required_string,
+};
+use enumset::EnumSet;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Root Overlay v1.0 document.
+///
+/// See [§3.1 Overlay Object](https://spec.openapis.org/overlay/v1.0.0.html#overlay-object).
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Overlay {
+    /// **Required** `1.0.x` per the schema's pattern `^1\.0\.\d+$`.
+    pub overlay: Version,
+
+    /// **Required** Metadata about the overlay.
+    pub info: Info,
+
+    /// URI reference identifying the target document the overlay
+    /// applies to. Absolute or relative per RFC 3986.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extends: Option<String>,
+
+    /// **Required** Ordered, non-empty list of actions applied
+    /// sequentially.
+    pub actions: Vec<Action>,
+
+    /// `x-`-prefixed Specification Extensions on the root.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Overlay {
+    fn validate_inner(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        let mut ctx: Context<Overlay> = Context::new(options);
+        let path = "#".to_owned();
+
+        self.info
+            .validate_with_context(&mut ctx, format!("{path}.info"));
+
+        if self.actions.is_empty() {
+            ctx.error(format!("{path}.actions"), "must contain at least one entry");
+        }
+        for (i, action) in self.actions.iter().enumerate() {
+            action.validate_with_context(&mut ctx, format!("{path}.actions[{i}]"));
+        }
+
+        if let Some(extends) = &self.extends
+            && !ctx.is_option(ValidationOptions::IgnoreExtendsFormat)
+        {
+            validate_required_string(extends, &mut ctx, format!("{path}.extends"));
+        }
+
+        ctx.into_result()
+    }
+}
+
+impl Validate for Overlay {
+    fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        self.validate_inner(options)
+    }
+}
+
+impl Apply for Overlay {
+    fn apply(
+        &self,
+        target: &mut Value,
+        options: EnumSet<ApplyOptions>,
+    ) -> Result<ApplyReport, ApplyError> {
+        // Work on a clone so a mid-pipeline failure leaves `target`
+        // untouched. Commit only on success.
+        let mut working = target.clone();
+        let mut report = ApplyReport::default();
+
+        for (index, action) in self.actions.iter().enumerate() {
+            let outcome = apply_action(index, action, &mut working, options)?;
+            report.actions.push(outcome);
+        }
+
+        *target = working;
+        Ok(report)
+    }
+}
+
+fn apply_action(
+    index: usize,
+    action: &Action,
+    doc: &mut Value,
+    options: EnumSet<ApplyOptions>,
+) -> Result<ActionOutcome, ApplyError> {
+    let path = compile_path(&action.target).map_err(|msg| ApplyError {
+        action_index: index,
+        target: action.target.clone(),
+        kind: ApplyErrorKind::InvalidJsonPath(msg),
+    })?;
+
+    let pointers = locate(doc, &path);
+
+    if pointers.is_empty() {
+        if options.contains(ApplyOptions::ErrorOnZeroMatch) {
+            return Err(ApplyError {
+                action_index: index,
+                target: action.target.clone(),
+                kind: ApplyErrorKind::ZeroMatch,
+            });
+        }
+        let operation = if action.is_remove() {
+            Operation::Remove
+        } else {
+            Operation::Update
+        };
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation,
+            matched: 0,
+        });
+    }
+
+    if action.is_remove() {
+        // Process in reverse to preserve earlier pointer validity
+        // when siblings live in the same array.
+        for ptr in pointers.iter().rev() {
+            remove_at(doc, ptr);
+        }
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation: Operation::Remove,
+            matched: pointers.len(),
+        });
+    }
+
+    if let Some(update) = &action.update {
+        // §4.4: when `update` is set, targets must be objects or arrays.
+        // We check kinds up front so failure leaves the working copy
+        // unchanged for this action.
+        let kinds: Vec<NodeKind> = pointers.iter().map(|p| classify(doc, p)).collect();
+
+        if kinds.iter().any(|k| matches!(k, NodeKind::Primitive)) {
+            return Err(ApplyError {
+                action_index: index,
+                target: action.target.clone(),
+                kind: ApplyErrorKind::UpdateOnPrimitiveTarget,
+            });
+        }
+
+        if options.contains(ApplyOptions::ErrorOnMixedKindMatch) && !uniform_kinds(&kinds) {
+            return Err(ApplyError {
+                action_index: index,
+                target: action.target.clone(),
+                kind: ApplyErrorKind::MixedKindMatch,
+            });
+        }
+
+        for ptr in &pointers {
+            if let Some(node) = doc.pointer_mut(ptr) {
+                merge_json(node, update);
+            }
+        }
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation: Operation::Update,
+            matched: pointers.len(),
+        });
+    }
+
+    // `remove: false` (or absent) and no `update`: silently no-op
+    // (the spec doesn't forbid an action that does nothing).
+    Ok(ActionOutcome {
+        index,
+        target: action.target.clone(),
+        operation: Operation::Update,
+        matched: pointers.len(),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeKind {
+    Object,
+    Array,
+    Primitive,
+    Missing,
+}
+
+fn classify(doc: &Value, pointer: &str) -> NodeKind {
+    match doc.pointer(pointer) {
+        None => NodeKind::Missing,
+        Some(Value::Object(_)) => NodeKind::Object,
+        Some(Value::Array(_)) => NodeKind::Array,
+        Some(_) => NodeKind::Primitive,
+    }
+}
+
+fn uniform_kinds(kinds: &[NodeKind]) -> bool {
+    let mut iter = kinds
+        .iter()
+        .copied()
+        .filter(|k| !matches!(k, NodeKind::Missing));
+    let Some(first) = iter.next() else {
+        return true;
+    };
+    iter.all(|k| k == first)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn parse(s: &str) -> Overlay {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn deserialize_minimal_round_trips() {
+        let json = r#"{
+            "overlay": "1.0.0",
+            "info": { "title": "T", "version": "1" },
+            "actions": [ { "target": "$.x", "update": {} } ]
+        }"#;
+        let o = parse(json);
+        assert_eq!(o.overlay, Version::V1_0_0());
+        assert_eq!(o.info.title, "T");
+        assert_eq!(o.actions.len(), 1);
+        assert!(o.extends.is_none());
+        assert!(o.extensions.is_none());
+    }
+
+    #[test]
+    fn deserialize_with_extends_and_extensions() {
+        let json = r#"{
+            "overlay": "1.0.0",
+            "info": { "title": "T", "version": "1" },
+            "extends": "./base.yaml",
+            "actions": [ { "target": "$", "update": {} } ],
+            "x-team": "platform",
+            "skipped": 1
+        }"#;
+        let o = parse(json);
+        assert_eq!(o.extends.as_deref(), Some("./base.yaml"));
+        let ext = o.extensions.as_ref().unwrap();
+        assert!(ext.contains_key("x-team"));
+        assert!(!ext.contains_key("skipped"));
+    }
+
+    #[test]
+    fn serialize_skips_optional_none_fields() {
+        let o = Overlay {
+            overlay: Version::V1_0_0(),
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            extends: None,
+            actions: vec![Action {
+                target: "$".into(),
+                ..Default::default()
+            }],
+            extensions: None,
+        };
+        let v = serde_json::to_value(&o).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "overlay": "1.0.0",
+                "info": { "title": "T", "version": "1" },
+                "actions": [ { "target": "$" } ]
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_non_1_0_overlay_version() {
+        let err = serde_json::from_value::<Overlay>(json!({
+            "overlay": "2.0.0",
+            "info": { "title": "T", "version": "1" },
+            "actions": [ { "target": "$" } ]
+        }))
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("\"2.0.0\"") && msg.contains("1.0"),
+            "expected error to mention the bad version and the schema, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_actions_vec() {
+        let o = Overlay {
+            overlay: Version::V1_0_0(),
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            actions: vec![],
+            extends: None,
+            extensions: None,
+        };
+        let err = o.validate(EnumSet::empty()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.actions: must contain at least one entry")
+        );
+    }
+
+    #[test]
+    fn validate_recurses_into_info_and_actions() {
+        let o = Overlay {
+            overlay: Version::V1_0_0(),
+            info: Info::default(), // empty title/version
+            actions: vec![Action {
+                target: "".into(), // empty
+                ..Default::default()
+            }],
+            extends: None,
+            extensions: None,
+        };
+        let err = o.validate(EnumSet::empty()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.info.title: must not be empty")
+        );
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.info.version: must not be empty")
+        );
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.actions[0].target: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_extends_must_not_be_empty_unless_ignored() {
+        let o = Overlay {
+            overlay: Version::V1_0_0(),
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            actions: vec![Action {
+                target: "$".into(),
+                ..Default::default()
+            }],
+            extends: Some(String::new()),
+            extensions: None,
+        };
+        let err = o.validate(EnumSet::empty()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.extends: must not be empty")
+        );
+
+        let ok = o.validate(ValidationOptions::IgnoreExtendsFormat.into());
+        assert!(ok.is_ok());
+    }
+
+    fn ovl(actions: Vec<Action>) -> Overlay {
+        Overlay {
+            overlay: Version::V1_0_0(),
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            extends: None,
+            actions,
+            extensions: None,
+        }
+    }
+
+    #[test]
+    fn apply_update_merges_into_selected_object() {
+        let o = ovl(vec![Action {
+            target: "$.info".into(),
+            update: Some(json!({ "description": "patched" })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "API", "version": "1.0.0" },
+            "paths": {}
+        });
+        let report = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(report.actions.len(), 1);
+        assert_eq!(report.actions[0].matched, 1);
+        assert_eq!(report.actions[0].operation, Operation::Update);
+        assert_eq!(doc["info"]["description"], "patched");
+        assert_eq!(doc["info"]["title"], "API"); // preserved
+    }
+
+    #[test]
+    fn apply_remove_drops_selected_node() {
+        let o = ovl(vec![Action {
+            target: "$.paths['/x']".into(),
+            remove: Some(true),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "paths": { "/x": { "get": {} }, "/y": { "get": {} } }
+        });
+        let report = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(report.actions[0].operation, Operation::Remove);
+        assert!(!doc["paths"].as_object().unwrap().contains_key("/x"));
+        assert!(doc["paths"].as_object().unwrap().contains_key("/y"));
+    }
+
+    #[test]
+    fn apply_zero_match_default_is_no_op_with_count_zero() {
+        let o = ovl(vec![Action {
+            target: "$.nope".into(),
+            update: Some(json!({})),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "foo": 1 });
+        let snapshot = doc.clone();
+        let report = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(report.actions[0].matched, 0);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_zero_match_strict_errors_and_rolls_back() {
+        let o = ovl(vec![
+            Action {
+                target: "$.foo".into(),
+                update: Some(json!({ "x": 1 })),
+                ..Default::default()
+            },
+            Action {
+                target: "$.nope".into(),
+                update: Some(json!({})),
+                ..Default::default()
+            },
+        ]);
+        let mut doc = json!({ "foo": { "a": 0 } });
+        let snapshot = doc.clone();
+        let err = o
+            .apply(&mut doc, ApplyOptions::ErrorOnZeroMatch.into())
+            .unwrap_err();
+        assert_eq!(err.action_index, 1);
+        assert_eq!(err.kind, ApplyErrorKind::ZeroMatch);
+        // First action's mutation must be rolled back.
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_invalid_jsonpath_errors_and_does_not_touch_target() {
+        let o = ovl(vec![Action {
+            target: "not a path".into(),
+            update: Some(json!({})),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "x": 1 });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        assert!(matches!(err.kind, ApplyErrorKind::InvalidJsonPath(_)));
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_update_on_primitive_target_errors() {
+        let o = ovl(vec![Action {
+            target: "$.info.title".into(),
+            update: Some(json!({ "ignored": true })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "info": { "title": "API" } });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        assert_eq!(err.kind, ApplyErrorKind::UpdateOnPrimitiveTarget);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_multiple_remove_targets_in_array_preserves_indices() {
+        let o = ovl(vec![Action {
+            target: "$.items[?@.delete == true]".into(),
+            remove: Some(true),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "items": [
+                { "id": 0, "delete": true },
+                { "id": 1 },
+                { "id": 2, "delete": true },
+                { "id": 3 }
+            ]
+        });
+        let report = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(report.actions[0].matched, 2);
+        assert_eq!(doc, json!({ "items": [ { "id": 1 }, { "id": 3 } ] }),);
+    }
+
+    #[test]
+    fn apply_sequential_actions_compose() {
+        let o = ovl(vec![
+            Action {
+                target: "$.info".into(),
+                update: Some(json!({ "description": "v1" })),
+                ..Default::default()
+            },
+            Action {
+                target: "$.info".into(),
+                update: Some(json!({ "description": "v2" })),
+                ..Default::default()
+            },
+        ]);
+        let mut doc = json!({ "info": { "title": "API" } });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(doc["info"]["description"], "v2");
+    }
+
+    #[test]
+    fn apply_mixed_kind_strict_errors() {
+        let o = ovl(vec![Action {
+            target: "$.choices[*]".into(),
+            update: Some(json!({ "z": 1 })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "choices": [ { "a": 1 }, [ 1, 2 ] ]
+        });
+        let snapshot = doc.clone();
+        let err = o
+            .apply(&mut doc, ApplyOptions::ErrorOnMixedKindMatch.into())
+            .unwrap_err();
+        assert_eq!(err.kind, ApplyErrorKind::MixedKindMatch);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_mixed_kind_lax_silently_merges_uniformly() {
+        let o = ovl(vec![Action {
+            target: "$.choices[*]".into(),
+            update: Some(json!({ "z": 1 })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "choices": [ { "a": 1 }, [ 1, 2 ] ]
+        });
+        // Without ErrorOnMixedKindMatch, no error; per-node merge runs.
+        // Object gets the new key; array (shape mismatch with update
+        // object) gets replaced by the update value.
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(doc["choices"][0], json!({ "a": 1, "z": 1 }));
+        assert_eq!(doc["choices"][1], json!({ "z": 1 }));
+    }
+
+    #[test]
+    fn apply_remove_only_no_update_runs_clean() {
+        let o = ovl(vec![Action {
+            target: "$.foo".into(),
+            // Neither remove nor update — should be a clean no-op
+            // with matched > 0.
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "foo": { "a": 1 } });
+        let r = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(r.actions[0].operation, Operation::Update);
+        assert_eq!(r.actions[0].matched, 1);
+        assert_eq!(doc, json!({ "foo": { "a": 1 } }));
+    }
+}

--- a/crates/roas-overlay/src/v1_0/version.rs
+++ b/crates/roas-overlay/src/v1_0/version.rs
@@ -43,8 +43,11 @@ impl serde::Serialize for Version {
 
 const VERSION_SCHEMA_DESCRIPTION: &str = "`1.0.<patch>` semver (Overlay v1.0)";
 
+/// Schema pattern is `^1\.0\.\d+$` — hand-rolled to avoid pulling in
+/// `lazy-regex` just for this one check.
 fn matches_overlay_1_0_version(s: &str) -> bool {
-    lazy_regex::regex!(r"^1\.0\.\d+$").is_match(s)
+    s.strip_prefix("1.0.")
+        .is_some_and(|patch| !patch.is_empty() && patch.bytes().all(|b| b.is_ascii_digit()))
 }
 
 impl<'de> serde::Deserialize<'de> for Version {

--- a/crates/roas-overlay/src/v1_0/version.rs
+++ b/crates/roas-overlay/src/v1_0/version.rs
@@ -153,4 +153,18 @@ mod tests {
         let v: Version = "1.0.3".parse().unwrap();
         assert_eq!(format!("{v}"), "1.0.3");
     }
+
+    #[test]
+    fn try_from_str_and_string_match_from_str() {
+        // `TryFrom<&str>` and `TryFrom<String>` exist for API parity
+        // with `roas::v3_2::spec::Version`; both should agree with
+        // `FromStr` on accept/reject.
+        assert_eq!(Version::try_from("1.0.0").unwrap(), Version::V1_0_0());
+        assert!(Version::try_from("2.0.0").is_err());
+
+        let owned_ok = Version::try_from(String::from("1.0.7")).unwrap();
+        assert_eq!(owned_ok.as_str(), "1.0.7");
+        let owned_err = Version::try_from(String::from("nope")).unwrap_err();
+        assert_eq!(owned_err.0, "nope");
+    }
 }

--- a/crates/roas-overlay/src/v1_0/version.rs
+++ b/crates/roas-overlay/src/v1_0/version.rs
@@ -1,0 +1,153 @@
+//! Version newtype for Overlay v1.0 (`overlay: "1.0.x"`).
+//!
+//! Mirrors `roas::v3_2::spec::Version`: the field is a string at the
+//! wire level but constrained to the schema pattern `^1\.0\.\d+$`
+//! ([JSON Schema](https://spec.openapis.org/overlay/1.0/schema/2026-04-01)).
+//! Deserialization rejects non-1.0 values up front so callers don't
+//! have to revalidate.
+
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version(String);
+
+impl Default for Version {
+    fn default() -> Self {
+        Self("1.0.0".to_owned())
+    }
+}
+
+impl Version {
+    /// Canonical `1.0.0` value.
+    #[allow(non_snake_case)]
+    pub fn V1_0_0() -> Self {
+        Self("1.0.0".to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+const VERSION_SCHEMA_DESCRIPTION: &str = "`1.0.<patch>` semver (Overlay v1.0)";
+
+fn matches_overlay_1_0_version(s: &str) -> bool {
+    lazy_regex::regex!(r"^1\.0\.\d+$").is_match(s)
+}
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &VERSION_SCHEMA_DESCRIPTION,
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidVersion(pub String);
+
+impl Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "overlay version {:?} must be {VERSION_SCHEMA_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if matches_overlay_1_0_version(s) {
+            Ok(Version(s.to_owned()))
+        } else {
+            Err(InvalidVersion(s.to_owned()))
+        }
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if matches_overlay_1_0_version(&s) {
+            Ok(Version(s))
+        } else {
+            Err(InvalidVersion(s))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_1_0_0() {
+        assert_eq!(Version::default().as_str(), "1.0.0");
+    }
+
+    #[test]
+    fn accepts_matching_patch_versions() {
+        assert!("1.0.0".parse::<Version>().is_ok());
+        assert!("1.0.42".parse::<Version>().is_ok());
+    }
+
+    #[test]
+    fn rejects_non_matching_versions() {
+        for bad in ["1.1.0", "2.0.0", "1.0", "1.0.x", "v1.0.0", ""] {
+            let err = bad.parse::<Version>().unwrap_err();
+            assert_eq!(err.0, bad);
+            let msg = err.to_string();
+            assert!(msg.contains(bad), "msg should echo input: {msg}");
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_wrong_minor() {
+        let err = serde_json::from_value::<Version>(serde_json::json!("1.1.0")).unwrap_err();
+        assert!(
+            err.to_string().contains("1.0"),
+            "expected schema description in error: {err}"
+        );
+    }
+
+    #[test]
+    fn serialize_round_trips_through_string() {
+        let v = Version::V1_0_0();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#""1.0.0""#);
+        let back: Version = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn display_renders_inner_string() {
+        let v: Version = "1.0.3".parse().unwrap();
+        assert_eq!(format!("{v}"), "1.0.3");
+    }
+}

--- a/crates/roas-overlay/src/validation.rs
+++ b/crates/roas-overlay/src/validation.rs
@@ -1,0 +1,273 @@
+//! Validation framework for Overlay documents.
+//!
+//! Modeled after [`roas::validation`]: a public [`Validate`] trait
+//! drives a recursive descent through a per-component crate-internal
+//! trait; each component pushes diagnostics into a context keyed by
+//! a JSONPath-flavor path string. Errors collect rather than fail
+//! fast.
+//!
+//! [`roas::validation`]: https://docs.rs/roas/latest/roas/validation/index.html
+
+use enumset::{EnumSet, EnumSetType};
+use std::fmt::{self, Display};
+
+/// A single validation finding.
+///
+/// `path` is a human-readable locator (e.g. `#.actions[3].target`),
+/// not an RFC 6901 JSON Pointer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ValidationError {
+    pub path: String,
+    pub message: String,
+}
+
+impl ValidationError {
+    pub(crate) fn new(path: String, message: String) -> Self {
+        Self { path, message }
+    }
+
+    /// Substring search across path and message (and the rendered
+    /// boundary). Mirrors the helper of the same name in `roas` for
+    /// consistency.
+    pub fn contains(&self, needle: &str) -> bool {
+        if self.path.contains(needle) || self.message.contains(needle) {
+            return true;
+        }
+        self.to_string().contains(needle)
+    }
+}
+
+impl Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.path, self.message)
+    }
+}
+
+impl PartialEq<str> for ValidationError {
+    fn eq(&self, other: &str) -> bool {
+        let plen = self.path.len();
+        let sep = ": ";
+        other.len() == plen + sep.len() + self.message.len()
+            && other.starts_with(&self.path)
+            && other[plen..].starts_with(sep)
+            && other[plen + sep.len()..] == self.message
+    }
+}
+
+impl PartialEq<&str> for ValidationError {
+    fn eq(&self, other: &&str) -> bool {
+        <ValidationError as PartialEq<str>>::eq(self, other)
+    }
+}
+
+/// The accumulated outcome of a validation pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Error {
+    pub errors: Vec<ValidationError>,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{} errors found:", self.errors.len())?;
+        for error in &self.errors {
+            writeln!(f, "- {error}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Per-call validation toggles.
+///
+/// Each option suppresses one shallow check so callers can opt out of
+/// individual diagnostics without disabling the whole validator.
+#[derive(EnumSetType, Debug)]
+pub enum ValidationOptions {
+    /// Allow `info.title` to be empty (still required to be present).
+    IgnoreEmptyInfoTitle,
+    /// Allow `info.version` to be empty (still required to be present).
+    IgnoreEmptyInfoVersion,
+    /// Skip the URI-reference format check on `extends`.
+    IgnoreExtendsFormat,
+}
+
+#[cfg(feature = "clap")]
+impl clap::ValueEnum for ValidationOptions {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            ValidationOptions::IgnoreEmptyInfoTitle,
+            ValidationOptions::IgnoreEmptyInfoVersion,
+            ValidationOptions::IgnoreExtendsFormat,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        let (name, help) = match self {
+            ValidationOptions::IgnoreEmptyInfoTitle => {
+                ("empty-info-title", "Allow empty `info.title`")
+            }
+            ValidationOptions::IgnoreEmptyInfoVersion => {
+                ("empty-info-version", "Allow empty `info.version`")
+            }
+            ValidationOptions::IgnoreExtendsFormat => (
+                "extends-format",
+                "Skip the URI-reference format check on `extends`",
+            ),
+        };
+        Some(clap::builder::PossibleValue::new(name).help(help))
+    }
+}
+
+/// Validate an Overlay document, collecting every diagnostic.
+pub trait Validate {
+    fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error>;
+}
+
+/// Crate-internal: implemented by every component type. The generic
+/// parameter `O` exists so per-version overlays can have their own
+/// component impls without ambiguity, even though the validator
+/// itself doesn't reach into the overlay during the recursive descent.
+pub(crate) trait ValidateWithContext<O> {
+    fn validate_with_context(&self, ctx: &mut Context<O>, path: String);
+}
+
+pub(crate) struct Context<O> {
+    pub options: EnumSet<ValidationOptions>,
+    pub errors: Vec<ValidationError>,
+    _marker: std::marker::PhantomData<fn() -> O>,
+}
+
+impl<O> Context<O> {
+    pub fn new(options: EnumSet<ValidationOptions>) -> Self {
+        Self {
+            options,
+            errors: Vec::new(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn is_option(&self, option: ValidationOptions) -> bool {
+        self.options.contains(option)
+    }
+
+    pub fn error(&mut self, path: String, message: impl Into<String>) {
+        self.errors.push(ValidationError::new(path, message.into()));
+    }
+
+    pub fn into_result(self) -> Result<(), Error> {
+        if self.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(Error {
+                errors: self.errors,
+            })
+        }
+    }
+}
+
+/// Validate that a required string is not empty. Mirrors the helper
+/// in `roas::common::helpers::validate_required_string` so per-version
+/// modules stay readable.
+pub(crate) fn validate_required_string<O>(s: &str, ctx: &mut Context<O>, path: String) {
+    if s.is_empty() {
+        ctx.error(path, "must not be empty");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_renders_with_count_and_bullets() {
+        let err = Error {
+            errors: vec![
+                ValidationError::new("#.a".into(), "first".into()),
+                ValidationError::new("#.b".into(), "second".into()),
+            ],
+        };
+        assert_eq!(
+            format!("{err}"),
+            "2 errors found:\n- #.a: first\n- #.b: second\n",
+        );
+    }
+
+    #[test]
+    fn error_zero_count_still_renders_header() {
+        let err = Error { errors: vec![] };
+        assert_eq!(format!("{err}"), "0 errors found:\n");
+    }
+
+    #[test]
+    fn validation_error_partial_eq_against_str_matches_display_form() {
+        let e = ValidationError::new("#.info.title".into(), "must not be empty".into());
+        // Exercises both PartialEq<&str> (via the literal) and
+        // PartialEq<str> (via deref of an owned String).
+        assert!(e == "#.info.title: must not be empty");
+        let owned = String::from("#.info.title: must not be empty");
+        assert!(e == *owned.as_str());
+        assert!(e != "different");
+    }
+
+    #[test]
+    fn validation_error_contains_matches_across_boundary() {
+        let e = ValidationError::new("#.info.title".into(), "must not be empty".into());
+        assert!(e.contains("title: must"));
+        assert!(e.contains("#.info"));
+        assert!(e.contains("must not"));
+        assert!(!e.contains("nowhere"));
+    }
+
+    #[test]
+    fn context_collects_errors_and_converts_to_result() {
+        let mut ctx: Context<()> = Context::new(EnumSet::empty());
+        ctx.error("#.x".into(), "kaboom");
+        let r = ctx.into_result();
+        let err = r.unwrap_err();
+        assert_eq!(err.errors.len(), 1);
+    }
+
+    #[test]
+    fn context_with_no_errors_returns_ok() {
+        let ctx: Context<()> = Context::new(EnumSet::empty());
+        assert!(ctx.into_result().is_ok());
+    }
+
+    #[test]
+    fn context_is_option_reflects_set_membership() {
+        let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle);
+        let ctx: Context<()> = Context::new(opts);
+        assert!(ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle));
+        assert!(!ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion));
+    }
+
+    #[test]
+    fn validate_required_string_pushes_error_for_empty() {
+        let mut ctx: Context<()> = Context::new(EnumSet::empty());
+        validate_required_string("", &mut ctx, "#.info.title".into());
+        validate_required_string("ok", &mut ctx, "#.info.version".into());
+        assert_eq!(ctx.errors.len(), 1);
+        assert!(ctx.errors[0] == "#.info.title: must not be empty");
+    }
+}
+
+#[cfg(all(test, feature = "clap"))]
+mod clap_tests {
+    use super::*;
+    use clap::ValueEnum;
+
+    #[test]
+    fn value_variants_round_trip_through_kebab_case_names() {
+        for v in <ValidationOptions as ValueEnum>::value_variants() {
+            let pv = v.to_possible_value().expect("possible value");
+            let name = pv.get_name();
+            let parsed = <ValidationOptions as ValueEnum>::from_str(name, false).expect("parses");
+            assert_eq!(parsed, *v);
+            assert!(
+                name.bytes().all(|b| b.is_ascii_lowercase() || b == b'-'),
+                "name `{name}` must be kebab-case",
+            );
+        }
+    }
+}

--- a/crates/roas-overlay/src/validation.rs
+++ b/crates/roas-overlay/src/validation.rs
@@ -88,8 +88,6 @@ pub enum ValidationOptions {
     IgnoreEmptyInfoTitle,
     /// Allow `info.version` to be empty (still required to be present).
     IgnoreEmptyInfoVersion,
-    /// Skip the URI-reference format check on `extends`.
-    IgnoreExtendsFormat,
 }
 
 #[cfg(feature = "clap")]
@@ -98,7 +96,6 @@ impl clap::ValueEnum for ValidationOptions {
         &[
             ValidationOptions::IgnoreEmptyInfoTitle,
             ValidationOptions::IgnoreEmptyInfoVersion,
-            ValidationOptions::IgnoreExtendsFormat,
         ]
     }
 
@@ -110,10 +107,6 @@ impl clap::ValueEnum for ValidationOptions {
             ValidationOptions::IgnoreEmptyInfoVersion => {
                 ("empty-info-version", "Allow empty `info.version`")
             }
-            ValidationOptions::IgnoreExtendsFormat => (
-                "extends-format",
-                "Skip the URI-reference format check on `extends`",
-            ),
         };
         Some(clap::builder::PossibleValue::new(name).help(help))
     }
@@ -124,26 +117,21 @@ pub trait Validate {
     fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error>;
 }
 
-/// Crate-internal: implemented by every component type. The generic
-/// parameter `O` exists so per-version overlays can have their own
-/// component impls without ambiguity, even though the validator
-/// itself doesn't reach into the overlay during the recursive descent.
-pub(crate) trait ValidateWithContext<O> {
-    fn validate_with_context(&self, ctx: &mut Context<O>, path: String);
+/// Crate-internal: implemented by every component type.
+pub(crate) trait ValidateWithContext {
+    fn validate_with_context(&self, ctx: &mut Context, path: String);
 }
 
-pub(crate) struct Context<O> {
+pub(crate) struct Context {
     pub options: EnumSet<ValidationOptions>,
     pub errors: Vec<ValidationError>,
-    _marker: std::marker::PhantomData<fn() -> O>,
 }
 
-impl<O> Context<O> {
+impl Context {
     pub fn new(options: EnumSet<ValidationOptions>) -> Self {
         Self {
             options,
             errors: Vec::new(),
-            _marker: std::marker::PhantomData,
         }
     }
 
@@ -166,10 +154,9 @@ impl<O> Context<O> {
     }
 }
 
-/// Validate that a required string is not empty. Mirrors the helper
-/// in `roas::common::helpers::validate_required_string` so per-version
-/// modules stay readable.
-pub(crate) fn validate_required_string<O>(s: &str, ctx: &mut Context<O>, path: String) {
+/// Validate that a required string is not empty. Mirrors
+/// `roas::common::helpers::validate_required_string`.
+pub(crate) fn validate_required_string(s: &str, ctx: &mut Context, path: String) {
     if s.is_empty() {
         ctx.error(path, "must not be empty");
     }
@@ -221,7 +208,7 @@ mod tests {
 
     #[test]
     fn context_collects_errors_and_converts_to_result() {
-        let mut ctx: Context<()> = Context::new(EnumSet::empty());
+        let mut ctx = Context::new(EnumSet::empty());
         ctx.error("#.x".into(), "kaboom");
         let r = ctx.into_result();
         let err = r.unwrap_err();
@@ -230,21 +217,21 @@ mod tests {
 
     #[test]
     fn context_with_no_errors_returns_ok() {
-        let ctx: Context<()> = Context::new(EnumSet::empty());
+        let ctx = Context::new(EnumSet::empty());
         assert!(ctx.into_result().is_ok());
     }
 
     #[test]
     fn context_is_option_reflects_set_membership() {
         let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle);
-        let ctx: Context<()> = Context::new(opts);
+        let ctx = Context::new(opts);
         assert!(ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle));
         assert!(!ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion));
     }
 
     #[test]
     fn validate_required_string_pushes_error_for_empty() {
-        let mut ctx: Context<()> = Context::new(EnumSet::empty());
+        let mut ctx = Context::new(EnumSet::empty());
         validate_required_string("", &mut ctx, "#.info.title".into());
         validate_required_string("ok", &mut ctx, "#.info.version".into());
         assert_eq!(ctx.errors.len(), 1);

--- a/crates/roas-overlay/tests/v1_0_data/bad_empty_actions.json
+++ b/crates/roas-overlay/tests/v1_0_data/bad_empty_actions.json
@@ -1,0 +1,5 @@
+{
+  "overlay": "1.0.0",
+  "info": { "title": "Empty actions list", "version": "1.0.0" },
+  "actions": []
+}

--- a/crates/roas-overlay/tests/v1_0_data/bad_invalid_jsonpath.json
+++ b/crates/roas-overlay/tests/v1_0_data/bad_invalid_jsonpath.json
@@ -1,0 +1,7 @@
+{
+  "overlay": "1.0.0",
+  "info": { "title": "Bad target", "version": "1.0.0" },
+  "actions": [
+    { "target": "not a path", "update": {} }
+  ]
+}

--- a/crates/roas-overlay/tests/v1_0_data/bad_remove_and_update.json
+++ b/crates/roas-overlay/tests/v1_0_data/bad_remove_and_update.json
@@ -1,0 +1,11 @@
+{
+  "overlay": "1.0.0",
+  "info": { "title": "Conflicting action", "version": "1.0.0" },
+  "actions": [
+    {
+      "target": "$.foo",
+      "remove": true,
+      "update": { "ignored": true }
+    }
+  ]
+}

--- a/crates/roas-overlay/tests/v1_0_data/base_petstore.json
+++ b/crates/roas-overlay/tests/v1_0_data/base_petstore.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Pet Store",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List pets",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    },
+    "/internal/metrics": {
+      "get": {
+        "summary": "Internal metrics",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/crates/roas-overlay/tests/v1_0_data/remove_internal.expected.json
+++ b/crates/roas-overlay/tests/v1_0_data/remove_internal.expected.json
@@ -1,0 +1,23 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Pet Store",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List pets",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    }
+  }
+}

--- a/crates/roas-overlay/tests/v1_0_data/remove_internal.json
+++ b/crates/roas-overlay/tests/v1_0_data/remove_internal.json
@@ -1,0 +1,14 @@
+{
+  "overlay": "1.0.0",
+  "info": {
+    "title": "Strip internal endpoints",
+    "version": "1.0.0"
+  },
+  "actions": [
+    {
+      "target": "$.paths['/internal/metrics']",
+      "remove": true,
+      "description": "Hide internal-only paths from the public bundle."
+    }
+  ]
+}

--- a/crates/roas-overlay/tests/v1_0_data/sequential_actions.expected.json
+++ b/crates/roas-overlay/tests/v1_0_data/sequential_actions.expected.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Pet Store",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List pets",
+        "description": "List all pets in the store.",
+        "tags": ["pets", "public"],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    }
+  }
+}

--- a/crates/roas-overlay/tests/v1_0_data/sequential_actions.yaml
+++ b/crates/roas-overlay/tests/v1_0_data/sequential_actions.yaml
@@ -1,0 +1,15 @@
+overlay: 1.0.0
+info:
+  title: Sequential actions demo
+  version: 1.0.0
+actions:
+  - target: $.paths['/pets'].get
+    update:
+      description: List all pets in the store.
+  - target: $.paths['/pets'].get
+    update:
+      tags:
+        - pets
+        - public
+  - target: $.paths['/internal/metrics']
+    remove: true

--- a/crates/roas-overlay/tests/v1_0_data/targeted_overlay.expected.json
+++ b/crates/roas-overlay/tests/v1_0_data/targeted_overlay.expected.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Pet Store",
+    "version": "1.0.0",
+    "contact": {
+      "name": "API Team",
+      "email": "api@example.com"
+    }
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List pets",
+        "description": "List all pets in the store.",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    },
+    "/internal/metrics": {
+      "get": {
+        "summary": "Internal metrics",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/crates/roas-overlay/tests/v1_0_data/targeted_overlay.json
+++ b/crates/roas-overlay/tests/v1_0_data/targeted_overlay.json
@@ -1,0 +1,26 @@
+{
+  "overlay": "1.0.0",
+  "info": {
+    "title": "Add descriptions to GET operations",
+    "version": "1.0.0"
+  },
+  "extends": "./base_petstore.json",
+  "actions": [
+    {
+      "target": "$.paths['/pets'].get",
+      "description": "Annotate the list endpoint.",
+      "update": {
+        "description": "List all pets in the store."
+      }
+    },
+    {
+      "target": "$.info",
+      "update": {
+        "contact": {
+          "name": "API Team",
+          "email": "api@example.com"
+        }
+      }
+    }
+  ]
+}

--- a/crates/roas-overlay/tests/v1_0_test.rs
+++ b/crates/roas-overlay/tests/v1_0_test.rs
@@ -136,19 +136,23 @@ fn error_on_zero_match_aborts_and_rolls_back() {
 }
 
 #[test]
-fn ignore_extends_format_option_skips_extends_diagnostic() {
+fn ignore_info_options_suppress_diagnostics() {
     let mut overlay = load_overlay_json("targeted_overlay.json");
-    overlay.extends = Some(String::new());
+    overlay.info.title.clear();
+    overlay.info.version.clear();
 
-    // Without the option, the empty `extends` field is flagged.
     let err = overlay.validate(EnumSet::empty()).unwrap_err();
     assert!(
         err.errors
             .iter()
-            .any(|e| e == "#.extends: must not be empty")
+            .any(|e| e == "#.info.title: must not be empty")
+    );
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e == "#.info.version: must not be empty")
     );
 
-    // With the option set, the diagnostic is suppressed.
-    let opts = ValidationOptions::IgnoreExtendsFormat.into();
-    overlay.validate(opts).expect("validates with option");
+    let opts = ValidationOptions::IgnoreEmptyInfoTitle | ValidationOptions::IgnoreEmptyInfoVersion;
+    overlay.validate(opts).expect("validates with options");
 }

--- a/crates/roas-overlay/tests/v1_0_test.rs
+++ b/crates/roas-overlay/tests/v1_0_test.rs
@@ -1,0 +1,154 @@
+//! Integration tests for Overlay v1.0: load fixtures from
+//! `tests/v1_0_data/`, parse them, validate, apply, and compare
+//! against checked-in `*.expected.json` fixtures.
+
+#![cfg(feature = "v1_0")]
+
+use enumset::EnumSet;
+use roas_overlay::apply::{Apply, ApplyErrorKind, ApplyOptions};
+use roas_overlay::v1_0::Overlay;
+use roas_overlay::validation::{Validate, ValidationOptions};
+use std::path::{Path, PathBuf};
+
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("v1_0_data")
+}
+
+fn load_json(name: &str) -> serde_json::Value {
+    let path = data_dir().join(name);
+    let s =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn load_yaml(name: &str) -> serde_json::Value {
+    let path = data_dir().join(name);
+    let s =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml_ng::from_str(&s).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn load_overlay_json(name: &str) -> Overlay {
+    serde_json::from_value(load_json(name)).expect("overlay deserialize")
+}
+
+fn load_overlay_yaml(name: &str) -> Overlay {
+    serde_json::from_value(load_yaml(name)).expect("overlay deserialize")
+}
+
+#[test]
+fn targeted_overlay_applies_and_validates() {
+    let overlay = load_overlay_json("targeted_overlay.json");
+    overlay
+        .validate(EnumSet::empty())
+        .expect("overlay must validate");
+
+    let mut target = load_json("base_petstore.json");
+    let report = overlay
+        .apply(&mut target, EnumSet::empty())
+        .expect("apply must succeed");
+    assert_eq!(report.actions.len(), 2);
+    assert!(report.actions.iter().all(|a| a.matched == 1));
+
+    let expected = load_json("targeted_overlay.expected.json");
+    assert_eq!(target, expected);
+}
+
+#[test]
+fn remove_action_drops_internal_path() {
+    let overlay = load_overlay_json("remove_internal.json");
+    overlay.validate(EnumSet::empty()).expect("validates");
+
+    let mut target = load_json("base_petstore.json");
+    let report = overlay
+        .apply(&mut target, EnumSet::empty())
+        .expect("apply succeeds");
+    assert_eq!(report.actions[0].matched, 1);
+
+    let expected = load_json("remove_internal.expected.json");
+    assert_eq!(target, expected);
+}
+
+#[test]
+fn sequential_yaml_overlay_composes_actions_in_order() {
+    let overlay = load_overlay_yaml("sequential_actions.yaml");
+    overlay.validate(EnumSet::empty()).expect("validates");
+
+    let mut target = load_json("base_petstore.json");
+    overlay
+        .apply(&mut target, EnumSet::empty())
+        .expect("apply succeeds");
+
+    let expected = load_json("sequential_actions.expected.json");
+    assert_eq!(target, expected);
+}
+
+#[test]
+fn empty_actions_fixture_fails_validation_with_helpful_path() {
+    let overlay = load_overlay_json("bad_empty_actions.json");
+    let err = overlay.validate(EnumSet::empty()).unwrap_err();
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e == "#.actions: must contain at least one entry"),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn invalid_jsonpath_fixture_fails_validation_and_apply() {
+    let overlay = load_overlay_json("bad_invalid_jsonpath.json");
+    let err = overlay.validate(EnumSet::empty()).unwrap_err();
+    assert!(
+        err.errors.iter().any(|e| e.contains("invalid JSONPath")),
+        "got: {err}",
+    );
+
+    let mut target = serde_json::json!({});
+    let snapshot = target.clone();
+    let apply_err = overlay.apply(&mut target, EnumSet::empty()).unwrap_err();
+    assert!(matches!(apply_err.kind, ApplyErrorKind::InvalidJsonPath(_)));
+    assert_eq!(target, snapshot, "target must be unchanged on apply error");
+}
+
+#[test]
+fn conflicting_remove_and_update_fixture_fails_validation() {
+    let overlay = load_overlay_json("bad_remove_and_update.json");
+    let err = overlay.validate(EnumSet::empty()).unwrap_err();
+    assert!(
+        err.errors.iter().any(|e| e.contains("mutually exclusive")),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn error_on_zero_match_aborts_and_rolls_back() {
+    let overlay = load_overlay_json("targeted_overlay.json");
+    let mut target = serde_json::json!({ "openapi": "3.1.0", "info": {} });
+    let snapshot = target.clone();
+    let err = overlay
+        .apply(&mut target, ApplyOptions::ErrorOnZeroMatch.into())
+        .unwrap_err();
+    assert!(matches!(err.kind, ApplyErrorKind::ZeroMatch));
+    assert_eq!(target, snapshot);
+}
+
+#[test]
+fn ignore_extends_format_option_skips_extends_diagnostic() {
+    let mut overlay = load_overlay_json("targeted_overlay.json");
+    overlay.extends = Some(String::new());
+
+    // Without the option, the empty `extends` field is flagged.
+    let err = overlay.validate(EnumSet::empty()).unwrap_err();
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e == "#.extends: must not be empty")
+    );
+
+    // With the option set, the diagnostic is suppressed.
+    let opts = ValidationOptions::IgnoreExtendsFormat.into();
+    overlay.validate(opts).expect("validates with option");
+}


### PR DESCRIPTION
New sibling workspace crate implementing the [OpenAPI Overlay Specification v1.0](https://spec.openapis.org/overlay/v1.0.0.html): parse, validate, and apply.

Operates on `serde_json::Value` (not typed `roas` specs) so a single impl works across v2.0 / v3.0 / v3.1 / v3.2 and so overlays that produce intermediate states the typed model would reject still apply cleanly. JSONPath via `serde_json_path` (RFC 9535).

Apply runs against a clone and commits on success — on error `target` is untouched. Options exposed: `ErrorOnZeroMatch`, `ErrorOnMixedKindMatch`. Validation produces collecting (not fail-fast) diagnostics with JSONPath-flavor paths.

Per-version files (`v1_0/`) stay duplicated; the v1.1 follow-up will copy and add `copy` action plus `info.description`.

Local checks pass: `cargo fmt`, `cargo clippy -p roas-overlay --all-features --all-targets -- -D warnings`, `cargo nextest run --workspace --all-features` (1888 tests), doctests.

Assisted-By: Claude <noreply@anthropic.com>