### PR TITLE
feat(roas-cli): overlay subcommand group + convert --apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1256,6 +1256,7 @@ dependencies = [
  "roas",
  "roas-file-fetcher",
  "roas-http-fetcher",
+ "roas-overlay",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 roas = { version = ">=0.15", path = "../roas", features = ["clap", "v2", "v3_0", "v3_1", "v3_2"] }
+roas-overlay = { version = ">=0.1", path = "../roas-overlay", features = ["clap", "v1_0", "v1_1"] }
 roas-file-fetcher = { version = ">=0.1", path = "../roas-file-fetcher", features = ["yaml"] }
 roas-http-fetcher = { version = ">=0.1", path = "../roas-http-fetcher", features = ["yaml"] }
 anyhow.workspace = true

--- a/crates/roas-cli/README.md
+++ b/crates/roas-cli/README.md
@@ -111,7 +111,7 @@ roas convert --to v3_2 --merge layer.yaml --merge-option merge-info spec.json
 
 Supported `--merge-option` values: `base-wins`, `error-on-conflict`, `deep-merge-object-schemas`, `merge-info`, `replace-lists-when-empty`. Under `error-on-conflict` the first real collision aborts the merge and `roas` exits non-zero with the conflicting path; the base spec is untouched on error.
 
-`--apply <FILE>` (repeatable) applies OpenAPI Overlay documents on top of the converted spec. Each overlay is loaded with extension-based format detection, its version detected from the `overlay` field, and applied via [`roas-overlay`](https://crates.io/crates/roas-overlay). The full convert pipeline is **convert → `--merge` → `--collapse` → `--apply`** — overlays run last, on the final JSON, because they produce arbitrary structure that no longer needs the typed model (whereas collapse does). `--apply-option` (repeatable) tunes the apply (`error-on-zero-match`, `error-on-mixed-kind-match`):
+`--apply <FILE>` (repeatable) applies OpenAPI Overlay documents to the converted spec. Each overlay is loaded with extension-based format detection, its version detected from the `overlay` field, and applied via [`roas-overlay`](https://crates.io/crates/roas-overlay). The full convert pipeline is **convert → `--merge` → `--apply` → `--collapse`** — overlays apply before collapse so overlay-introduced inline components are lifted into `$ref`s too. (When `--apply` and `--collapse` are combined, the overlaid spec is re-parsed at the target version before collapsing, so it must still be a valid OpenAPI document.) `--apply-option` (repeatable) tunes the apply (`error-on-zero-match`, `error-on-mixed-kind-match`):
 
 ```shell
 roas convert --to v3_2 --apply patch.yaml spec.json

--- a/crates/roas-cli/README.md
+++ b/crates/roas-cli/README.md
@@ -1,6 +1,6 @@
 # roas-cli
 
-Command-line front-end for [`roas`](https://crates.io/crates/roas): validate and convert OpenAPI specs across versions 2.0 / 3.0.x / 3.1.x / 3.2.x.
+Command-line front-end for [`roas`](https://crates.io/crates/roas): validate and convert OpenAPI specs across versions 2.0 / 3.0.x / 3.1.x / 3.2.x, and validate / convert / apply [OpenAPI Overlay](https://spec.openapis.org/overlay/v1.0.0.html) documents (v1.0 / v1.1) via [`roas-overlay`](https://crates.io/crates/roas-overlay).
 
 [![crates.io](https://img.shields.io/crates/v/roas-cli.svg)](https://crates.io/crates/roas-cli)
 
@@ -35,10 +35,15 @@ Pinned versions: `ghcr.io/sv-tools/roas:<version>` — see the [GitHub Releases]
 ## Usage
 
 ```shell
-roas validate [FILE]            # parse + validate
-roas convert --to v3_2 [FILE]   # upconvert across versions
-roas preview [FILE]             # open the spec in a browser via Redoc
+roas validate [FILE]                       # parse + validate an OpenAPI spec
+roas convert --to v3_2 [FILE]              # upconvert across versions
+roas overlay validate [FILE]               # validate an OpenAPI Overlay document
+roas overlay convert --to v1_1 [FILE]      # upconvert an overlay
+roas overlay apply --overlay O.yaml [SPEC] # apply overlay(s) to a spec
+roas preview [FILE]                        # open the spec in a browser via Redoc
 ```
+
+The root `validate` and `convert` commands operate on OpenAPI specs; the `overlay` subcommand group operates on OpenAPI Overlay documents.
 
 Input can be JSON or YAML. With a file path, the parser is selected by extension (`.yaml` / `.yml` → YAML, everything else → JSON). Pass `-` as the file path, or omit it entirely and pipe the spec, to read from stdin; stdin defaults to JSON. `--format json|yaml` overrides everything.
 
@@ -105,6 +110,30 @@ roas convert --to v3_2 --merge layer.yaml --merge-option merge-info spec.json
 ```
 
 Supported `--merge-option` values: `base-wins`, `error-on-conflict`, `deep-merge-object-schemas`, `merge-info`, `replace-lists-when-empty`. Under `error-on-conflict` the first real collision aborts the merge and `roas` exits non-zero with the conflicting path; the base spec is untouched on error.
+
+`--apply <FILE>` (repeatable) applies OpenAPI Overlay documents on top of the converted spec. Each overlay is loaded with extension-based format detection, its version detected from the `overlay` field, and applied via [`roas-overlay`](https://crates.io/crates/roas-overlay). The full convert pipeline is **convert → `--merge` → `--collapse` → `--apply`** — overlays run last, on the final JSON, because they produce arbitrary structure that no longer needs the typed model (whereas collapse does). `--apply-option` (repeatable) tunes the apply (`error-on-zero-match`, `error-on-mixed-kind-match`):
+
+```shell
+roas convert --to v3_2 --apply patch.yaml spec.json
+roas convert --to v3_2 --merge layer.yaml --apply patch.yaml --collapse spec.json
+roas convert --to v3_2 --apply patch.yaml --apply-option error-on-zero-match spec.json
+```
+
+### `overlay`
+
+Work with [OpenAPI Overlay](https://spec.openapis.org/overlay/v1.0.0.html) documents (v1.0 and v1.1). The overlay version is auto-detected from the `overlay` field.
+
+```shell
+roas overlay validate overlay.yaml                          # parse + validate
+roas overlay convert --to v1_1 overlay.json                 # upconvert v1.0 → v1.1
+roas overlay apply --overlay patch.yaml spec.json           # apply to a spec
+cat spec.json | roas overlay apply --overlay patch.yaml     # spec on stdin
+roas overlay apply --overlay a.yaml --overlay b.yaml spec.json | roas validate
+```
+
+- **`overlay validate`** — checks structure: the `overlay` version, non-empty `actions`, valid RFC 9535 JSONPath in every `target` (and `copy`), and the mutual-exclusivity rules. `--ignore <CHECK>` skips a check (`empty-info-title`, `empty-info-version`); `--print` echoes the parsed overlay.
+- **`overlay convert --to <v1_0|v1_1>`** — upconverts an overlay. Only upconversion is supported (v1.0 → v1.1 adds the `copy` action and `info.description`); downconversion errors.
+- **`overlay apply`** — applies overlay(s) to a target spec. The spec is the positional argument (or stdin); `--overlay <FILE>` (repeatable, at least one required) names the overlay(s), applied in order. The spec is treated as untyped JSON, so this works for any OpenAPI version. `--apply-option` (repeatable) accepts `error-on-zero-match` and `error-on-mixed-kind-match`. On any apply error the spec is left untouched and `roas` exits non-zero.
 
 ### `preview`
 

--- a/crates/roas-cli/src/main.rs
+++ b/crates/roas-cli/src/main.rs
@@ -1,6 +1,7 @@
 //! `roas` command-line front-end.
 //!
-//! Three subcommands today:
+//! The root `validate` and `convert` commands operate on OpenAPI specs;
+//! the `overlay` subcommand group operates on OpenAPI Overlay documents.
 //!
 //! - `roas validate [FILE]` — parse and validate an OpenAPI spec. Version is
 //!   auto-detected from the document; pass `--from` to force. External
@@ -20,10 +21,20 @@
 //!   run `Spec::collapse` on the (post-conversion, post-merge)
 //!   result, lifting every inline component into the matching
 //!   `components.<bag>` / `definitions` / `parameters` / `responses`
-//!   slot with strict dedup. External `$ref`s are skipped by default;
-//!   use `--load file` / `--load http` to opt into the loader. Output
-//!   defaults to the input format (YAML in → YAML out, JSON in → JSON
-//!   out); pass `--output-format json|yaml` to override.
+//!   slot with strict dedup. Pass `--apply <FILE>` (repeatable) to
+//!   apply OpenAPI Overlay documents on top of the final spec —
+//!   overlays run *last*, after conversion, `--merge`, and
+//!   `--collapse`; `--apply-option` tunes the apply. External `$ref`s
+//!   are skipped by default; use `--load file` / `--load http` to opt
+//!   into the loader. Output defaults to the input format (YAML in →
+//!   YAML out, JSON in → JSON out); pass `--output-format json|yaml`
+//!   to override.
+//!
+//! - `roas overlay <validate|convert|apply>` — work with OpenAPI
+//!   Overlay documents. `overlay validate` parses + validates an
+//!   overlay; `overlay convert --to v1_1` upconverts one; `overlay
+//!   apply --overlay <FILE> [SPEC]` applies overlay(s) to a target
+//!   spec (spec on stdin or as the positional arg).
 //!
 //! - `roas preview [FILE]` — start a local HTTP server on
 //!   `127.0.0.1:<random>` that serves the spec rendered with
@@ -54,9 +65,11 @@ use std::path::{Path, PathBuf};
 // Variants render as kebab-case with the `Ignore` prefix dropped: e.g.
 // `Options::IgnoreMissingTags` ↔ `--ignore missing-tags`.
 
+mod overlay;
 mod preview;
 mod versioned;
 
+use overlay::OverlayCommand;
 use preview::PreviewArgs;
 use versioned::{SpecVersion, parse_value, path_looks_like_yaml};
 
@@ -73,6 +86,9 @@ enum Command {
     Validate(ValidateArgs),
     /// Convert an OpenAPI spec to a different version.
     Convert(ConvertArgs),
+    /// Work with OpenAPI Overlay documents: validate, convert, or apply.
+    #[command(subcommand)]
+    Overlay(OverlayCommand),
     /// Preview the spec in a browser, rendered with Redoc or Swagger UI.
     Preview(PreviewArgs),
     /// Print a shell completion script to stdout.
@@ -179,6 +195,22 @@ struct ConvertArgs {
     #[arg(long)]
     collapse: bool,
 
+    /// Path to an OpenAPI Overlay document to apply on top of the
+    /// converted (and merged / collapsed) spec. Each `--apply` source
+    /// is loaded with extension-based format detection, its version
+    /// detected from the `overlay` field, and applied via
+    /// `roas-overlay`. Repeat the flag to apply several overlays in
+    /// order. Apply runs *last* — after conversion, `--merge`, and
+    /// `--collapse`.
+    #[arg(long, value_name = "FILE")]
+    apply: Vec<PathBuf>,
+
+    /// Per-call overlay apply option (repeatable). Maps to
+    /// `roas_overlay::apply::ApplyOptions`. Requires at least one
+    /// `--apply` source (clap rejects the flag on its own).
+    #[arg(long = "apply-option", value_enum, requires = "apply")]
+    apply_options: Vec<roas_overlay::apply::ApplyOptions>,
+
     /// Enable external-reference loading during `--collapse`. Same
     /// semantics as `roas validate --load`: pass `--load file` to
     /// allow `file://` refs, `--load http` for `http(s)://`; repeat
@@ -242,6 +274,7 @@ fn main() -> Result<()> {
     match cli.command {
         Command::Validate(args) => run_validate(args),
         Command::Convert(args) => run_convert(args),
+        Command::Overlay(cmd) => overlay::run_overlay(cmd),
         Command::Preview(args) => preview::run_preview(args),
         Command::Completions { shell } => run_completions(shell),
         Command::Manpages { out } => run_manpages(&out),
@@ -399,7 +432,7 @@ fn build_loader(kinds: &[LoaderKind]) -> Option<Loader> {
 ///
 /// Used by both `validate --print` (compact, pipeline-friendly) and
 /// `convert` (pretty, file-friendly).
-fn serialize_spec(
+pub(crate) fn serialize_spec(
     value: &serde_json::Value,
     format: InputFormat,
     pretty_json: bool,
@@ -524,12 +557,24 @@ fn run_convert(args: ConvertArgs) -> Result<()> {
         }
     }
 
-    // 3) Collapse last so it has visibility into the final merged tree.
+    // 3) Collapse so it has visibility into the final merged tree.
     if args.collapse {
         let mut loader = build_loader(&args.load);
         converted.collapse(loader.as_mut())?;
     }
-    let value = converted.into_value()?;
+    let mut value = converted.into_value()?;
+
+    // 4) Apply overlays last, on the serialized JSON. Overlays produce
+    //    arbitrary JSON that no longer needs the typed model, whereas
+    //    collapse does — so apply must run after it.
+    if !args.apply.is_empty() {
+        let mut apply_options = enumset::EnumSet::<roas_overlay::apply::ApplyOptions>::empty();
+        for opt in &args.apply_options {
+            apply_options |= *opt;
+        }
+        overlay::apply_overlays(&mut value, &args.apply, apply_options)?;
+    }
+
     // Output format defaults to the input format; `--output-format` overrides.
     let out_format = args.output_format.unwrap_or(input_format);
     print!("{}", serialize_spec(&value, out_format, true)?);
@@ -1139,6 +1184,8 @@ mod tests {
             load: vec![],
             merge: vec![],
             merge_options: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         run_convert(args).expect("v2 → v3.2 must succeed");
     }
@@ -1189,6 +1236,8 @@ mod tests {
             load: vec![LoaderKind::File],
             merge: vec![],
             merge_options: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         run_convert(args).expect("convert + collapse + --load file must succeed");
     }
@@ -1232,6 +1281,8 @@ mod tests {
             load: vec![],
             merge: vec![],
             merge_options: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         run_convert(args).expect("convert + collapse must succeed");
     }
@@ -1249,6 +1300,8 @@ mod tests {
             load: vec![],
             merge: vec![],
             merge_options: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         let err = run_convert(args).expect_err("downconversion must error");
         assert!(
@@ -1280,6 +1333,8 @@ mod tests {
             merge_options: vec![],
             collapse: false,
             load: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         run_convert(args).expect("convert + merge must succeed");
     }
@@ -1305,6 +1360,8 @@ mod tests {
             merge_options: vec![],
             collapse: false,
             load: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         run_convert(args).expect("cross-version merge after convert must succeed");
     }
@@ -1331,6 +1388,8 @@ mod tests {
             merge_options: vec![MergeOptionFlag::MergeInfo, MergeOptionFlag::ErrorOnConflict],
             collapse: false,
             load: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         let err = run_convert(args).expect_err("error-on-conflict must surface");
         assert!(
@@ -1352,12 +1411,104 @@ mod tests {
             merge_options: vec![],
             collapse: false,
             load: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         let err = run_convert(args).expect_err("missing merge source must error");
         assert!(
             err.to_string().contains("reading"),
             "expected `reading` context, got: {err}",
         );
+    }
+
+    #[test]
+    fn run_convert_with_apply_layers_an_overlay_after_conversion() {
+        let base = TempFile::write("base.json", MINIMAL_V3_2);
+        let overlay = TempFile::write(
+            "overlay.json",
+            br#"{"overlay":"1.0.0","info":{"title":"o","version":"1"},"actions":[{"target":"$.info","update":{"description":"added"}}]}"#,
+        );
+        let args = ConvertArgs {
+            file: Some(base.0.clone()),
+            to: SpecVersion::V3_2,
+            from: None,
+            format: None,
+            output_format: None,
+            merge: vec![],
+            merge_options: vec![],
+            collapse: false,
+            load: vec![],
+            apply: vec![overlay.0.clone()],
+            apply_options: vec![],
+        };
+        run_convert(args).expect("convert + apply must succeed");
+    }
+
+    #[test]
+    fn run_convert_apply_option_error_on_zero_match_surfaces() {
+        // Threading check: an overlay targeting a missing node, with
+        // `--apply-option error-on-zero-match`, must abort `convert`.
+        let base = TempFile::write("base.json", MINIMAL_V3_2);
+        let overlay = TempFile::write(
+            "overlay.json",
+            br#"{"overlay":"1.0.0","info":{"title":"o","version":"1"},"actions":[{"target":"$.nope","update":{}}]}"#,
+        );
+        let args = ConvertArgs {
+            file: Some(base.0.clone()),
+            to: SpecVersion::V3_2,
+            from: None,
+            format: None,
+            output_format: None,
+            merge: vec![],
+            merge_options: vec![],
+            collapse: false,
+            load: vec![],
+            apply: vec![overlay.0.clone()],
+            apply_options: vec![roas_overlay::apply::ApplyOptions::ErrorOnZeroMatch],
+        };
+        let err = run_convert(args).expect_err("error-on-zero-match must surface");
+        assert!(
+            err.to_string().contains("applying overlay"),
+            "expected `applying overlay` context, got: {err}",
+        );
+    }
+
+    #[test]
+    fn cli_parses_convert_with_apply_and_apply_option() {
+        let cli = Cli::try_parse_from([
+            "roas",
+            "convert",
+            "--to",
+            "v3_2",
+            "--apply",
+            "o.yaml",
+            "--apply-option",
+            "error-on-zero-match",
+            "spec.json",
+        ])
+        .expect("convert --apply parse");
+        match cli.command {
+            Command::Convert(a) => {
+                assert_eq!(a.apply, vec![PathBuf::from("o.yaml")]);
+                assert_eq!(a.apply_options.len(), 1);
+            }
+            _ => panic!("expected convert"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_apply_option_without_apply() {
+        // `--apply-option` requires at least one `--apply` source.
+        let res = Cli::try_parse_from([
+            "roas",
+            "convert",
+            "--to",
+            "v3_2",
+            "--apply-option",
+            "error-on-zero-match",
+            "spec.json",
+        ]);
+        assert!(res.is_err(), "--apply-option without --apply must error");
     }
 
     #[test]
@@ -1372,6 +1523,8 @@ mod tests {
             load: vec![],
             merge: vec![],
             merge_options: vec![],
+            apply: vec![],
+            apply_options: vec![],
         };
         let err = run_convert(args).expect_err("missing file must error");
         assert!(

--- a/crates/roas-cli/src/main.rs
+++ b/crates/roas-cli/src/main.rs
@@ -22,13 +22,13 @@
 //!   result, lifting every inline component into the matching
 //!   `components.<bag>` / `definitions` / `parameters` / `responses`
 //!   slot with strict dedup. Pass `--apply <FILE>` (repeatable) to
-//!   apply OpenAPI Overlay documents on top of the final spec —
-//!   overlays run *last*, after conversion, `--merge`, and
-//!   `--collapse`; `--apply-option` tunes the apply. External `$ref`s
-//!   are skipped by default; use `--load file` / `--load http` to opt
-//!   into the loader. Output defaults to the input format (YAML in →
-//!   YAML out, JSON in → JSON out); pass `--output-format json|yaml`
-//!   to override.
+//!   apply OpenAPI Overlay documents to the spec; `--apply-option`
+//!   tunes the apply. The pipeline runs convert → `--merge` →
+//!   `--apply` → `--collapse`, so overlay edits are visible to
+//!   collapse. External `$ref`s are skipped by default; use `--load
+//!   file` / `--load http` to opt into the loader. Output defaults to
+//!   the input format (YAML in → YAML out, JSON in → JSON out); pass
+//!   `--output-format json|yaml` to override.
 //!
 //! - `roas overlay <validate|convert|apply>` — work with OpenAPI
 //!   Overlay documents. `overlay validate` parses + validates an
@@ -557,23 +557,44 @@ fn run_convert(args: ConvertArgs) -> Result<()> {
         }
     }
 
-    // 3) Collapse so it has visibility into the final merged tree.
-    if args.collapse {
-        let mut loader = build_loader(&args.load);
-        converted.collapse(loader.as_mut())?;
-    }
-    let mut value = converted.into_value()?;
-
-    // 4) Apply overlays last, on the serialized JSON. Overlays produce
-    //    arbitrary JSON that no longer needs the typed model, whereas
-    //    collapse does — so apply must run after it.
-    if !args.apply.is_empty() {
+    // Pipeline order is convert → merge → apply → collapse, so overlay
+    // edits are visible to collapse (overlay-introduced inline
+    // components get lifted into `$ref`s too). `collapse` works on the
+    // typed spec while `apply` works on `serde_json::Value`, so:
+    //
+    //   - no `--apply`: collapse on the typed spec directly (no
+    //     serialize/re-parse round-trip; identical to plain convert).
+    //   - with `--apply`: serialize, apply the overlays, then — if
+    //     `--collapse` — re-parse the result at the target version and
+    //     collapse the typed spec.
+    let value = if args.apply.is_empty() {
+        // 3) Collapse on the typed (post-merge) spec.
+        if args.collapse {
+            let mut loader = build_loader(&args.load);
+            converted.collapse(loader.as_mut())?;
+        }
+        converted.into_value()?
+    } else {
+        // 3) Apply overlays on the serialized (post-merge) spec.
         let mut apply_options = enumset::EnumSet::<roas_overlay::apply::ApplyOptions>::empty();
         for opt in &args.apply_options {
             apply_options |= *opt;
         }
+        let mut value = converted.into_value()?;
         overlay::apply_overlays(&mut value, &args.apply, apply_options)?;
-    }
+
+        // 4) Collapse the overlaid spec. Re-parse at the target
+        //    version first, since collapse needs the typed model.
+        if args.collapse {
+            let mut respec = versioned::detect_or_use(Some(target), value)
+                .context("re-parsing the overlaid spec for --collapse")?;
+            let mut loader = build_loader(&args.load);
+            respec.collapse(loader.as_mut())?;
+            respec.into_value()?
+        } else {
+            value
+        }
+    };
 
     // Output format defaults to the input format; `--output-format` overrides.
     let out_format = args.output_format.unwrap_or(input_format);
@@ -1442,6 +1463,33 @@ mod tests {
             apply_options: vec![],
         };
         run_convert(args).expect("convert + apply must succeed");
+    }
+
+    #[test]
+    fn run_convert_with_apply_then_collapse_reparses_and_collapses() {
+        // Exercises the apply → collapse path: the overlay edits the
+        // spec (Value), then it's re-parsed at the target version and
+        // collapsed. The overlay adds an inline schema that collapse
+        // can lift into components.
+        let base = TempFile::write("base.json", MINIMAL_V3_2);
+        let overlay = TempFile::write(
+            "overlay.json",
+            br#"{"overlay":"1.0.0","info":{"title":"o","version":"1"},"actions":[{"target":"$","update":{"components":{"schemas":{"Pet":{"type":"object"}}}}}]}"#,
+        );
+        let args = ConvertArgs {
+            file: Some(base.0.clone()),
+            to: SpecVersion::V3_2,
+            from: None,
+            format: None,
+            output_format: None,
+            merge: vec![],
+            merge_options: vec![],
+            collapse: true,
+            load: vec![],
+            apply: vec![overlay.0.clone()],
+            apply_options: vec![],
+        };
+        run_convert(args).expect("convert + apply + collapse must succeed");
     }
 
     #[test]

--- a/crates/roas-cli/src/overlay.rs
+++ b/crates/roas-cli/src/overlay.rs
@@ -1,0 +1,477 @@
+//! `roas overlay` subcommand group — validate, convert, and apply
+//! OpenAPI Overlay documents (powered by the `roas-overlay` crate).
+//!
+//! Overlays transform a *target* OpenAPI document; the apply step is
+//! version-agnostic on the spec side (it operates on the spec as
+//! untyped JSON), so these commands never go through the
+//! [`crate::versioned::DetectedSpec`] machinery — they read the spec
+//! as a `serde_json::Value`, apply, and serialise back.
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::{Subcommand, ValueEnum};
+use enumset::EnumSet;
+use roas_overlay::apply::{Apply, ApplyError, ApplyOptions, ApplyReport};
+use roas_overlay::validation::{Error as OverlayError, Validate, ValidationOptions};
+use roas_overlay::{v1_0, v1_1};
+use serde_json::Value;
+use std::path::PathBuf;
+
+use crate::{InputFormat, InputSource, read_input, resolve_input_source, serialize_spec};
+
+/// Overlay specification version, mirroring [`crate::versioned::SpecVersion`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum OverlayVersion {
+    #[value(name = "v1_0", alias = "1.0", alias = "v1.0")]
+    V1_0,
+    #[value(name = "v1_1", alias = "1.1", alias = "v1.1")]
+    V1_1,
+}
+
+impl OverlayVersion {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            OverlayVersion::V1_0 => "Overlay 1.0",
+            OverlayVersion::V1_1 => "Overlay 1.1",
+        }
+    }
+}
+
+/// A parsed overlay tagged with its version, mirroring
+/// [`crate::versioned::DetectedSpec`].
+#[derive(Debug)]
+pub(crate) enum DetectedOverlay {
+    V1_0(v1_0::Overlay),
+    V1_1(v1_1::Overlay),
+}
+
+impl DetectedOverlay {
+    pub(crate) fn version(&self) -> OverlayVersion {
+        match self {
+            DetectedOverlay::V1_0(_) => OverlayVersion::V1_0,
+            DetectedOverlay::V1_1(_) => OverlayVersion::V1_1,
+        }
+    }
+
+    pub(crate) fn label(&self) -> &'static str {
+        self.version().label()
+    }
+
+    pub(crate) fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), OverlayError> {
+        match self {
+            DetectedOverlay::V1_0(o) => o.validate(options),
+            DetectedOverlay::V1_1(o) => o.validate(options),
+        }
+    }
+
+    /// Upconvert to `target`. Same-version is the identity; v1.0 → v1.1
+    /// uses the `From` impl. Downconversion is not supported.
+    pub(crate) fn convert_to(self, target: OverlayVersion) -> Result<DetectedOverlay> {
+        match (self, target) {
+            (DetectedOverlay::V1_0(o), OverlayVersion::V1_0) => Ok(DetectedOverlay::V1_0(o)),
+            (DetectedOverlay::V1_0(o), OverlayVersion::V1_1) => {
+                Ok(DetectedOverlay::V1_1(v1_1::Overlay::from(o)))
+            }
+            (DetectedOverlay::V1_1(o), OverlayVersion::V1_1) => Ok(DetectedOverlay::V1_1(o)),
+            (DetectedOverlay::V1_1(_), OverlayVersion::V1_0) => bail!(
+                "downconversion is not supported: input is Overlay 1.1, target is Overlay 1.0",
+            ),
+        }
+    }
+
+    pub(crate) fn apply(
+        &self,
+        target: &mut Value,
+        options: EnumSet<ApplyOptions>,
+    ) -> Result<ApplyReport, ApplyError> {
+        match self {
+            DetectedOverlay::V1_0(o) => o.apply(target, options),
+            DetectedOverlay::V1_1(o) => o.apply(target, options),
+        }
+    }
+
+    pub(crate) fn into_value(self) -> Result<Value> {
+        match self {
+            DetectedOverlay::V1_0(o) => {
+                serde_json::to_value(o).context("serialising Overlay 1.0 document")
+            }
+            DetectedOverlay::V1_1(o) => {
+                serde_json::to_value(o).context("serialising Overlay 1.1 document")
+            }
+        }
+    }
+}
+
+/// Detect the overlay version by reading the top-level `overlay` field
+/// (`"1.0.x"` → v1.0, `"1.1.x"` → v1.1).
+pub(crate) fn detect_overlay(value: &Value) -> Result<OverlayVersion> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| anyhow!("overlay must be an object at the top level"))?;
+    let overlay = obj
+        .get("overlay")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("could not detect overlay version: no `overlay` field"))?;
+
+    if overlay.starts_with("1.0.") {
+        Ok(OverlayVersion::V1_0)
+    } else if overlay.starts_with("1.1.") {
+        Ok(OverlayVersion::V1_1)
+    } else {
+        bail!("unsupported overlay version: {overlay}")
+    }
+}
+
+/// Detect (or force) the overlay version and deserialise into the
+/// matching typed `Overlay`.
+pub(crate) fn detect_or_use_overlay(
+    forced: Option<OverlayVersion>,
+    value: Value,
+) -> Result<DetectedOverlay> {
+    let version = match forced {
+        Some(v) => v,
+        None => detect_overlay(&value)?,
+    };
+    Ok(match version {
+        OverlayVersion::V1_0 => DetectedOverlay::V1_0(
+            serde_json::from_value(value).context("deserialising as Overlay 1.0")?,
+        ),
+        OverlayVersion::V1_1 => DetectedOverlay::V1_1(
+            serde_json::from_value(value).context("deserialising as Overlay 1.1")?,
+        ),
+    })
+}
+
+#[derive(Subcommand)]
+pub(crate) enum OverlayCommand {
+    /// Parse and validate an Overlay document.
+    Validate(OverlayValidateArgs),
+    /// Upconvert an Overlay document to a newer version.
+    Convert(OverlayConvertArgs),
+    /// Apply overlay(s) to a target OpenAPI spec.
+    Apply(OverlayApplyArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct OverlayValidateArgs {
+    /// Path to the overlay file (JSON or YAML). Pass `-`, or omit and
+    /// pipe the overlay, to read from stdin.
+    file: Option<PathBuf>,
+
+    /// Override format detection. By default, file paths use the
+    /// extension (`.yaml`/`.yml` → YAML, otherwise JSON) and stdin
+    /// defaults to JSON.
+    #[arg(long, value_enum)]
+    format: Option<InputFormat>,
+
+    /// Skip a specific validation check (repeatable). Maps to
+    /// `roas_overlay::validation::ValidationOptions`.
+    #[arg(long, value_enum)]
+    ignore: Vec<ValidationOptions>,
+
+    /// Echo the parsed overlay to stdout on success, in the input
+    /// format (YAML in → YAML out, JSON in → JSON out).
+    #[arg(long)]
+    print: bool,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct OverlayConvertArgs {
+    /// Path to the overlay file (JSON or YAML). Pass `-`, or omit and
+    /// pipe the overlay, to read from stdin.
+    file: Option<PathBuf>,
+
+    /// Target overlay version. Only upconversion is supported.
+    #[arg(long, value_enum)]
+    to: OverlayVersion,
+
+    /// Override format detection (see `overlay validate --format`).
+    #[arg(long, value_enum)]
+    format: Option<InputFormat>,
+
+    /// Output format. Defaults to the input format.
+    #[arg(long, value_enum)]
+    output_format: Option<InputFormat>,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct OverlayApplyArgs {
+    /// Path to the target OpenAPI spec (JSON or YAML). Pass `-`, or
+    /// omit and pipe the spec, to read from stdin.
+    file: Option<PathBuf>,
+
+    /// Path to an overlay document to apply (repeatable). Overlays are
+    /// applied in the order given, each on the result of the previous.
+    #[arg(long, value_name = "FILE", required = true)]
+    overlay: Vec<PathBuf>,
+
+    /// Per-call apply option (repeatable). Maps to
+    /// `roas_overlay::apply::ApplyOptions`.
+    #[arg(long = "apply-option", value_enum)]
+    apply_options: Vec<ApplyOptions>,
+
+    /// Override format detection for the *spec* input (see
+    /// `overlay validate --format`). Each `--overlay` source uses its
+    /// own extension-based detection.
+    #[arg(long, value_enum)]
+    format: Option<InputFormat>,
+
+    /// Output format. Defaults to the spec's input format.
+    #[arg(long, value_enum)]
+    output_format: Option<InputFormat>,
+}
+
+pub(crate) fn run_overlay(cmd: OverlayCommand) -> Result<()> {
+    match cmd {
+        OverlayCommand::Validate(args) => run_overlay_validate(args),
+        OverlayCommand::Convert(args) => run_overlay_convert(args),
+        OverlayCommand::Apply(args) => run_overlay_apply(args),
+    }
+}
+
+fn run_overlay_validate(args: OverlayValidateArgs) -> Result<()> {
+    let source = resolve_input_source(args.file.as_deref())?;
+    let (value, input_format) = read_input(&source, args.format)?;
+    let detected = detect_or_use_overlay(None, value)?;
+
+    let mut options = EnumSet::<ValidationOptions>::empty();
+    for ignore in &args.ignore {
+        options |= *ignore;
+    }
+
+    match detected.validate(options) {
+        Ok(()) => {
+            eprintln!("{}: valid {}", source.display(), detected.label());
+            if args.print {
+                let value = detected.into_value()?;
+                print!("{}", serialize_spec(&value, input_format, false)?);
+            }
+            Ok(())
+        }
+        Err(err) => {
+            for e in &err.errors {
+                eprintln!("- {e}");
+            }
+            Err(anyhow!(
+                "{}: overlay validation failed ({} error{})",
+                source.display(),
+                err.errors.len(),
+                if err.errors.len() == 1 { "" } else { "s" }
+            ))
+        }
+    }
+}
+
+fn run_overlay_convert(args: OverlayConvertArgs) -> Result<()> {
+    let source = resolve_input_source(args.file.as_deref())?;
+    let (value, input_format) = read_input(&source, args.format)?;
+    let detected = detect_or_use_overlay(None, value)?;
+
+    let converted = detected.convert_to(args.to)?;
+    let value = converted.into_value()?;
+    let out_format = args.output_format.unwrap_or(input_format);
+    print!("{}", serialize_spec(&value, out_format, true)?);
+    Ok(())
+}
+
+fn run_overlay_apply(args: OverlayApplyArgs) -> Result<()> {
+    let source = resolve_input_source(args.file.as_deref())?;
+    let (mut spec, input_format) = read_input(&source, args.format)?;
+
+    let mut options = EnumSet::<ApplyOptions>::empty();
+    for opt in &args.apply_options {
+        options |= *opt;
+    }
+
+    apply_overlays(&mut spec, &args.overlay, options)?;
+
+    let out_format = args.output_format.unwrap_or(input_format);
+    print!("{}", serialize_spec(&spec, out_format, true)?);
+    Ok(())
+}
+
+/// Apply each overlay at `paths` to `spec` in order. Shared by
+/// `overlay apply` and `convert --apply`. Each overlay is loaded with
+/// extension-based format detection and its version detected from the
+/// `overlay` field.
+pub(crate) fn apply_overlays(
+    spec: &mut Value,
+    paths: &[PathBuf],
+    options: EnumSet<ApplyOptions>,
+) -> Result<()> {
+    for path in paths {
+        let (value, _format) = read_input(&InputSource::File(path.clone()), None)
+            .with_context(|| format!("reading overlay {}", path.display()))?;
+        let overlay = detect_or_use_overlay(None, value)
+            .with_context(|| format!("parsing overlay {}", path.display()))?;
+        overlay
+            .apply(spec, options)
+            .map_err(|e| anyhow!("applying overlay {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use serde_json::json;
+
+    // A minimal `Cli` mirror so we can exercise clap parsing of the
+    // overlay subcommand tree in isolation.
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: OverlayCommand,
+    }
+
+    fn v1_0_overlay() -> Value {
+        json!({
+            "overlay": "1.0.0",
+            "info": { "title": "T", "version": "1.0.0" },
+            "actions": [ { "target": "$.info", "update": { "description": "d" } } ]
+        })
+    }
+
+    #[test]
+    fn detect_overlay_distinguishes_versions() {
+        assert_eq!(
+            detect_overlay(&v1_0_overlay()).unwrap(),
+            OverlayVersion::V1_0
+        );
+        let v11 = json!({
+            "overlay": "1.1.0",
+            "info": { "title": "T", "version": "1.0.0" },
+            "actions": [ { "target": "$", "remove": true } ]
+        });
+        assert_eq!(detect_overlay(&v11).unwrap(), OverlayVersion::V1_1);
+    }
+
+    #[test]
+    fn detect_overlay_rejects_missing_or_unknown_version() {
+        let err = detect_overlay(&json!({ "info": {} })).unwrap_err();
+        assert!(err.to_string().contains("no `overlay` field"));
+        let err = detect_overlay(&json!({ "overlay": "2.0.0" })).unwrap_err();
+        assert!(err.to_string().contains("unsupported overlay version"));
+        let err = detect_overlay(&json!("not an object")).unwrap_err();
+        assert!(err.to_string().contains("object at the top level"));
+    }
+
+    #[test]
+    fn convert_upconverts_v1_0_to_v1_1_and_rejects_downconvert() {
+        let d = detect_or_use_overlay(None, v1_0_overlay()).unwrap();
+        let up = d.convert_to(OverlayVersion::V1_1).unwrap();
+        assert_eq!(up.version(), OverlayVersion::V1_1);
+        let value = up.into_value().unwrap();
+        assert_eq!(value["overlay"], "1.1.0");
+
+        // identity
+        let d = detect_or_use_overlay(None, v1_0_overlay()).unwrap();
+        assert_eq!(
+            d.convert_to(OverlayVersion::V1_0).unwrap().version(),
+            OverlayVersion::V1_0
+        );
+
+        // downconvert errors
+        let v11 = json!({
+            "overlay": "1.1.0",
+            "info": { "title": "T", "version": "1.0.0" },
+            "actions": [ { "target": "$", "remove": true } ]
+        });
+        let d = detect_or_use_overlay(None, v11).unwrap();
+        let err = d.convert_to(OverlayVersion::V1_0).unwrap_err();
+        assert!(err.to_string().contains("downconversion is not supported"));
+    }
+
+    #[test]
+    fn apply_overlays_transforms_spec_in_order() {
+        let mut spec = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "API", "version": "1.0.0" }
+        });
+        // Write the v1.0 overlay to a temp file and apply it.
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("roas-cli-overlay-test-{}.json", std::process::id()));
+        std::fs::write(&path, serde_json::to_string(&v1_0_overlay()).unwrap()).unwrap();
+        let res = apply_overlays(&mut spec, std::slice::from_ref(&path), EnumSet::empty());
+        let _ = std::fs::remove_file(&path);
+        res.unwrap();
+        assert_eq!(spec["info"]["description"], "d");
+    }
+
+    #[test]
+    fn apply_overlays_surfaces_apply_errors_with_path() {
+        let mut spec = json!({ "info": { "title": "x" } });
+        let bad = json!({
+            "overlay": "1.0.0",
+            "info": { "title": "T", "version": "1.0.0" },
+            // target a primitive → PrimitiveActionTarget
+            "actions": [ { "target": "$.info.title", "update": { "x": 1 } } ]
+        });
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("roas-cli-overlay-bad-{}.json", std::process::id()));
+        std::fs::write(&path, serde_json::to_string(&bad).unwrap()).unwrap();
+        let err =
+            apply_overlays(&mut spec, std::slice::from_ref(&path), EnumSet::empty()).unwrap_err();
+        let _ = std::fs::remove_file(&path);
+        assert!(err.to_string().contains("applying overlay"));
+    }
+
+    #[test]
+    fn cli_parses_overlay_validate() {
+        let cli = TestCli::try_parse_from(["roas", "validate", "overlay.yaml"]).unwrap();
+        assert!(matches!(cli.command, OverlayCommand::Validate(_)));
+    }
+
+    #[test]
+    fn cli_parses_overlay_convert_with_to() {
+        let cli =
+            TestCli::try_parse_from(["roas", "convert", "--to", "v1_1", "overlay.json"]).unwrap();
+        match cli.command {
+            OverlayCommand::Convert(a) => assert_eq!(a.to, OverlayVersion::V1_1),
+            _ => panic!("expected convert"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_overlay_apply_with_overlay_flag() {
+        let res = TestCli::try_parse_from([
+            "roas",
+            "apply",
+            "--overlay",
+            "o.yaml",
+            "--overlay",
+            "p.yaml",
+            "spec.json",
+        ]);
+        match res {
+            Ok(cli) => match cli.command {
+                OverlayCommand::Apply(a) => {
+                    assert_eq!(a.overlay.len(), 2);
+                    assert_eq!(a.file.as_deref(), Some(std::path::Path::new("spec.json")));
+                }
+                _ => panic!("expected apply"),
+            },
+            Err(e) => panic!("parse failed: {e}"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_overlay_apply_without_overlay_flag() {
+        match TestCli::try_parse_from(["roas", "apply", "spec.json"]) {
+            Err(e) => assert_eq!(e.kind(), clap::error::ErrorKind::MissingRequiredArgument),
+            Ok(_) => panic!("expected a missing-`--overlay` error"),
+        }
+    }
+
+    #[test]
+    fn overlay_version_value_enum_aliases_parse() {
+        assert_eq!(
+            OverlayVersion::from_str("1.0", true).unwrap(),
+            OverlayVersion::V1_0
+        );
+        assert_eq!(
+            OverlayVersion::from_str("v1.1", true).unwrap(),
+            OverlayVersion::V1_1
+        );
+    }
+}

--- a/crates/roas-cli/src/overlay.rs
+++ b/crates/roas-cli/src/overlay.rs
@@ -332,6 +332,38 @@ mod tests {
         })
     }
 
+    fn v1_1_overlay() -> Value {
+        json!({
+            "overlay": "1.1.0",
+            "info": { "title": "T", "version": "1.0.0", "description": "via copy" },
+            "actions": [ { "target": "$.paths['/b']", "copy": "$.paths['/a']" } ]
+        })
+    }
+
+    /// A temp file that cleans itself up on drop (mirrors the helper in
+    /// `main.rs`'s test module).
+    struct TempFile(PathBuf);
+
+    impl TempFile {
+        fn write(name: &str, value: &Value) -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "roas-cli-overlay-{}-{n}-{name}",
+                std::process::id(),
+            ));
+            std::fs::write(&path, serde_json::to_string(value).unwrap()).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
     #[test]
     fn detect_overlay_distinguishes_versions() {
         assert_eq!(
@@ -364,22 +396,37 @@ mod tests {
         let value = up.into_value().unwrap();
         assert_eq!(value["overlay"], "1.1.0");
 
-        // identity
+        // identity (v1.0 → v1.0)
         let d = detect_or_use_overlay(None, v1_0_overlay()).unwrap();
         assert_eq!(
             d.convert_to(OverlayVersion::V1_0).unwrap().version(),
             OverlayVersion::V1_0
         );
 
+        // identity (v1.1 → v1.1)
+        let d = detect_or_use_overlay(None, v1_1_overlay()).unwrap();
+        assert_eq!(
+            d.convert_to(OverlayVersion::V1_1).unwrap().version(),
+            OverlayVersion::V1_1
+        );
+
         // downconvert errors
-        let v11 = json!({
+        let d = detect_or_use_overlay(None, v1_1_overlay()).unwrap();
+        let err = d.convert_to(OverlayVersion::V1_0).unwrap_err();
+        assert!(err.to_string().contains("downconversion is not supported"));
+    }
+
+    #[test]
+    fn detect_or_use_overlay_honors_forced_version() {
+        // Force v1.1 even though a bare doc could be ambiguous; the
+        // forced branch skips `detect_overlay`.
+        let doc = json!({
             "overlay": "1.1.0",
             "info": { "title": "T", "version": "1.0.0" },
             "actions": [ { "target": "$", "remove": true } ]
         });
-        let d = detect_or_use_overlay(None, v11).unwrap();
-        let err = d.convert_to(OverlayVersion::V1_0).unwrap_err();
-        assert!(err.to_string().contains("downconversion is not supported"));
+        let d = detect_or_use_overlay(Some(OverlayVersion::V1_1), doc).unwrap();
+        assert_eq!(d.version(), OverlayVersion::V1_1);
     }
 
     #[test]
@@ -389,12 +436,8 @@ mod tests {
             "info": { "title": "API", "version": "1.0.0" }
         });
         // Write the v1.0 overlay to a temp file and apply it.
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!("roas-cli-overlay-test-{}.json", std::process::id()));
-        std::fs::write(&path, serde_json::to_string(&v1_0_overlay()).unwrap()).unwrap();
-        let res = apply_overlays(&mut spec, std::slice::from_ref(&path), EnumSet::empty());
-        let _ = std::fs::remove_file(&path);
-        res.unwrap();
+        let f = TempFile::write("apply.json", &v1_0_overlay());
+        apply_overlays(&mut spec, std::slice::from_ref(&f.0), EnumSet::empty()).unwrap();
         assert_eq!(spec["info"]["description"], "d");
     }
 
@@ -407,12 +450,9 @@ mod tests {
             // target a primitive → PrimitiveActionTarget
             "actions": [ { "target": "$.info.title", "update": { "x": 1 } } ]
         });
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!("roas-cli-overlay-bad-{}.json", std::process::id()));
-        std::fs::write(&path, serde_json::to_string(&bad).unwrap()).unwrap();
+        let f = TempFile::write("bad.json", &bad);
         let err =
-            apply_overlays(&mut spec, std::slice::from_ref(&path), EnumSet::empty()).unwrap_err();
-        let _ = std::fs::remove_file(&path);
+            apply_overlays(&mut spec, std::slice::from_ref(&f.0), EnumSet::empty()).unwrap_err();
         assert!(err.to_string().contains("applying overlay"));
     }
 
@@ -473,5 +513,148 @@ mod tests {
             OverlayVersion::from_str("v1.1", true).unwrap(),
             OverlayVersion::V1_1
         );
+    }
+
+    // --- end-to-end run-function coverage (build args directly, like
+    // the `run_convert` tests in main.rs; assert Ok/Err since stdout
+    // isn't captured here). ---
+
+    #[test]
+    fn run_overlay_validate_ok_with_print_covers_v1_0() {
+        let f = TempFile::write("ok.json", &v1_0_overlay());
+        let args = OverlayValidateArgs {
+            file: Some(f.0.clone()),
+            format: None,
+            ignore: vec![],
+            print: true, // exercises into_value + serialize_spec
+        };
+        run_overlay(OverlayCommand::Validate(args)).expect("valid overlay must pass");
+    }
+
+    #[test]
+    fn run_overlay_validate_ok_covers_v1_1() {
+        let f = TempFile::write("ok11.json", &v1_1_overlay());
+        let args = OverlayValidateArgs {
+            file: Some(f.0.clone()),
+            format: None,
+            ignore: vec![],
+            print: false,
+        };
+        run_overlay(OverlayCommand::Validate(args)).expect("valid v1.1 overlay must pass");
+    }
+
+    #[test]
+    fn run_overlay_validate_reports_single_error() {
+        // Valid info, empty actions → exactly one error (singular "").
+        let doc = json!({
+            "overlay": "1.0.0",
+            "info": { "title": "T", "version": "1.0.0" },
+            "actions": []
+        });
+        let f = TempFile::write("empty-actions.json", &doc);
+        let args = OverlayValidateArgs {
+            file: Some(f.0.clone()),
+            format: None,
+            ignore: vec![],
+            print: false,
+        };
+        let err = run_overlay(OverlayCommand::Validate(args)).unwrap_err();
+        assert!(
+            err.to_string().contains("1 error)"),
+            "expected singular error count, got: {err}",
+        );
+    }
+
+    #[test]
+    fn run_overlay_validate_reports_multiple_errors() {
+        // Empty info title+version AND empty actions → 3 errors (plural).
+        let doc = json!({
+            "overlay": "1.0.0",
+            "info": { "title": "", "version": "" },
+            "actions": []
+        });
+        let f = TempFile::write("many-errors.json", &doc);
+        let args = OverlayValidateArgs {
+            file: Some(f.0.clone()),
+            format: None,
+            ignore: vec![],
+            print: false,
+        };
+        let err = run_overlay(OverlayCommand::Validate(args)).unwrap_err();
+        assert!(
+            err.to_string().contains("errors)"),
+            "expected plural error count, got: {err}",
+        );
+    }
+
+    #[test]
+    fn run_overlay_validate_ignore_suppresses_check() {
+        // Empty title but `--ignore empty-info-title` → still other
+        // diagnostics, but proves the ignore set is threaded through.
+        let doc = json!({
+            "overlay": "1.0.0",
+            "info": { "title": "", "version": "1.0.0" },
+            "actions": [ { "target": "$.info", "update": {} } ]
+        });
+        let f = TempFile::write("ignore.json", &doc);
+        let args = OverlayValidateArgs {
+            file: Some(f.0.clone()),
+            format: None,
+            ignore: vec![ValidationOptions::IgnoreEmptyInfoTitle],
+            print: false,
+        };
+        run_overlay(OverlayCommand::Validate(args)).expect("empty title is ignored");
+    }
+
+    #[test]
+    fn run_overlay_convert_upconverts_v1_0_to_v1_1() {
+        let f = TempFile::write("conv.json", &v1_0_overlay());
+        let args = OverlayConvertArgs {
+            file: Some(f.0.clone()),
+            to: OverlayVersion::V1_1,
+            format: None,
+            output_format: None,
+        };
+        run_overlay(OverlayCommand::Convert(args)).expect("upconvert must succeed");
+    }
+
+    #[test]
+    fn run_overlay_apply_applies_v1_1_overlay_to_spec() {
+        let spec = json!({
+            "openapi": "3.1.0",
+            "info": { "title": "API", "version": "1.0.0" },
+            "paths": { "/a": { "get": { "summary": "s" } }, "/b": {} }
+        });
+        let spec_file = TempFile::write("spec.json", &spec);
+        let overlay_file = TempFile::write("ov.json", &v1_1_overlay());
+        let args = OverlayApplyArgs {
+            file: Some(spec_file.0.clone()),
+            overlay: vec![overlay_file.0.clone()],
+            apply_options: vec![],
+            format: None,
+            output_format: Some(InputFormat::Yaml), // exercise output-format override
+        };
+        run_overlay(OverlayCommand::Apply(args)).expect("apply must succeed");
+    }
+
+    #[test]
+    fn run_overlay_apply_surfaces_apply_error() {
+        let spec = json!({ "info": { "title": "x" } });
+        let spec_file = TempFile::write("spec.json", &spec);
+        let bad = json!({
+            "overlay": "1.0.0",
+            "info": { "title": "T", "version": "1.0.0" },
+            "actions": [ { "target": "$.nope", "update": {} } ]
+        });
+        let overlay_file = TempFile::write("bad.json", &bad);
+        let args = OverlayApplyArgs {
+            file: Some(spec_file.0.clone()),
+            overlay: vec![overlay_file.0.clone()],
+            apply_options: vec![ApplyOptions::ErrorOnZeroMatch],
+            format: None,
+            output_format: None,
+        };
+        let err = run_overlay(OverlayCommand::Apply(args)).unwrap_err();
+        assert!(err.to_string().contains("applying overlay"));
     }
 }


### PR DESCRIPTION
Wires [`roas-overlay`](https://crates.io/crates/roas-overlay) into the `roas` CLI.

**New `overlay` subcommand group** (operates on Overlay documents; root `validate`/`convert` stay OpenAPI-spec-only):
- `roas overlay validate [FILE]` — parse + validate an overlay (`--ignore`, `--print`).
- `roas overlay convert --to <v1_0|v1_1> [FILE]` — upconvert (v1.0 → v1.1); downconvert errors.
- `roas overlay apply --overlay <FILE>… [SPEC]` — apply overlay(s) to a target spec. Spec is positional/stdin, `--overlay` is repeatable (consistent with `convert --merge`), so it pipes: `cat spec.json | roas overlay apply --overlay o.yaml | roas validate`. `--apply-option` exposes `error-on-zero-match` / `error-on-mixed-kind-match`.

**Root `convert` gains `--apply <FILE>` / `--apply-option`** — the pipeline runs **convert → `--merge` → `--apply` → `--collapse`**, so overlay edits are visible to collapse (overlay-introduced inline components get lifted into `$ref`s too). When `--apply` and `--collapse` are combined, the overlaid spec is re-parsed at the target version before collapsing; the no-overlay path collapses the typed spec directly with no round-trip.

Apply is version-agnostic on the spec side (operates on `serde_json::Value`), so no `DetectedSpec` round-trip — `DetectedOverlay` / `OverlayVersion` mirror the existing dispatch types and detect the overlay version from the `overlay` field. Completions and manpages pick up the nested group automatically (`roas-overlay-apply.1` etc.).

Bumps roas-cli 0.7.0 → 0.8.0.