### PR TITLE
feat(roas-overlay): add Overlay v1.1 (copy action + info.description)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -100,3 +100,8 @@ component_management:
       paths:
         - crates/roas-overlay/src/v1_0/**
         - crates/roas-overlay/tests/v1_0_test.rs
+    - component_id: overlay-v1_1
+      name: overlay-v1.1
+      paths:
+        - crates/roas-overlay/src/v1_1/**
+        - crates/roas-overlay/tests/v1_1_test.rs

--- a/crates/roas-overlay/Cargo.toml
+++ b/crates/roas-overlay/Cargo.toml
@@ -15,9 +15,11 @@ publish = true
 
 [features]
 default = ["v1_0"]
-# Support for OpenAPI Overlay v1.0.x
+# Support for OpenAPI Overlay v1.0.x.
 v1_0 = []
-# Support for OpenAPI Overlay v1.1.x (not yet implemented)
+# Support for OpenAPI Overlay v1.1.x. Independent of `v1_0`; enable
+# both to get the additional `From<v1_0::Overlay> for v1_1::Overlay`
+# upconversion impl.
 v1_1 = []
 
 # `clap::ValueEnum` impls for `apply::ApplyOptions` and

--- a/crates/roas-overlay/README.md
+++ b/crates/roas-overlay/README.md
@@ -59,10 +59,12 @@ For each action in declaration order, against the *current* working copy of the 
 3. Zero matches → silent no-op (or `ZeroMatch` error under `ApplyOptions::ErrorOnZeroMatch`).
 4. Targets must be objects or arrays for *every* action (spec §4.4); primitives or `null` raise `PrimitiveActionTarget`.
 5. `remove: true` → drop each matched node from its container. Sibling array indices are preserved by processing matches in reverse.
-6. **v1.1 only:** if `copy` is set, the action's source JSONPath is evaluated against the *current* doc; it must match exactly one node (`CopySourceNotFound` / `CopySourceMultiple`). The source value is then merged into each `target` as if it were `update`.
-7. Otherwise, if `update` is set, the behavior depends on the matched node's kind:
-   - **Array target** → the merge value is appended as a single new element, regardless of its shape (spec §4.4: *"an entry to append to the array"*).
-   - **Object target** → recursive merge per [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules): keys present in both sides recurse (objects), or use the merge rules (primitives replace, arrays concatenate at the property level).
+6. **v1.1 only:** if `copy` is set, the action's source JSONPath is evaluated against the *current* doc; it must match exactly one node (`CopySourceNotFound` / `CopySourceMultiple`). The source value is then used as the merge value, exactly like `update`. Setting both `update` and `copy` raises `ConflictingMergeSources`.
+7. Otherwise, the merge value (`update`, or the `copy` source) is merged into each matched node by kind:
+   - **Object target** → recursive merge per [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules): shared object keys recurse; primitives replace; nested arrays concatenate.
+   - **Array target** → depends on the version:
+     - **v1.0** — the merge value is appended as a single new element (spec §3.3: *"an entry to append to the array"*).
+     - **v1.1** — an *array* merge value is concatenated element-wise; an *object or primitive* merge value is appended as a single element (spec §3.3).
 
 On any error the target document is left **untouched** — `Overlay::apply` operates on a clone and commits only on success.
 

--- a/crates/roas-overlay/README.md
+++ b/crates/roas-overlay/README.md
@@ -10,10 +10,12 @@ This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed pa
 
 ## Versions
 
-| Overlay version | Feature flag     | Status            |
-|-----------------|------------------|-------------------|
-| 1.0             | `v1_0` (default) | ✅ implemented     |
-| 1.1             | `v1_1`           | planned (next PR) |
+| Overlay version | Feature flag     | Status         | Adds over the previous version                     |
+|-----------------|------------------|----------------|----------------------------------------------------|
+| 1.0             | `v1_0` (default) | ✅ implemented  | —                                                  |
+| 1.1             | `v1_1`           | ✅ implemented  | `copy` action, `info.description`                  |
+
+`v1_0` and `v1_1` are independent — enable whichever you need. With both enabled, an `impl From<v1_0::Overlay> for v1_1::Overlay` is available for upconverting an existing v1.0 document.
 
 ## Quick start
 
@@ -57,8 +59,9 @@ For each action in declaration order, against the *current* working copy of the 
 3. Zero matches → silent no-op (or `ZeroMatch` error under `ApplyOptions::ErrorOnZeroMatch`).
 4. Targets must be objects or arrays for *every* action (spec §4.4); primitives or `null` raise `PrimitiveActionTarget`.
 5. `remove: true` → drop each matched node from its container. Sibling array indices are preserved by processing matches in reverse.
-6. Otherwise, if `update` is set, the behavior depends on the matched node's kind:
-   - **Array target** → `update` is appended as a single new element, regardless of its shape (spec §4.4: *"an entry to append to the array"*).
+6. **v1.1 only:** if `copy` is set, the action's source JSONPath is evaluated against the *current* doc; it must match exactly one node (`CopySourceNotFound` / `CopySourceMultiple`). The source value is then merged into each `target` as if it were `update`.
+7. Otherwise, if `update` is set, the behavior depends on the matched node's kind:
+   - **Array target** → the merge value is appended as a single new element, regardless of its shape (spec §4.4: *"an entry to append to the array"*).
    - **Object target** → recursive merge per [§4.4.3.1](https://spec.openapis.org/overlay/v1.0.0.html#merging-rules): keys present in both sides recurse (objects), or use the merge rules (primitives replace, arrays concatenate at the property level).
 
 On any error the target document is left **untouched** — `Overlay::apply` operates on a clone and commits only on success.

--- a/crates/roas-overlay/src/apply.rs
+++ b/crates/roas-overlay/src/apply.rs
@@ -73,6 +73,9 @@ pub struct ActionOutcome {
 pub enum Operation {
     Update,
     Remove,
+    /// Overlay v1.1 only: source node located via the action's `copy`
+    /// JSONPath was merged into each matched `target` node.
+    Copy,
 }
 
 impl Display for Operation {
@@ -80,6 +83,7 @@ impl Display for Operation {
         f.write_str(match self {
             Operation::Update => "update",
             Operation::Remove => "remove",
+            Operation::Copy => "copy",
         })
     }
 }
@@ -128,6 +132,12 @@ pub enum ApplyErrorKind {
     /// requires action targets to be objects or arrays, for both
     /// `update` and `remove` actions.
     PrimitiveActionTarget,
+    /// Overlay v1.1 only: the action's `copy` JSONPath is
+    /// syntactically valid but matched no node in the working doc.
+    CopySourceNotFound(String),
+    /// Overlay v1.1 only: the action's `copy` JSONPath matched more
+    /// than one node; the spec requires exactly one source.
+    CopySourceMultiple(String),
 }
 
 impl Display for ApplyErrorKind {
@@ -145,6 +155,13 @@ impl Display for ApplyErrorKind {
                 "action `target` must resolve to objects or arrays, \
                  not primitives or null",
             ),
+            ApplyErrorKind::CopySourceNotFound(s) => {
+                write!(f, "`copy` source {s:?} matched no node")
+            }
+            ApplyErrorKind::CopySourceMultiple(s) => write!(
+                f,
+                "`copy` source {s:?} matched multiple nodes; exactly one is required",
+            ),
         }
     }
 }
@@ -157,6 +174,7 @@ mod tests {
     fn operation_display_uses_lowercase_words() {
         assert_eq!(Operation::Update.to_string(), "update");
         assert_eq!(Operation::Remove.to_string(), "remove");
+        assert_eq!(Operation::Copy.to_string(), "copy");
     }
 
     #[test]
@@ -179,6 +197,8 @@ mod tests {
             ApplyErrorKind::ZeroMatch,
             ApplyErrorKind::MixedKindMatch,
             ApplyErrorKind::PrimitiveActionTarget,
+            ApplyErrorKind::CopySourceNotFound("$.src".into()),
+            ApplyErrorKind::CopySourceMultiple("$.src".into()),
         ];
         for k in cases {
             assert!(

--- a/crates/roas-overlay/src/apply.rs
+++ b/crates/roas-overlay/src/apply.rs
@@ -138,6 +138,10 @@ pub enum ApplyErrorKind {
     /// Overlay v1.1 only: the action's `copy` JSONPath matched more
     /// than one node; the spec requires exactly one source.
     CopySourceMultiple(String),
+    /// Overlay v1.1 only: the action set both `update` and `copy`,
+    /// which the spec treats as mutually exclusive. Validation flags
+    /// this; apply fails fast rather than silently dropping one.
+    ConflictingMergeSources,
 }
 
 impl Display for ApplyErrorKind {
@@ -162,6 +166,9 @@ impl Display for ApplyErrorKind {
                 f,
                 "`copy` source {s:?} matched multiple nodes; exactly one is required",
             ),
+            ApplyErrorKind::ConflictingMergeSources => {
+                f.write_str("action sets both `update` and `copy`; they are mutually exclusive")
+            }
         }
     }
 }
@@ -199,6 +206,7 @@ mod tests {
             ApplyErrorKind::PrimitiveActionTarget,
             ApplyErrorKind::CopySourceNotFound("$.src".into()),
             ApplyErrorKind::CopySourceMultiple("$.src".into()),
+            ApplyErrorKind::ConflictingMergeSources,
         ];
         for k in cases {
             assert!(

--- a/crates/roas-overlay/src/lib.rs
+++ b/crates/roas-overlay/src/lib.rs
@@ -53,3 +53,6 @@ pub mod validation;
 
 #[cfg(feature = "v1_0")]
 pub mod v1_0;
+
+#[cfg(feature = "v1_1")]
+pub mod v1_1;

--- a/crates/roas-overlay/src/v1_0/action.rs
+++ b/crates/roas-overlay/src/v1_0/action.rs
@@ -6,7 +6,7 @@
 //! each match or removes them.
 
 use crate::common::apply::compile_path;
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -38,22 +38,25 @@ pub struct Action {
 
 impl Action {
     /// Returns `true` if this action's `remove` field is set to `true`.
+    #[must_use]
     pub fn is_remove(&self) -> bool {
         self.remove == Some(true)
     }
 }
 
+/// Validate that `value` is a non-empty, syntactically valid RFC 9535
+/// JSONPath, recording diagnostics under `path` (computed once).
+fn validate_jsonpath(value: &str, ctx: &mut Context, path: String) {
+    if value.is_empty() {
+        ctx.error(path, "must not be empty");
+    } else if let Err(msg) = compile_path(value) {
+        ctx.error(path, format!("invalid JSONPath query: {msg}"));
+    }
+}
+
 impl ValidateWithContext for Action {
     fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.target, ctx, format!("{path}.target"));
-        if !self.target.is_empty()
-            && let Err(msg) = compile_path(&self.target)
-        {
-            ctx.error(
-                format!("{path}.target"),
-                format!("invalid JSONPath query: {msg}"),
-            );
-        }
+        validate_jsonpath(&self.target, ctx, format!("{path}.target"));
         // The spec says `update` "has no impact if the `remove` field
         // of this action object is `true`", but at validation time we
         // reject the combo because it almost certainly indicates an

--- a/crates/roas-overlay/src/v1_0/version.rs
+++ b/crates/roas-overlay/src/v1_0/version.rs
@@ -24,6 +24,7 @@ impl Version {
         Self("1.0.0".to_owned())
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/crates/roas-overlay/src/v1_1/action.rs
+++ b/crates/roas-overlay/src/v1_1/action.rs
@@ -5,7 +5,7 @@
 //! source node whose value is merged into each `target` node.
 
 use crate::common::apply::compile_path;
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -45,33 +45,28 @@ pub struct Action {
 
 impl Action {
     /// Returns `true` if this action's `remove` field is set to `true`.
+    #[must_use]
     pub fn is_remove(&self) -> bool {
         self.remove == Some(true)
     }
 }
 
+/// Validate that `value` is a non-empty, syntactically valid RFC 9535
+/// JSONPath, recording diagnostics under `path` (computed once).
+fn validate_jsonpath(value: &str, ctx: &mut Context, path: String) {
+    if value.is_empty() {
+        ctx.error(path, "must not be empty");
+    } else if let Err(msg) = compile_path(value) {
+        ctx.error(path, format!("invalid JSONPath query: {msg}"));
+    }
+}
+
 impl ValidateWithContext for Action {
     fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.target, ctx, format!("{path}.target"));
-        if !self.target.is_empty()
-            && let Err(msg) = compile_path(&self.target)
-        {
-            ctx.error(
-                format!("{path}.target"),
-                format!("invalid JSONPath query: {msg}"),
-            );
-        }
+        validate_jsonpath(&self.target, ctx, format!("{path}.target"));
 
         if let Some(copy) = &self.copy {
-            validate_required_string(copy, ctx, format!("{path}.copy"));
-            if !copy.is_empty()
-                && let Err(msg) = compile_path(copy)
-            {
-                ctx.error(
-                    format!("{path}.copy"),
-                    format!("invalid JSONPath query: {msg}"),
-                );
-            }
+            validate_jsonpath(copy, ctx, format!("{path}.copy"));
         }
 
         // The spec says `update` "has no impact if the `remove` field

--- a/crates/roas-overlay/src/v1_1/action.rs
+++ b/crates/roas-overlay/src/v1_1/action.rs
@@ -1,0 +1,320 @@
+//! Overlay v1.1 `Action` object.
+//!
+//! See [§3.3 Action Object](https://spec.openapis.org/overlay/v1.1.0.html#action-object).
+//! New in v1.1: the `copy` field — a JSONPath selecting a single
+//! source node whose value is merged into each `target` node.
+
+use crate::common::apply::compile_path;
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Action {
+    /// **Required** RFC 9535 JSONPath selecting the nodes to act on.
+    pub target: String,
+
+    /// CommonMark-flavored description of the action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Value (object, array, or primitive) merged into the selected
+    /// nodes. Mutually exclusive with `copy` and with `remove: true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update: Option<serde_json::Value>,
+
+    /// RFC 9535 JSONPath selecting exactly one source node in the
+    /// working document. The source's value is merged into each
+    /// `target` node using the same merging rules as `update`.
+    /// Mutually exclusive with `update` and with `remove: true`.
+    /// Added in Overlay v1.1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub copy: Option<String>,
+
+    /// When `true`, removes the selected nodes from their container.
+    /// Mutually exclusive with `update` and `copy`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub remove: Option<bool>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Action {
+    /// Returns `true` if this action's `remove` field is set to `true`.
+    pub fn is_remove(&self) -> bool {
+        self.remove == Some(true)
+    }
+}
+
+impl ValidateWithContext for Action {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.target, ctx, format!("{path}.target"));
+        if !self.target.is_empty()
+            && let Err(msg) = compile_path(&self.target)
+        {
+            ctx.error(
+                format!("{path}.target"),
+                format!("invalid JSONPath query: {msg}"),
+            );
+        }
+
+        if let Some(copy) = &self.copy {
+            validate_required_string(copy, ctx, format!("{path}.copy"));
+            if !copy.is_empty()
+                && let Err(msg) = compile_path(copy)
+            {
+                ctx.error(
+                    format!("{path}.copy"),
+                    format!("invalid JSONPath query: {msg}"),
+                );
+            }
+        }
+
+        // The spec says `update` "has no impact if the `remove` field
+        // of this action object is `true`"; the same applies to
+        // `copy`. We reject all three combinations because they
+        // almost certainly indicate an authoring mistake.
+        if self.is_remove() && self.update.is_some() {
+            ctx.error(
+                path.clone(),
+                "`remove: true` and `update` are mutually exclusive",
+            );
+        }
+        if self.is_remove() && self.copy.is_some() {
+            ctx.error(
+                path.clone(),
+                "`remove: true` and `copy` are mutually exclusive",
+            );
+        }
+        if self.update.is_some() && self.copy.is_some() {
+            ctx.error(path.clone(), "`update` and `copy` are mutually exclusive");
+        }
+
+        // Catch the silent-no-op authoring bug.
+        if !self.is_remove() && self.update.is_none() && self.copy.is_none() {
+            ctx.error(
+                path,
+                "action must specify one of `update`, `copy`, or `remove: true`",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(action: &Action) -> Vec<String> {
+        let mut ctx = Context::new(EnumSet::empty());
+        action.validate_with_context(&mut ctx, "#.actions[0]".into());
+        ctx.errors.iter().map(|e| e.to_string()).collect()
+    }
+
+    #[test]
+    fn deserialize_update_action_round_trips() {
+        let a: Action = serde_json::from_value(json!({
+            "target": "$.info",
+            "update": { "description": "patched" }
+        }))
+        .unwrap();
+        assert_eq!(a.target, "$.info");
+        assert!(a.copy.is_none());
+
+        let v = serde_json::to_value(&a).unwrap();
+        assert_eq!(
+            v,
+            json!({ "target": "$.info", "update": { "description": "patched" } })
+        );
+    }
+
+    #[test]
+    fn deserialize_copy_action_round_trips() {
+        let a: Action = serde_json::from_value(json!({
+            "target": "$.paths['/dst']",
+            "copy": "$.paths['/src']"
+        }))
+        .unwrap();
+        assert_eq!(a.target, "$.paths['/dst']");
+        assert_eq!(a.copy.as_deref(), Some("$.paths['/src']"));
+        assert!(a.update.is_none());
+        assert!(a.remove.is_none());
+
+        let v = serde_json::to_value(&a).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "target": "$.paths['/dst']",
+                "copy": "$.paths['/src']"
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialize_remove_action() {
+        let a: Action =
+            serde_json::from_value(json!({ "target": "$.paths['/x']", "remove": true })).unwrap();
+        assert!(a.is_remove());
+        assert!(a.update.is_none());
+        assert!(a.copy.is_none());
+    }
+
+    #[test]
+    fn deserialize_keeps_x_dash_extensions() {
+        let a: Action = serde_json::from_value(json!({
+            "target": "$",
+            "update": {},
+            "x-author": "me",
+        }))
+        .unwrap();
+        assert!(a.extensions.as_ref().unwrap().contains_key("x-author"));
+    }
+
+    #[test]
+    fn validate_empty_target_errors() {
+        let errs = validate(&Action::default());
+        assert!(
+            errs.iter()
+                .any(|s| s == "#.actions[0].target: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_invalid_target_jsonpath_errors() {
+        let a = Action {
+            target: "not a path".into(),
+            update: Some(json!({})),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(errs.iter().any(|s| s.contains("invalid JSONPath")));
+    }
+
+    #[test]
+    fn validate_invalid_copy_jsonpath_errors() {
+        let a = Action {
+            target: "$.dst".into(),
+            copy: Some("not a path".into()),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(
+            errs.iter()
+                .any(|s| s.contains("invalid JSONPath") && s.contains(".copy")),
+            "expected invalid-copy diagnostic, got: {errs:?}",
+        );
+    }
+
+    #[test]
+    fn validate_empty_copy_string_errors() {
+        let a = Action {
+            target: "$.dst".into(),
+            copy: Some(String::new()),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(
+            errs.iter()
+                .any(|s| s == "#.actions[0].copy: must not be empty"),
+            "got: {errs:?}",
+        );
+    }
+
+    #[test]
+    fn validate_remove_and_update_together_errors() {
+        let a = Action {
+            target: "$.foo".into(),
+            update: Some(json!({})),
+            remove: Some(true),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(
+            errs.iter()
+                .any(|s| s.contains("`remove: true` and `update`"))
+        );
+    }
+
+    #[test]
+    fn validate_remove_and_copy_together_errors() {
+        let a = Action {
+            target: "$.foo".into(),
+            copy: Some("$.src".into()),
+            remove: Some(true),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(errs.iter().any(|s| s.contains("`remove: true` and `copy`")));
+    }
+
+    #[test]
+    fn validate_update_and_copy_together_errors() {
+        let a = Action {
+            target: "$.foo".into(),
+            update: Some(json!({})),
+            copy: Some("$.src".into()),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(errs.iter().any(|s| s.contains("`update` and `copy`")));
+    }
+
+    #[test]
+    fn validate_no_effect_action_errors() {
+        let a = Action {
+            target: "$.foo".into(),
+            ..Default::default()
+        };
+        let errs = validate(&a);
+        assert!(
+            errs.iter()
+                .any(|s| s.contains("must specify one of `update`, `copy`, or `remove: true`")),
+            "got: {errs:?}",
+        );
+    }
+
+    #[test]
+    fn validate_remove_false_with_update_is_ok() {
+        let a = Action {
+            target: "$.foo".into(),
+            update: Some(json!({})),
+            remove: Some(false),
+            ..Default::default()
+        };
+        assert!(validate(&a).is_empty());
+    }
+
+    #[test]
+    fn validate_remove_false_with_copy_is_ok() {
+        let a = Action {
+            target: "$.foo".into(),
+            copy: Some("$.src".into()),
+            remove: Some(false),
+            ..Default::default()
+        };
+        assert!(validate(&a).is_empty());
+    }
+
+    #[test]
+    fn is_remove_only_true_when_remove_set_to_true() {
+        let a = Action::default();
+        assert!(!a.is_remove());
+
+        let a = Action {
+            remove: Some(false),
+            ..Default::default()
+        };
+        assert!(!a.is_remove());
+
+        let a = Action {
+            remove: Some(true),
+            ..Default::default()
+        };
+        assert!(a.is_remove());
+    }
+}

--- a/crates/roas-overlay/src/v1_1/info.rs
+++ b/crates/roas-overlay/src/v1_1/info.rs
@@ -1,0 +1,125 @@
+//! Overlay v1.1 `Info` object.
+//!
+//! Per [§3.2 Info Object](https://spec.openapis.org/overlay/v1.1.0.html#info-object):
+//! the v1.0 fields plus an optional `description`.
+
+use crate::validation::{
+    Context, ValidateWithContext, ValidationOptions, validate_required_string,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Info {
+    /// **Required** A human-readable description of the purpose of the overlay.
+    pub title: String,
+
+    /// **Required** A version identifier for changes to the Overlay document.
+    pub version: String,
+
+    /// Optional CommonMark-flavored prose description. Added in v1.1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Info {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle) {
+            validate_required_string(&self.title, ctx, format!("{path}.title"));
+        }
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion) {
+            validate_required_string(&self.version, ctx, format!("{path}.version"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn ctx() -> Context {
+        Context::new(EnumSet::empty())
+    }
+
+    #[test]
+    fn deserialize_minimal_info_round_trips() {
+        let info: Info = serde_json::from_value(json!({ "title": "T", "version": "1.0" })).unwrap();
+        assert_eq!(info.title, "T");
+        assert_eq!(info.version, "1.0");
+        assert!(info.description.is_none());
+        assert!(info.extensions.is_none());
+
+        let v = serde_json::to_value(&info).unwrap();
+        assert_eq!(v, json!({ "title": "T", "version": "1.0" }));
+    }
+
+    #[test]
+    fn deserialize_with_description_round_trips() {
+        let info: Info = serde_json::from_value(json!({
+            "title": "T",
+            "version": "1.0",
+            "description": "Adds error responses."
+        }))
+        .unwrap();
+        assert_eq!(info.description.as_deref(), Some("Adds error responses."));
+
+        let v = serde_json::to_value(&info).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "title": "T",
+                "version": "1.0",
+                "description": "Adds error responses."
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialize_keeps_x_dash_extensions_and_drops_others() {
+        let info: Info = serde_json::from_value(json!({
+            "title": "T",
+            "version": "1.0",
+            "x-team": "platform",
+            "ignored": 42,
+        }))
+        .unwrap();
+        let ext = info.extensions.as_ref().unwrap();
+        assert_eq!(ext.get("x-team").unwrap(), &json!("platform"));
+        assert!(!ext.contains_key("ignored"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_title_and_version() {
+        let mut c = ctx();
+        let info = Info::default();
+        info.validate_with_context(&mut c, "#.info".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.info.title: must not be empty")
+        );
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.info.version: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_ignore_options_suppress_diagnostics() {
+        let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle)
+            | ValidationOptions::IgnoreEmptyInfoVersion;
+        let mut c = Context::new(opts);
+        let info = Info::default();
+        info.validate_with_context(&mut c, "#.info".into());
+        assert!(c.errors.is_empty());
+    }
+}

--- a/crates/roas-overlay/src/v1_1/mod.rs
+++ b/crates/roas-overlay/src/v1_1/mod.rs
@@ -1,0 +1,23 @@
+//! OpenAPI Overlay v1.1 — see
+//! <https://spec.openapis.org/overlay/v1.1.0.html>.
+//!
+//! Authoritative JSON Schema:
+//! <https://spec.openapis.org/overlay/1.1/schema/2026-04-01>.
+//!
+//! Additive over v1.0:
+//! - `Info` gains an optional `description` field.
+//! - `Action` gains an optional `copy` field — a JSONPath selecting a
+//!   single source node in the working document whose value is then
+//!   merged into each `target` node (mutually exclusive with `update`
+//!   and `remove: true`).
+//! - `overlay` version regex becomes `^1\.1\.\d+$`.
+
+pub mod action;
+pub mod info;
+pub mod overlay;
+pub mod version;
+
+pub use action::Action;
+pub use info::Info;
+pub use overlay::Overlay;
+pub use version::Version;

--- a/crates/roas-overlay/src/v1_1/overlay.rs
+++ b/crates/roas-overlay/src/v1_1/overlay.rs
@@ -131,10 +131,6 @@ fn apply_action(
         kind,
     };
 
-    let path =
-        compile_path(&action.target).map_err(|msg| err(ApplyErrorKind::InvalidJsonPath(msg)))?;
-    let pointers = locate(doc, &path);
-
     let operation = if action.is_remove() {
         Operation::Remove
     } else if action.copy.is_some() {
@@ -142,7 +138,29 @@ fn apply_action(
     } else {
         Operation::Update
     };
-    let no_effect = !action.is_remove() && action.update.is_none() && action.copy.is_none();
+
+    // No-op fast path (validate flags it; this is the defensive
+    // arm for callers that skip validation). Bail before any JSONPath
+    // work — a do-nothing action can't affect the document.
+    if !action.is_remove() && action.update.is_none() && action.copy.is_none() {
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation,
+            matched: 0,
+        });
+    }
+
+    // `update` and `copy` are mutually exclusive (validate flags it).
+    // Fail fast rather than silently dropping `update` — there is no
+    // spec-defined precedence between the two, unlike `remove`.
+    if !action.is_remove() && action.update.is_some() && action.copy.is_some() {
+        return Err(err(ApplyErrorKind::ConflictingMergeSources));
+    }
+
+    let path =
+        compile_path(&action.target).map_err(|msg| err(ApplyErrorKind::InvalidJsonPath(msg)))?;
+    let pointers = locate(doc, &path);
 
     if pointers.is_empty() {
         if options.contains(ApplyOptions::ErrorOnZeroMatch) {
@@ -167,15 +185,6 @@ fn apply_action(
         return Err(err(ApplyErrorKind::MixedKindMatch));
     }
 
-    if no_effect {
-        return Ok(ActionOutcome {
-            index,
-            target: action.target.clone(),
-            operation,
-            matched: 0,
-        });
-    }
-
     if action.is_remove() {
         // Process in reverse to preserve earlier pointer validity
         // when siblings live in the same array. Count only successful
@@ -194,10 +203,11 @@ fn apply_action(
         });
     }
 
-    // Resolve the effective merge value: either the inline `update`,
-    // or — for v1.1 `copy` actions — the value at the `copy` source
-    // JSONPath. The source must resolve to exactly one node.
-    let effective_update: Value = if let Some(copy_src) = &action.copy {
+    // Resolve the effective merge value. For `copy` it must be owned
+    // (cloned out of the doc so the later mutation can't alias it);
+    // for `update` we borrow the payload to avoid an extra deep clone
+    // when every target is an object (`merge_json` only needs `&Value`).
+    let copy_value: Option<Value> = if let Some(copy_src) = &action.copy {
         let copy_path =
             compile_path(copy_src).map_err(|msg| err(ApplyErrorKind::InvalidJsonPath(msg)))?;
         let src_pointers = locate(doc, &copy_path);
@@ -207,29 +217,38 @@ fn apply_action(
         if src_pointers.len() > 1 {
             return Err(err(ApplyErrorKind::CopySourceMultiple(copy_src.clone())));
         }
-        doc.pointer(&src_pointers[0])
-            .expect("located pointer must resolve in same doc snapshot")
-            .clone()
+        Some(
+            doc.pointer(&src_pointers[0])
+                .expect("located pointer must resolve in same doc snapshot")
+                .clone(),
+        )
     } else {
-        action
+        None
+    };
+    let effective_update: &Value = match &copy_value {
+        Some(v) => v,
+        None => action
             .update
             .as_ref()
-            .expect("no_effect path covers the all-None case")
-            .clone()
+            .expect("no-op fast path covers the all-None case"),
     };
 
-    // Update / copy share the same per-node merge rules. Array
-    // targets append `effective_update` as a single entry; object
-    // targets recurse per §4.4.3.1.
+    // Update / copy share the same per-node merge rules. For an array
+    // target the merge value either concatenates (when it is itself an
+    // array) or is appended as a single entry (object / primitive),
+    // per Overlay v1.1 §3.3. Object targets recurse per §4.4.3.1.
     for (ptr, kind) in pointers.iter().zip(kinds.iter()) {
         if let Some(node) = doc.pointer_mut(ptr) {
             match kind {
                 NodeKind::Array => {
                     if let Value::Array(arr) = node {
-                        arr.push(effective_update.clone());
+                        match effective_update {
+                            Value::Array(items) => arr.extend(items.iter().cloned()),
+                            other => arr.push(other.clone()),
+                        }
                     }
                 }
-                NodeKind::Object => merge_json(node, &effective_update),
+                NodeKind::Object => merge_json(node, effective_update),
                 NodeKind::Primitive | NodeKind::Missing => {
                     // Primitives rejected above; Missing can't occur
                     // because pointers were just located.
@@ -373,7 +392,9 @@ mod tests {
     }
 
     #[test]
-    fn apply_copy_against_array_target_appends_source_as_single_entry() {
+    fn apply_copy_against_array_target_appends_object_source_as_single_entry() {
+        // v1.1 §3.3: an object/primitive merge value is *appended* as
+        // one element to an array target.
         let o = ovl(vec![Action {
             target: "$.parameters".into(),
             copy: Some("$.shared_parameter".into()),
@@ -391,6 +412,65 @@ mod tests {
                 { "name": "limit", "in": "query" }
             ]),
         );
+    }
+
+    #[test]
+    fn apply_update_array_value_into_array_target_concatenates() {
+        // v1.1 §3.3: an *array* merge value is concatenated with the
+        // target array (element-wise), not nested as one element.
+        // This is the v1.1 divergence from v1.0.
+        let o = ovl(vec![Action {
+            target: "$.tags".into(),
+            update: Some(json!(["new-a", "new-b"])),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "tags": ["existing"] });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(doc["tags"], json!(["existing", "new-a", "new-b"]));
+    }
+
+    #[test]
+    fn apply_copy_array_value_into_array_target_concatenates() {
+        let o = ovl(vec![Action {
+            target: "$.dst".into(),
+            copy: Some("$.src".into()),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "dst": [1, 2],
+            "src": [3, 4]
+        });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(doc["dst"], json!([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn apply_update_object_value_into_array_target_appends() {
+        let o = ovl(vec![Action {
+            target: "$.list".into(),
+            update: Some(json!({ "added": true })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "list": [1, 2] });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(doc["list"], json!([1, 2, { "added": true }]));
+    }
+
+    #[test]
+    fn apply_conflicting_update_and_copy_errors_and_rolls_back() {
+        // Validate flags this; apply fails fast rather than silently
+        // dropping `update`.
+        let o = ovl(vec![Action {
+            target: "$.dest".into(),
+            update: Some(json!({ "from": "update" })),
+            copy: Some("$.src".into()),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "dest": {}, "src": { "from": "copy" } });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        assert_eq!(err.kind, ApplyErrorKind::ConflictingMergeSources);
+        assert_eq!(doc, snapshot);
     }
 
     #[test]

--- a/crates/roas-overlay/src/v1_1/overlay.rs
+++ b/crates/roas-overlay/src/v1_1/overlay.rs
@@ -1,0 +1,611 @@
+//! Overlay v1.1 root document.
+
+use crate::apply::{
+    ActionOutcome, Apply, ApplyError, ApplyErrorKind, ApplyOptions, ApplyReport, Operation,
+};
+use crate::common::apply::{compile_path, locate, merge_json, remove_at};
+use crate::v1_1::action::Action;
+use crate::v1_1::info::Info;
+use crate::v1_1::version::Version;
+use crate::validation::{Context, Error, Validate, ValidateWithContext, ValidationOptions};
+use enumset::EnumSet;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Root Overlay v1.1 document.
+///
+/// See [§3.1 Overlay Object](https://spec.openapis.org/overlay/v1.1.0.html#overlay-object).
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Overlay {
+    /// **Required** `1.1.x` per the schema's pattern `^1\.1\.\d+$`.
+    pub overlay: Version,
+
+    /// **Required** Metadata about the overlay.
+    pub info: Info,
+
+    /// URI reference identifying the target document the overlay
+    /// applies to. Absolute or relative per RFC 3986.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extends: Option<String>,
+
+    /// **Required** Ordered, non-empty list of actions applied
+    /// sequentially.
+    pub actions: Vec<Action>,
+
+    /// `x-`-prefixed Specification Extensions on the root.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Overlay {
+    fn validate_inner(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        let mut ctx = Context::new(options);
+        let path = "#".to_owned();
+
+        self.info
+            .validate_with_context(&mut ctx, format!("{path}.info"));
+
+        if self.actions.is_empty() {
+            ctx.error(format!("{path}.actions"), "must contain at least one entry");
+        }
+        for (i, action) in self.actions.iter().enumerate() {
+            action.validate_with_context(&mut ctx, format!("{path}.actions[{i}]"));
+        }
+
+        ctx.into_result()
+    }
+}
+
+impl Validate for Overlay {
+    fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        self.validate_inner(options)
+    }
+}
+
+impl Apply for Overlay {
+    fn apply(
+        &self,
+        target: &mut Value,
+        options: EnumSet<ApplyOptions>,
+    ) -> Result<ApplyReport, ApplyError> {
+        // Work on a clone so a mid-pipeline failure leaves `target`
+        // untouched. Commit only on success.
+        let mut working = target.clone();
+        let mut report = ApplyReport::default();
+
+        for (index, action) in self.actions.iter().enumerate() {
+            let outcome = apply_action(index, action, &mut working, options)?;
+            report.actions.push(outcome);
+        }
+
+        *target = working;
+        Ok(report)
+    }
+}
+
+#[cfg(feature = "v1_0")]
+impl From<crate::v1_0::Overlay> for Overlay {
+    /// Upconvert an Overlay v1.0 document to v1.1. Additive: only the
+    /// `overlay` version string changes (to `1.1.0`); v1.0 `Info` and
+    /// `Action` map structurally because v1.1 only adds optional
+    /// fields (`Info.description`, `Action.copy`).
+    fn from(o: crate::v1_0::Overlay) -> Self {
+        Self {
+            overlay: Version::V1_1_0(),
+            info: Info {
+                title: o.info.title,
+                version: o.info.version,
+                description: None,
+                extensions: o.info.extensions,
+            },
+            extends: o.extends,
+            actions: o
+                .actions
+                .into_iter()
+                .map(|a| Action {
+                    target: a.target,
+                    description: a.description,
+                    update: a.update,
+                    copy: None,
+                    remove: a.remove,
+                    extensions: a.extensions,
+                })
+                .collect(),
+            extensions: o.extensions,
+        }
+    }
+}
+
+fn apply_action(
+    index: usize,
+    action: &Action,
+    doc: &mut Value,
+    options: EnumSet<ApplyOptions>,
+) -> Result<ActionOutcome, ApplyError> {
+    let err = |kind| ApplyError {
+        action_index: index,
+        target: action.target.clone(),
+        kind,
+    };
+
+    let path =
+        compile_path(&action.target).map_err(|msg| err(ApplyErrorKind::InvalidJsonPath(msg)))?;
+    let pointers = locate(doc, &path);
+
+    let operation = if action.is_remove() {
+        Operation::Remove
+    } else if action.copy.is_some() {
+        Operation::Copy
+    } else {
+        Operation::Update
+    };
+    let no_effect = !action.is_remove() && action.update.is_none() && action.copy.is_none();
+
+    if pointers.is_empty() {
+        if options.contains(ApplyOptions::ErrorOnZeroMatch) {
+            return Err(err(ApplyErrorKind::ZeroMatch));
+        }
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation,
+            matched: 0,
+        });
+    }
+
+    // Spec §4.4: `target` MUST resolve to objects or arrays for every
+    // action — checked up front so a failure leaves the working copy
+    // untouched.
+    let kinds: Vec<NodeKind> = pointers.iter().map(|p| classify(doc, p)).collect();
+    if kinds.iter().any(|k| matches!(k, NodeKind::Primitive)) {
+        return Err(err(ApplyErrorKind::PrimitiveActionTarget));
+    }
+    if options.contains(ApplyOptions::ErrorOnMixedKindMatch) && !uniform_kinds(&kinds) {
+        return Err(err(ApplyErrorKind::MixedKindMatch));
+    }
+
+    if no_effect {
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation,
+            matched: 0,
+        });
+    }
+
+    if action.is_remove() {
+        // Process in reverse to preserve earlier pointer validity
+        // when siblings live in the same array. Count only successful
+        // removes.
+        let mut removed = 0;
+        for ptr in pointers.iter().rev() {
+            if remove_at(doc, ptr) {
+                removed += 1;
+            }
+        }
+        return Ok(ActionOutcome {
+            index,
+            target: action.target.clone(),
+            operation,
+            matched: removed,
+        });
+    }
+
+    // Resolve the effective merge value: either the inline `update`,
+    // or — for v1.1 `copy` actions — the value at the `copy` source
+    // JSONPath. The source must resolve to exactly one node.
+    let effective_update: Value = if let Some(copy_src) = &action.copy {
+        let copy_path =
+            compile_path(copy_src).map_err(|msg| err(ApplyErrorKind::InvalidJsonPath(msg)))?;
+        let src_pointers = locate(doc, &copy_path);
+        if src_pointers.is_empty() {
+            return Err(err(ApplyErrorKind::CopySourceNotFound(copy_src.clone())));
+        }
+        if src_pointers.len() > 1 {
+            return Err(err(ApplyErrorKind::CopySourceMultiple(copy_src.clone())));
+        }
+        doc.pointer(&src_pointers[0])
+            .expect("located pointer must resolve in same doc snapshot")
+            .clone()
+    } else {
+        action
+            .update
+            .as_ref()
+            .expect("no_effect path covers the all-None case")
+            .clone()
+    };
+
+    // Update / copy share the same per-node merge rules. Array
+    // targets append `effective_update` as a single entry; object
+    // targets recurse per §4.4.3.1.
+    for (ptr, kind) in pointers.iter().zip(kinds.iter()) {
+        if let Some(node) = doc.pointer_mut(ptr) {
+            match kind {
+                NodeKind::Array => {
+                    if let Value::Array(arr) = node {
+                        arr.push(effective_update.clone());
+                    }
+                }
+                NodeKind::Object => merge_json(node, &effective_update),
+                NodeKind::Primitive | NodeKind::Missing => {
+                    // Primitives rejected above; Missing can't occur
+                    // because pointers were just located.
+                }
+            }
+        }
+    }
+    Ok(ActionOutcome {
+        index,
+        target: action.target.clone(),
+        operation,
+        matched: pointers.len(),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeKind {
+    Object,
+    Array,
+    Primitive,
+    Missing,
+}
+
+fn classify(doc: &Value, pointer: &str) -> NodeKind {
+    match doc.pointer(pointer) {
+        None => NodeKind::Missing,
+        Some(Value::Object(_)) => NodeKind::Object,
+        Some(Value::Array(_)) => NodeKind::Array,
+        Some(_) => NodeKind::Primitive,
+    }
+}
+
+fn uniform_kinds(kinds: &[NodeKind]) -> bool {
+    let mut iter = kinds
+        .iter()
+        .copied()
+        .filter(|k| !matches!(k, NodeKind::Missing));
+    let Some(first) = iter.next() else {
+        return true;
+    };
+    iter.all(|k| k == first)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn parse(s: &str) -> Overlay {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn deserialize_minimal_round_trips() {
+        let json = r#"{
+            "overlay": "1.1.0",
+            "info": { "title": "T", "version": "1" },
+            "actions": [ { "target": "$.x", "update": {} } ]
+        }"#;
+        let o = parse(json);
+        assert_eq!(o.overlay, Version::V1_1_0());
+        assert_eq!(o.info.title, "T");
+        assert_eq!(o.actions.len(), 1);
+    }
+
+    #[test]
+    fn deserialize_rejects_non_1_1_overlay_version() {
+        let err = serde_json::from_value::<Overlay>(json!({
+            "overlay": "1.0.0",
+            "info": { "title": "T", "version": "1" },
+            "actions": [ { "target": "$" } ]
+        }))
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("\"1.0.0\"") && msg.contains("1.1"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_actions_vec() {
+        let o = Overlay {
+            overlay: Version::V1_1_0(),
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            actions: vec![],
+            extends: None,
+            extensions: None,
+        };
+        let err = o.validate(EnumSet::empty()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.actions: must contain at least one entry")
+        );
+    }
+
+    fn ovl(actions: Vec<Action>) -> Overlay {
+        Overlay {
+            overlay: Version::V1_1_0(),
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            extends: None,
+            actions,
+            extensions: None,
+        }
+    }
+
+    #[test]
+    fn apply_copy_merges_source_value_into_target() {
+        // Copy the `/source` path under `/dest`.
+        let o = ovl(vec![Action {
+            target: "$.paths['/dest']".into(),
+            copy: Some("$.paths['/source']".into()),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "paths": {
+                "/source": {
+                    "get": { "summary": "the source" }
+                },
+                "/dest": {}
+            }
+        });
+        let r = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(r.actions[0].operation, Operation::Copy);
+        assert_eq!(r.actions[0].matched, 1);
+        assert_eq!(
+            doc["paths"]["/dest"],
+            json!({ "get": { "summary": "the source" } }),
+        );
+        // Source must be unchanged.
+        assert_eq!(
+            doc["paths"]["/source"],
+            json!({ "get": { "summary": "the source" } }),
+        );
+    }
+
+    #[test]
+    fn apply_copy_against_array_target_appends_source_as_single_entry() {
+        let o = ovl(vec![Action {
+            target: "$.parameters".into(),
+            copy: Some("$.shared_parameter".into()),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "parameters": [ { "name": "page", "in": "query" } ],
+            "shared_parameter": { "name": "limit", "in": "query" }
+        });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(
+            doc["parameters"],
+            json!([
+                { "name": "page", "in": "query" },
+                { "name": "limit", "in": "query" }
+            ]),
+        );
+    }
+
+    #[test]
+    fn apply_copy_source_not_found_errors_and_rolls_back() {
+        let o = ovl(vec![Action {
+            target: "$.dest".into(),
+            copy: Some("$.missing".into()),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "dest": {} });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        match &err.kind {
+            ApplyErrorKind::CopySourceNotFound(s) => assert_eq!(s, "$.missing"),
+            other => panic!("expected CopySourceNotFound, got {other:?}"),
+        }
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_copy_source_multiple_matches_errors_and_rolls_back() {
+        let o = ovl(vec![Action {
+            target: "$.dest".into(),
+            copy: Some("$.items[*]".into()),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "dest": {},
+            "items": [ { "a": 1 }, { "b": 2 } ]
+        });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        assert!(matches!(err.kind, ApplyErrorKind::CopySourceMultiple(_)));
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_copy_with_invalid_jsonpath_errors_and_rolls_back() {
+        let o = ovl(vec![Action {
+            target: "$.dest".into(),
+            copy: Some("not a path".into()),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "dest": {} });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        assert!(matches!(err.kind, ApplyErrorKind::InvalidJsonPath(_)));
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_remove_with_copy_field_still_removes() {
+        // Validation would flag this combination, but apply is
+        // defensive: `remove: true` wins (matches the `is_remove`
+        // branch above any update/copy logic).
+        let o = ovl(vec![Action {
+            target: "$.paths['/x']".into(),
+            copy: Some("$.somewhere".into()),
+            remove: Some(true),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "paths": { "/x": { "get": {} } } });
+        let r = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(r.actions[0].operation, Operation::Remove);
+        assert!(!doc["paths"].as_object().unwrap().contains_key("/x"));
+    }
+
+    #[test]
+    fn apply_update_then_copy_actions_compose() {
+        let o = ovl(vec![
+            Action {
+                target: "$.dest".into(),
+                update: Some(json!({ "tag": "first" })),
+                ..Default::default()
+            },
+            Action {
+                target: "$.dest".into(),
+                copy: Some("$.src".into()),
+                ..Default::default()
+            },
+        ]);
+        let mut doc = json!({
+            "dest": {},
+            "src": { "tag": "second", "extra": 7 }
+        });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        // First action added tag=first. Second action copies src
+        // (tag=second, extra=7) over dest, with merge semantics:
+        // tag is replaced by "second", extra is added.
+        assert_eq!(doc["dest"], json!({ "tag": "second", "extra": 7 }),);
+    }
+
+    #[test]
+    fn apply_zero_match_default_is_no_op() {
+        let o = ovl(vec![Action {
+            target: "$.nope".into(),
+            update: Some(json!({})),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "foo": 1 });
+        let snapshot = doc.clone();
+        let r = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(r.actions[0].matched, 0);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_zero_match_strict_errors_and_rolls_back() {
+        let o = ovl(vec![Action {
+            target: "$.nope".into(),
+            update: Some(json!({})),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "foo": 1 });
+        let snapshot = doc.clone();
+        let err = o
+            .apply(&mut doc, ApplyOptions::ErrorOnZeroMatch.into())
+            .unwrap_err();
+        assert_eq!(err.kind, ApplyErrorKind::ZeroMatch);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_update_on_primitive_target_errors() {
+        let o = ovl(vec![Action {
+            target: "$.info.title".into(),
+            update: Some(json!({ "ignored": true })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "info": { "title": "API" } });
+        let snapshot = doc.clone();
+        let err = o.apply(&mut doc, EnumSet::empty()).unwrap_err();
+        assert_eq!(err.kind, ApplyErrorKind::PrimitiveActionTarget);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_mixed_kind_strict_errors() {
+        let o = ovl(vec![Action {
+            target: "$.choices[*]".into(),
+            update: Some(json!({ "z": 1 })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "choices": [ { "a": 1 }, [ 1, 2 ] ]
+        });
+        let snapshot = doc.clone();
+        let err = o
+            .apply(&mut doc, ApplyOptions::ErrorOnMixedKindMatch.into())
+            .unwrap_err();
+        assert_eq!(err.kind, ApplyErrorKind::MixedKindMatch);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[test]
+    fn apply_mixed_kind_lax_treats_each_match_per_its_kind() {
+        // Exercises both the uniform_kinds check (no strict opt) and
+        // the per-match Array vs Object branches.
+        let o = ovl(vec![Action {
+            target: "$.choices[*]".into(),
+            update: Some(json!({ "z": 1 })),
+            ..Default::default()
+        }]);
+        let mut doc = json!({
+            "choices": [ { "a": 1 }, [ 1, 2 ] ]
+        });
+        o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(doc["choices"][0], json!({ "a": 1, "z": 1 }));
+        assert_eq!(doc["choices"][1], json!([1, 2, { "z": 1 }]));
+    }
+
+    #[test]
+    fn apply_action_with_no_effect_reports_matched_zero() {
+        // Defensive: validate flags this, but if it reaches apply
+        // anyway it's a true no-op.
+        let o = ovl(vec![Action {
+            target: "$.foo".into(),
+            ..Default::default()
+        }]);
+        let mut doc = json!({ "foo": { "a": 1 } });
+        let snapshot = doc.clone();
+        let r = o.apply(&mut doc, EnumSet::empty()).unwrap();
+        assert_eq!(r.actions[0].matched, 0);
+        assert_eq!(doc, snapshot);
+    }
+
+    #[cfg(feature = "v1_0")]
+    #[test]
+    fn from_v1_0_overlay_upconverts_additive_fields_to_none() {
+        use crate::v1_0;
+        let src = v1_0::Overlay {
+            overlay: v1_0::version::Version::V1_0_0(),
+            info: v1_0::Info {
+                title: "T".into(),
+                version: "1".into(),
+                extensions: None,
+            },
+            extends: Some("./base.yaml".into()),
+            actions: vec![v1_0::Action {
+                target: "$.info".into(),
+                description: Some("Note".into()),
+                update: Some(json!({ "x": 1 })),
+                remove: None,
+                extensions: None,
+            }],
+            extensions: None,
+        };
+        let dst: Overlay = src.into();
+        assert_eq!(dst.overlay, Version::V1_1_0());
+        assert_eq!(dst.info.title, "T");
+        assert!(dst.info.description.is_none());
+        assert_eq!(dst.extends.as_deref(), Some("./base.yaml"));
+        assert_eq!(dst.actions.len(), 1);
+        assert_eq!(dst.actions[0].target, "$.info");
+        assert!(dst.actions[0].copy.is_none());
+        assert_eq!(dst.actions[0].update.as_ref().unwrap(), &json!({ "x": 1 }));
+    }
+}

--- a/crates/roas-overlay/src/v1_1/version.rs
+++ b/crates/roas-overlay/src/v1_1/version.rs
@@ -24,6 +24,7 @@ impl Version {
         Self("1.1.0".to_owned())
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/crates/roas-overlay/src/v1_1/version.rs
+++ b/crates/roas-overlay/src/v1_1/version.rs
@@ -1,0 +1,163 @@
+//! Version newtype for Overlay v1.1 (`overlay: "1.1.x"`).
+//!
+//! Mirrors `v1_0::Version`: the field is a string at the wire level
+//! but constrained to the schema pattern `^1\.1\.\d+$`
+//! ([JSON Schema](https://spec.openapis.org/overlay/1.1/schema/2026-04-01)).
+//! Deserialization rejects non-1.1 values up front so callers don't
+//! have to revalidate.
+
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version(String);
+
+impl Default for Version {
+    fn default() -> Self {
+        Self("1.1.0".to_owned())
+    }
+}
+
+impl Version {
+    /// Canonical `1.1.0` value.
+    #[allow(non_snake_case)]
+    pub fn V1_1_0() -> Self {
+        Self("1.1.0".to_owned())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+const VERSION_SCHEMA_DESCRIPTION: &str = "`1.1.<patch>` semver (Overlay v1.1)";
+
+/// Schema pattern is `^1\.1\.\d+$` — hand-rolled to avoid pulling in
+/// `lazy-regex` just for this one check.
+fn matches_overlay_1_1_version(s: &str) -> bool {
+    s.strip_prefix("1.1.")
+        .is_some_and(|patch| !patch.is_empty() && patch.bytes().all(|b| b.is_ascii_digit()))
+}
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &VERSION_SCHEMA_DESCRIPTION,
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidVersion(pub String);
+
+impl Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "overlay version {:?} must be {VERSION_SCHEMA_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if matches_overlay_1_1_version(s) {
+            Ok(Version(s.to_owned()))
+        } else {
+            Err(InvalidVersion(s.to_owned()))
+        }
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if matches_overlay_1_1_version(&s) {
+            Ok(Version(s))
+        } else {
+            Err(InvalidVersion(s))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_1_1_0() {
+        assert_eq!(Version::default().as_str(), "1.1.0");
+    }
+
+    #[test]
+    fn accepts_matching_patch_versions() {
+        assert!("1.1.0".parse::<Version>().is_ok());
+        assert!("1.1.42".parse::<Version>().is_ok());
+    }
+
+    #[test]
+    fn rejects_non_matching_versions() {
+        for bad in ["1.0.0", "1.2.0", "2.1.0", "1.1", "1.1.x", "v1.1.0", ""] {
+            let err = bad.parse::<Version>().unwrap_err();
+            assert_eq!(err.0, bad);
+            assert!(err.to_string().contains(bad));
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_wrong_minor() {
+        let err = serde_json::from_value::<Version>(serde_json::json!("1.0.0")).unwrap_err();
+        assert!(err.to_string().contains("1.1"));
+    }
+
+    #[test]
+    fn serialize_round_trips_through_string() {
+        let v = Version::V1_1_0();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#""1.1.0""#);
+        let back: Version = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn display_renders_inner_string() {
+        let v: Version = "1.1.3".parse().unwrap();
+        assert_eq!(format!("{v}"), "1.1.3");
+    }
+
+    #[test]
+    fn try_from_str_and_string_match_from_str() {
+        assert_eq!(Version::try_from("1.1.0").unwrap(), Version::V1_1_0());
+        assert!(Version::try_from("2.0.0").is_err());
+
+        let owned_ok = Version::try_from(String::from("1.1.7")).unwrap();
+        assert_eq!(owned_ok.as_str(), "1.1.7");
+        let owned_err = Version::try_from(String::from("nope")).unwrap_err();
+        assert_eq!(owned_err.0, "nope");
+    }
+}

--- a/crates/roas-overlay/tests/v1_1_data/bad_copy_and_update.json
+++ b/crates/roas-overlay/tests/v1_1_data/bad_copy_and_update.json
@@ -1,0 +1,11 @@
+{
+  "overlay": "1.1.0",
+  "info": { "title": "Bad combo", "version": "1.0.0" },
+  "actions": [
+    {
+      "target": "$.dest",
+      "update": { "x": 1 },
+      "copy": "$.src"
+    }
+  ]
+}

--- a/crates/roas-overlay/tests/v1_1_data/bad_copy_invalid_jsonpath.json
+++ b/crates/roas-overlay/tests/v1_1_data/bad_copy_invalid_jsonpath.json
@@ -1,0 +1,10 @@
+{
+  "overlay": "1.1.0",
+  "info": { "title": "Bad copy path", "version": "1.0.0" },
+  "actions": [
+    {
+      "target": "$.dest",
+      "copy": "not a path"
+    }
+  ]
+}

--- a/crates/roas-overlay/tests/v1_1_data/base_with_source.json
+++ b/crates/roas-overlay/tests/v1_1_data/base_with_source.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Source / Destination demo",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/source": {
+      "get": {
+        "summary": "Source endpoint",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/destination": {}
+  },
+  "components": {
+    "schemas": {
+      "PetCore": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/crates/roas-overlay/tests/v1_1_data/copy_and_extend.expected.json
+++ b/crates/roas-overlay/tests/v1_1_data/copy_and_extend.expected.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Source / Destination demo",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/source": {
+      "get": {
+        "summary": "Source endpoint",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/destination": {}
+  },
+  "components": {
+    "schemas": {
+      "PetCore": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" }
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" }
+        },
+        "required": ["id", "name"]
+      }
+    }
+  }
+}

--- a/crates/roas-overlay/tests/v1_1_data/copy_and_extend.yaml
+++ b/crates/roas-overlay/tests/v1_1_data/copy_and_extend.yaml
@@ -1,0 +1,19 @@
+overlay: 1.1.0
+info:
+  title: Compose copy + update
+  version: 1.0.0
+  description: Copy the PetCore schema as Pet, then patch the copy.
+actions:
+  # Create an empty Pet slot by merging into the schemas map.
+  - target: $.components.schemas
+    update:
+      Pet: {}
+  # Copy the existing PetCore over the empty Pet (merge semantics).
+  - target: $.components.schemas['Pet']
+    copy: $.components.schemas['PetCore']
+  # Patch the copy with the required field.
+  - target: $.components.schemas['Pet']
+    update:
+      required:
+        - id
+        - name

--- a/crates/roas-overlay/tests/v1_1_data/copy_overlay.expected.json
+++ b/crates/roas-overlay/tests/v1_1_data/copy_overlay.expected.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Source / Destination demo",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/source": {
+      "get": {
+        "summary": "Source endpoint",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/destination": {
+      "get": {
+        "summary": "Source endpoint",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PetCore": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/crates/roas-overlay/tests/v1_1_data/copy_overlay.json
+++ b/crates/roas-overlay/tests/v1_1_data/copy_overlay.json
@@ -1,0 +1,15 @@
+{
+  "overlay": "1.1.0",
+  "info": {
+    "title": "Copy /source to /destination",
+    "version": "1.0.0",
+    "description": "Demonstrates the v1.1 `copy` action."
+  },
+  "actions": [
+    {
+      "target": "$.paths['/destination']",
+      "copy": "$.paths['/source']",
+      "description": "Mirror the source endpoint under /destination."
+    }
+  ]
+}

--- a/crates/roas-overlay/tests/v1_1_test.rs
+++ b/crates/roas-overlay/tests/v1_1_test.rs
@@ -1,0 +1,120 @@
+//! Integration tests for Overlay v1.1: load fixtures from
+//! `tests/v1_1_data/`, parse them, validate, apply, and compare
+//! against checked-in `*.expected.json` fixtures.
+
+#![cfg(feature = "v1_1")]
+
+use enumset::EnumSet;
+use roas_overlay::apply::{Apply, ApplyErrorKind};
+use roas_overlay::v1_1::Overlay;
+use roas_overlay::validation::Validate;
+use std::path::{Path, PathBuf};
+
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("v1_1_data")
+}
+
+fn load_json(name: &str) -> serde_json::Value {
+    let path = data_dir().join(name);
+    let s =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn load_yaml(name: &str) -> serde_json::Value {
+    let path = data_dir().join(name);
+    let s =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml_ng::from_str(&s).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn load_overlay_json(name: &str) -> Overlay {
+    serde_json::from_value(load_json(name)).expect("overlay deserialize")
+}
+
+fn load_overlay_yaml(name: &str) -> Overlay {
+    serde_json::from_value(load_yaml(name)).expect("overlay deserialize")
+}
+
+#[test]
+fn copy_action_mirrors_source_under_destination() {
+    let overlay = load_overlay_json("copy_overlay.json");
+    overlay.validate(EnumSet::empty()).expect("validates");
+
+    let mut target = load_json("base_with_source.json");
+    let report = overlay
+        .apply(&mut target, EnumSet::empty())
+        .expect("apply succeeds");
+    assert_eq!(report.actions.len(), 1);
+
+    let expected = load_json("copy_overlay.expected.json");
+    assert_eq!(target, expected);
+}
+
+#[test]
+fn copy_then_update_pattern_lets_authors_compose() {
+    let overlay = load_overlay_yaml("copy_and_extend.yaml");
+    overlay.validate(EnumSet::empty()).expect("validates");
+
+    let mut target = load_json("base_with_source.json");
+    overlay
+        .apply(&mut target, EnumSet::empty())
+        .expect("apply succeeds");
+
+    let expected = load_json("copy_and_extend.expected.json");
+    assert_eq!(target, expected);
+}
+
+#[test]
+fn conflicting_copy_and_update_fixture_fails_validation() {
+    let overlay = load_overlay_json("bad_copy_and_update.json");
+    let err = overlay.validate(EnumSet::empty()).unwrap_err();
+    assert!(
+        err.errors.iter().any(|e| e.contains("`update` and `copy`")),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn invalid_copy_jsonpath_fixture_fails_validation_and_apply() {
+    let overlay = load_overlay_json("bad_copy_invalid_jsonpath.json");
+    let err = overlay.validate(EnumSet::empty()).unwrap_err();
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e.contains("invalid JSONPath") && e.contains(".copy")),
+        "got: {err}",
+    );
+
+    let mut target = serde_json::json!({ "dest": {} });
+    let snapshot = target.clone();
+    let apply_err = overlay.apply(&mut target, EnumSet::empty()).unwrap_err();
+    assert!(matches!(apply_err.kind, ApplyErrorKind::InvalidJsonPath(_)));
+    assert_eq!(target, snapshot, "target must be unchanged on apply error");
+}
+
+#[cfg(feature = "v1_0")]
+#[test]
+fn v1_0_overlay_upconverts_to_v1_1() {
+    use roas_overlay::v1_0;
+
+    let v10_json = serde_json::json!({
+        "overlay": "1.0.0",
+        "info": { "title": "T", "version": "1.0.0" },
+        "actions": [
+            { "target": "$.info", "update": { "description": "Patched." } }
+        ]
+    });
+    let src: v1_0::Overlay = serde_json::from_value(v10_json).unwrap();
+    let dst: Overlay = src.into();
+
+    // Apply the upconverted overlay and confirm it still works.
+    let mut target = serde_json::json!({
+        "openapi": "3.1.0",
+        "info": { "title": "API", "version": "1.0.0" }
+    });
+    dst.apply(&mut target, EnumSet::empty()).unwrap();
+    assert_eq!(target["info"]["description"], "Patched.");
+}


### PR DESCRIPTION
Additive over v1.0 (per [Overlay v1.1.0 spec](https://spec.openapis.org/overlay/v1.1.0.html)):

- `Info` gains optional `description`.
- `Action` gains optional `copy` — RFC 9535 JSONPath selecting a single source node; mutually exclusive with `update` and `remove: true`.
- `overlay` version regex `^1\.1\.\d+$`.
- `impl From<v1_0::Overlay> for v1_1::Overlay` when both features are enabled.

`copy` apply path: compile JSONPath, evaluate against the current working doc, require exactly one match (`CopySourceNotFound` / `CopySourceMultiple`), use that value as the effective merge value. Same merge semantics as `update` — object targets recurse per §4.4.3.1, array targets append as a single entry.

Coverage: 98.89% overall; `overlay-v1_1` codecov component sits at 98.73%.

Verified: `cargo fmt`, `cargo clippy -p roas-overlay --all-features --all-targets -- -D warnings`, `cargo nextest run --workspace --all-features` (1941 tests), doctests.
