### PR TITLE
feat(roas-arazzo): Arazzo v1.0 model + validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "roas-arazzo"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "enumset",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+]
+
+[[package]]
 name = "roas-cli"
 version = "0.8.0"
 dependencies = [

--- a/crates/roas-arazzo/Cargo.toml
+++ b/crates/roas-arazzo/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "roas-arazzo"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+description = "Rust implementation of the OpenAPI Arazzo Specification v1.0 — parse and validate"
+readme = "README.md"
+categories = ["web-programming", "parser-implementations"]
+include = ["src", "Cargo.toml", "README.md"]
+publish = true
+
+[features]
+default = ["v1_0"]
+# Support for Arazzo v1.0.x.
+v1_0 = []
+
+# `clap::ValueEnum` impls for `validation::ValidationOptions`, for
+# downstream CLIs.
+clap = ["dep:clap"]
+
+[dependencies]
+clap = { workspace = true, optional = true }
+enumset.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+serde_yaml_ng.workspace = true

--- a/crates/roas-arazzo/README.md
+++ b/crates/roas-arazzo/README.md
@@ -1,0 +1,70 @@
+# roas-arazzo
+
+Rust implementation of the [OpenAPI Arazzo Specification](https://spec.openapis.org/arazzo/v1.0.1.html): parse and validate Arazzo workflow descriptions.
+
+[![crates.io](https://img.shields.io/crates/v/roas-arazzo.svg)](https://crates.io/crates/roas-arazzo)
+
+An *Arazzo description* declares deterministic sequences of API calls — *workflows* of *steps*, each invoking an OpenAPI operation or another workflow — together with their inputs, success/failure criteria, and outputs. It complements an OpenAPI description by capturing *how* to use an API, not just *what* it exposes.
+
+This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed parser / validator / merger for OpenAPI 2.0–3.2) and [`roas-overlay`](https://crates.io/crates/roas-overlay). It provides the typed document model plus a `Validate` framework that collects every diagnostic in one pass.
+
+## Versions
+
+| Arazzo version | Feature flag     | Status         |
+|----------------|------------------|----------------|
+| 1.0            | `v1_0` (default) | ✅ implemented  |
+| 1.1            | `v1_1`           | 🔜 planned      |
+
+Authoritative JSON Schema for v1.0: <https://spec.openapis.org/arazzo/1.0/schema/2025-10-15>.
+
+## Quick start
+
+```rust
+use enumset::EnumSet;
+use roas_arazzo::v1_0::Description;
+use roas_arazzo::validation::Validate;
+
+let doc: Description = serde_json::from_str(r#"{
+    "arazzo": "1.0.1",
+    "info": { "title": "Example", "version": "1.0.0" },
+    "sourceDescriptions": [
+        { "name": "petStore", "url": "https://api.example.com/openapi.json", "type": "openapi" }
+    ],
+    "workflows": [
+        {
+            "workflowId": "getPet",
+            "steps": [
+                {
+                    "stepId": "findPet",
+                    "operationId": "getPetById",
+                    "parameters": [ { "name": "petId", "in": "path", "value": "$inputs.petId" } ],
+                    "successCriteria": [ { "condition": "$statusCode == 200" } ]
+                }
+            ]
+        }
+    ]
+}"#).unwrap();
+
+doc.validate(EnumSet::empty()).expect("description is well-formed");
+assert_eq!(doc.workflows[0].workflow_id, "getPet");
+```
+
+YAML descriptions work the same way — parse with `serde_yaml_ng` (or any other YAML crate) into `Description`.
+
+## Validation
+
+`Validate::validate` returns every diagnostic it finds rather than failing on the first one. Diagnostics carry a JSONPath-flavor `path` (e.g. `#.workflows[0].steps[1].stepId`). Checks include:
+
+- required / non-empty fields, and the source-name (`^[A-Za-z0-9_\-]+$`) and component/output-key (`^[a-zA-Z0-9\.\-_]+$`) patterns;
+- uniqueness of source names, workflow ids, and step ids;
+- a step setting exactly one of `operationId` / `operationPath` / `workflowId`, with `in` required on operation-step parameters;
+- criterion `type` → `context` dependency and expression-type `version` constants;
+- `goto` actions requiring exactly one of `workflowId` / `stepId`.
+
+`ValidationOptions` (EnumSet): `IgnoreEmptyInfoTitle`, `IgnoreEmptyInfoVersion`. Behind the `clap` feature, the enum implements `clap::ValueEnum` so downstream CLIs can surface it directly.
+
+Runtime-expression grammar, `sourceDescriptions` / `$ref` resolution, and deep JSON Schema semantics for `inputs` are out of scope for this release.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.

--- a/crates/roas-arazzo/src/common/extensions.rs
+++ b/crates/roas-arazzo/src/common/extensions.rs
@@ -1,0 +1,173 @@
+//! Serde helpers for `x-*` extension fields, matching the Arazzo
+//! specification's
+//! [Specification Extensions](https://spec.openapis.org/arazzo/v1.0.1.html#specification-extensions).
+//!
+//! Mirrors the analogous helper in the sibling `roas` / `roas-overlay`
+//! crates; kept local so this crate is dependency-free against them.
+//!
+//! Only entries whose key starts with `x-` are deserialised / serialised.
+//! Any non-`x-` key encountered during deserialization is silently
+//! dropped (serde's `#[serde(flatten)]` ensures the typed fields claim
+//! their keys first, so this only sees genuinely unknown ones).
+//!
+//! ### Usage
+//!
+//! ```rust
+//! use std::collections::BTreeMap;
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+//! pub struct WithExtensions {
+//!     pub foo: String,
+//!     #[serde(flatten)]
+//!     #[serde(with = "roas_arazzo::common::extensions")]
+//!     #[serde(skip_serializing_if = "Option::is_none")]
+//!     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+//! }
+//! ```
+
+use serde::de::{Error, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
+
+pub fn deserialize<'de, D>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<String, serde_json::Value>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ExtensionsVisitor;
+    impl<'de> Visitor<'de> for ExtensionsVisitor {
+        type Value = BTreeMap<String, serde_json::Value>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("extensions: Option<BTreeMap<String, serde_json::Value>>")
+        }
+
+        fn visit_map<V>(self, mut map: V) -> Result<BTreeMap<String, serde_json::Value>, V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            let mut ext: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                if key.starts_with("x-") {
+                    if ext.contains_key(key.as_str()) {
+                        return Err(Error::custom(format_args!("duplicate field `{key}`")));
+                    }
+                    let value: serde_json::Value = map.next_value()?;
+                    ext.insert(key, value);
+                }
+            }
+            Ok(ext)
+        }
+    }
+
+    let map = deserializer.deserialize_map(ExtensionsVisitor)?;
+    Ok(if map.is_empty() { None } else { Some(map) })
+}
+
+pub fn serialize<S>(
+    ext: &Option<BTreeMap<String, serde_json::Value>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(ext) = ext {
+        let mut map = serializer.serialize_map(Some(ext.len()))?;
+        for (k, v) in ext {
+            if k.starts_with("x-") {
+                map.serialize_entry(k, v)?;
+            }
+        }
+        map.end()
+    } else {
+        None::<BTreeMap<String, serde_json::Value>>.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+    struct TestExtensions {
+        pub foo: String,
+        #[serde(flatten)]
+        #[serde(with = "super")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+    }
+
+    #[test]
+    fn deserialize_filters_non_x_dash_keys() {
+        let parsed: TestExtensions = serde_json::from_value(serde_json::json!({
+            "foo": "bar",
+            "skipped": 1,
+            "x-added": 2,
+        }))
+        .unwrap();
+        let mut expected_ext = BTreeMap::new();
+        expected_ext.insert("x-added".to_owned(), serde_json::json!(2));
+        assert_eq!(
+            parsed,
+            TestExtensions {
+                foo: "bar".into(),
+                extensions: Some(expected_ext),
+            },
+        );
+    }
+
+    #[test]
+    fn deserialize_no_extensions_returns_none() {
+        let parsed: TestExtensions =
+            serde_json::from_value(serde_json::json!({ "foo": "bar" })).unwrap();
+        assert_eq!(
+            parsed,
+            TestExtensions {
+                foo: "bar".into(),
+                extensions: None,
+            },
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_duplicate_extension_keys() {
+        let err =
+            serde_json::from_str::<TestExtensions>(r#"{"foo":"bar","x-a":1,"x-a":2}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate field `x-a`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn serialize_only_x_dash_keys_are_emitted() {
+        let mut ext = BTreeMap::new();
+        ext.insert("x-added".to_owned(), serde_json::json!(1));
+        ext.insert("skipped".to_owned(), serde_json::json!(2));
+        let v = serde_json::to_value(TestExtensions {
+            foo: "bar".into(),
+            extensions: Some(ext),
+        })
+        .unwrap();
+        assert_eq!(v, serde_json::json!({ "foo": "bar", "x-added": 1 }));
+    }
+
+    #[test]
+    fn serialize_none_emits_null() {
+        let none: Option<BTreeMap<String, serde_json::Value>> = None;
+        let out = super::serialize(&none, serde_json::value::Serializer).unwrap();
+        assert_eq!(out, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn visitor_expecting_invoked_on_type_mismatch() {
+        let mut de = serde_json::Deserializer::from_str(r#""not-a-map""#);
+        let err = super::deserialize(&mut de).unwrap_err();
+        assert!(err.to_string().contains("map") || err.to_string().contains("expected"));
+    }
+}

--- a/crates/roas-arazzo/src/common/mod.rs
+++ b/crates/roas-arazzo/src/common/mod.rs
@@ -1,0 +1,3 @@
+//! Version-agnostic helpers shared across Arazzo versions.
+
+pub mod extensions;

--- a/crates/roas-arazzo/src/lib.rs
+++ b/crates/roas-arazzo/src/lib.rs
@@ -1,0 +1,61 @@
+//! OpenAPI Arazzo Specification — parser and validator.
+//!
+//! Implements the [Arazzo Specification](https://spec.openapis.org/arazzo/v1.0.1.html):
+//! a document format that describes sequences of API calls (*workflows*)
+//! and their dependencies, independent of the underlying OpenAPI
+//! descriptions they orchestrate.
+//!
+//! ## Modules
+//!
+//! - [`common`] — version-agnostic helpers: the `x-` extensions serde
+//!   helper.
+//! - [`validation`] — [`Validate`](validation::Validate) trait,
+//!   [`ValidationOptions`](validation::ValidationOptions) flag set,
+//!   `Context` / `ValidationError` types.
+//! - [`v1_0`] — Arazzo v1.0 document model + `Validate` impls.
+//!
+//! ## Parsing and validating
+//!
+//! ```rust
+//! use enumset::EnumSet;
+//! use roas_arazzo::v1_0::Description;
+//! use roas_arazzo::validation::Validate;
+//!
+//! // Parse an Arazzo description (JSON or YAML).
+//! let doc: Description = serde_json::from_str(r#"{
+//!     "arazzo": "1.0.1",
+//!     "info": { "title": "Example", "version": "1.0.0" },
+//!     "sourceDescriptions": [
+//!         { "name": "petStore", "url": "https://api.example.com/openapi.json", "type": "openapi" }
+//!     ],
+//!     "workflows": [
+//!         {
+//!             "workflowId": "getPet",
+//!             "steps": [
+//!                 {
+//!                     "stepId": "findPet",
+//!                     "operationId": "getPetById",
+//!                     "successCriteria": [ { "condition": "$statusCode == 200" } ]
+//!                 }
+//!             ]
+//!         }
+//!     ]
+//! }"#).unwrap();
+//!
+//! doc.validate(EnumSet::empty()).expect("description is well-formed");
+//! assert_eq!(doc.workflows[0].workflow_id, "getPet");
+//! ```
+//!
+//! YAML descriptions work the same way — parse with `serde_yaml_ng` (or
+//! any other YAML crate) into [`v1_0::Description`].
+//!
+//! ## Versions
+//!
+//! v1.0.x is implemented behind the default `v1_0` feature. v1.1.x
+//! support is planned for a follow-up release.
+
+pub mod common;
+pub mod validation;
+
+#[cfg(feature = "v1_0")]
+pub mod v1_0;

--- a/crates/roas-arazzo/src/v1_0/components.rs
+++ b/crates/roas-arazzo/src/v1_0/components.rs
@@ -1,0 +1,112 @@
+//! Arazzo v1.0 `Components` object.
+//!
+//! Per [Components Object](https://spec.openapis.org/arazzo/v1.0.1.html#components-object):
+//! reusable inputs, parameters, and success / failure actions
+//! referenced from elsewhere via [`Reusable`](crate::v1_0::Reusable).
+//! All map keys must match `^[a-zA-Z0-9\.\-_]+$`.
+
+use crate::v1_0::failure_action::FailureAction;
+use crate::v1_0::parameter::Parameter;
+use crate::v1_0::success_action::SuccessAction;
+use crate::validation::{Context, ValidateWithContext, validate_map_keys};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Components {
+    /// Reusable JSON Schema 2020-12 schemas, referenced from workflow
+    /// inputs. Kept as opaque JSON.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub inputs: BTreeMap<String, serde_json::Value>,
+
+    /// Reusable parameter objects.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub parameters: BTreeMap<String, Parameter>,
+
+    /// Reusable success action objects.
+    #[serde(
+        rename = "successActions",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub success_actions: BTreeMap<String, SuccessAction>,
+
+    /// Reusable failure action objects.
+    #[serde(
+        rename = "failureActions",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub failure_actions: BTreeMap<String, FailureAction>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Components {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_map_keys(&self.inputs, ctx, &format!("{path}.inputs"));
+        validate_map_keys(&self.parameters, ctx, &format!("{path}.parameters"));
+        validate_map_keys(
+            &self.success_actions,
+            ctx,
+            &format!("{path}.successActions"),
+        );
+        validate_map_keys(
+            &self.failure_actions,
+            ctx,
+            &format!("{path}.failureActions"),
+        );
+
+        for (name, parameter) in &self.parameters {
+            parameter.validate_with_context(ctx, format!("{path}.parameters.{name}"));
+        }
+        for (name, action) in &self.success_actions {
+            action.validate_with_context(ctx, format!("{path}.successActions.{name}"));
+        }
+        for (name, action) in &self.failure_actions {
+            action.validate_with_context(ctx, format!("{path}.failureActions.{name}"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn deserialize_round_trips() {
+        let c: Components = serde_json::from_value(json!({
+            "parameters": {
+                "petId": { "name": "petId", "in": "path", "value": "$inputs.petId" }
+            }
+        }))
+        .unwrap();
+        assert!(c.parameters.contains_key("petId"));
+
+        let v = serde_json::to_value(&c).unwrap();
+        assert!(v["parameters"]["petId"].is_object());
+        assert!(v.get("inputs").is_none());
+    }
+
+    #[test]
+    fn validate_rejects_bad_key_and_recurses() {
+        let mut ctx = Context::new(EnumSet::empty());
+        let mut parameters = BTreeMap::new();
+        parameters.insert("bad key".to_owned(), Parameter::default());
+        let c = Components {
+            parameters,
+            ..Default::default()
+        };
+        c.validate_with_context(&mut ctx, "#.components".into());
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        assert!(msgs.iter().any(|e| e.contains("key must match")));
+        // recursion reaches the empty parameter name
+        assert!(msgs.iter().any(|e| e.contains("name: must not be empty")));
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/criterion.rs
+++ b/crates/roas-arazzo/src/v1_0/criterion.rs
@@ -1,0 +1,187 @@
+//! Arazzo v1.0 `Criterion` object.
+//!
+//! Per [Criterion Object](https://spec.openapis.org/arazzo/v1.0.1.html#criterion-object):
+//! an assertion used in step `successCriteria` and action `criteria`.
+//!
+//! The schema folds the *Criterion Expression Type Object* into the
+//! criterion via `anyOf`, so `type` and `version` are flat optional
+//! fields here rather than a nested object.
+
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The type of condition expressed by a [`Criterion`].
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CriterionType {
+    #[default]
+    Simple,
+    Regex,
+    Jsonpath,
+    Xpath,
+}
+
+/// Required `version` for `type: jsonpath` (per the schema `const`).
+const JSONPATH_VERSION: &str = "draft-goessner-dispatch-jsonpath-00";
+/// Allowed `version` values for `type: xpath`.
+const XPATH_VERSIONS: [&str; 3] = ["xpath-10", "xpath-20", "xpath-30"];
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Criterion {
+    /// A runtime expression setting the context the condition applies
+    /// to. Required when `type` is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+
+    /// **Required** The condition to apply.
+    pub condition: String,
+
+    /// The type of condition (defaults to `simple` when omitted).
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub type_: Option<CriterionType>,
+
+    /// A shorthand string for the expression-type version. Only valid
+    /// with `type: jsonpath` or `type: xpath`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Criterion {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.condition, ctx, format!("{path}.condition"));
+
+        // `dependentRequired`: a `type` requires a `context`.
+        if self.type_.is_some() && self.context.is_none() {
+            ctx.error(format!("{path}.context"), "is required when `type` is set");
+        }
+
+        // `version` belongs to the expression-type form (jsonpath/xpath)
+        // and must match the value allowed for that type.
+        if let Some(version) = &self.version {
+            match self.type_ {
+                Some(CriterionType::Jsonpath) if version != JSONPATH_VERSION => {
+                    ctx.error(
+                        format!("{path}.version"),
+                        format!("must be `{JSONPATH_VERSION}` for type `jsonpath`"),
+                    );
+                }
+                Some(CriterionType::Xpath) if !XPATH_VERSIONS.contains(&version.as_str()) => {
+                    ctx.error(
+                        format!("{path}.version"),
+                        "must be one of `xpath-10`, `xpath-20`, `xpath-30` for type `xpath`",
+                    );
+                }
+                Some(CriterionType::Jsonpath | CriterionType::Xpath) => {}
+                _ => ctx.error(
+                    format!("{path}.version"),
+                    "is only valid with type `jsonpath` or `xpath`",
+                ),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(c: &Criterion) -> Vec<String> {
+        let mut ctx = Context::new(EnumSet::empty());
+        c.validate_with_context(&mut ctx, "#.c".into());
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn simple_condition_round_trips() {
+        let c: Criterion =
+            serde_json::from_value(json!({ "condition": "$statusCode == 200" })).unwrap();
+        assert_eq!(c.condition, "$statusCode == 200");
+        assert!(c.type_.is_none());
+        assert!(validate(&c).is_empty());
+    }
+
+    #[test]
+    fn flat_expression_type_round_trips() {
+        let c: Criterion = serde_json::from_value(json!({
+            "context": "$response.body",
+            "condition": "$[?count(@.pets) > 0]",
+            "type": "jsonpath",
+            "version": "draft-goessner-dispatch-jsonpath-00",
+        }))
+        .unwrap();
+        assert_eq!(c.type_, Some(CriterionType::Jsonpath));
+        assert_eq!(c.version.as_deref(), Some(JSONPATH_VERSION));
+        assert!(validate(&c).is_empty());
+    }
+
+    #[test]
+    fn empty_condition_is_rejected() {
+        let c = Criterion::default();
+        assert!(validate(&c).iter().any(|e| e.contains("condition")));
+    }
+
+    #[test]
+    fn type_without_context_is_rejected() {
+        let c = Criterion {
+            condition: "x".into(),
+            type_: Some(CriterionType::Regex),
+            ..Default::default()
+        };
+        assert!(
+            validate(&c)
+                .iter()
+                .any(|e| e == "#.c.context: is required when `type` is set")
+        );
+    }
+
+    #[test]
+    fn jsonpath_with_wrong_version_is_rejected() {
+        let c = Criterion {
+            context: Some("$x".into()),
+            condition: "x".into(),
+            type_: Some(CriterionType::Jsonpath),
+            version: Some("nope".into()),
+            ..Default::default()
+        };
+        assert!(validate(&c).iter().any(|e| e.contains("jsonpath")));
+    }
+
+    #[test]
+    fn xpath_version_must_be_in_set() {
+        let bad = Criterion {
+            context: Some("$x".into()),
+            condition: "x".into(),
+            type_: Some(CriterionType::Xpath),
+            version: Some("xpath-99".into()),
+            ..Default::default()
+        };
+        assert!(validate(&bad).iter().any(|e| e.contains("xpath")));
+
+        let ok = Criterion {
+            version: Some("xpath-30".into()),
+            ..bad
+        };
+        assert!(validate(&ok).is_empty());
+    }
+
+    #[test]
+    fn version_without_expression_type_is_rejected() {
+        let c = Criterion {
+            context: Some("$x".into()),
+            condition: "x".into(),
+            type_: Some(CriterionType::Simple),
+            version: Some("xpath-10".into()),
+            ..Default::default()
+        };
+        assert!(validate(&c).iter().any(|e| e.contains("only valid with")));
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/description.rs
+++ b/crates/roas-arazzo/src/v1_0/description.rs
@@ -1,0 +1,209 @@
+//! Arazzo v1.0 root document (the *Arazzo Description*).
+
+use crate::v1_0::components::Components;
+use crate::v1_0::info::Info;
+use crate::v1_0::source_description::SourceDescription;
+use crate::v1_0::version::Version;
+use crate::v1_0::workflow::Workflow;
+use crate::validation::{Context, Error, Validate, ValidateWithContext, ValidationOptions};
+use enumset::EnumSet;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Root Arazzo v1.0 document.
+///
+/// See [Arazzo Description](https://spec.openapis.org/arazzo/v1.0.1.html#arazzo-description).
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Description {
+    /// **Required** `1.0.x` per the schema's pattern `^1\.0\.\d+(-.+)?$`.
+    pub arazzo: Version,
+
+    /// **Required** Metadata about the Arazzo description.
+    pub info: Info,
+
+    /// **Required** Non-empty list of referenced source descriptions
+    /// (OpenAPI or Arazzo documents).
+    #[serde(rename = "sourceDescriptions")]
+    pub source_descriptions: Vec<SourceDescription>,
+
+    /// **Required** Non-empty list of workflows.
+    pub workflows: Vec<Workflow>,
+
+    /// Reusable components referenced throughout the description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Components>,
+
+    /// `x-`-prefixed Specification Extensions on the root.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Description {
+    fn validate_inner(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        let mut ctx = Context::new(options);
+        let path = "#".to_owned();
+
+        self.info
+            .validate_with_context(&mut ctx, format!("{path}.info"));
+
+        if self.source_descriptions.is_empty() {
+            ctx.error(
+                format!("{path}.sourceDescriptions"),
+                "must contain at least one entry",
+            );
+        }
+        let mut seen_names = BTreeSet::new();
+        for (i, source) in self.source_descriptions.iter().enumerate() {
+            let source_path = format!("{path}.sourceDescriptions[{i}]");
+            source.validate_with_context(&mut ctx, source_path.clone());
+            if !source.name.is_empty() && !seen_names.insert(source.name.as_str()) {
+                ctx.error(
+                    format!("{source_path}.name"),
+                    format!("duplicate source name `{}`", source.name),
+                );
+            }
+        }
+
+        if self.workflows.is_empty() {
+            ctx.error(
+                format!("{path}.workflows"),
+                "must contain at least one entry",
+            );
+        }
+        let mut seen_workflow_ids = BTreeSet::new();
+        for (i, workflow) in self.workflows.iter().enumerate() {
+            let workflow_path = format!("{path}.workflows[{i}]");
+            workflow.validate_with_context(&mut ctx, workflow_path.clone());
+            if !workflow.workflow_id.is_empty()
+                && !seen_workflow_ids.insert(workflow.workflow_id.as_str())
+            {
+                ctx.error(
+                    format!("{workflow_path}.workflowId"),
+                    format!("duplicate workflowId `{}`", workflow.workflow_id),
+                );
+            }
+        }
+
+        if let Some(components) = &self.components {
+            components.validate_with_context(&mut ctx, format!("{path}.components"));
+        }
+
+        ctx.into_result()
+    }
+}
+
+impl Validate for Description {
+    fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        self.validate_inner(options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn minimal() -> serde_json::Value {
+        json!({
+            "arazzo": "1.0.1",
+            "info": { "title": "T", "version": "1.0.0" },
+            "sourceDescriptions": [ { "name": "src", "url": "openapi.yaml" } ],
+            "workflows": [
+                { "workflowId": "wf", "steps": [ { "stepId": "s", "operationId": "op",
+                    "parameters": [ { "name": "p", "in": "query", "value": 1 } ] } ] }
+            ]
+        })
+    }
+
+    #[test]
+    fn deserialize_minimal_round_trips() {
+        let doc: Description = serde_json::from_value(minimal()).unwrap();
+        assert_eq!(doc.arazzo, Version::V1_0_1());
+        assert_eq!(doc.source_descriptions.len(), 1);
+        assert_eq!(doc.workflows.len(), 1);
+        assert!(doc.components.is_none());
+        doc.validate(EnumSet::empty()).expect("valid");
+    }
+
+    #[test]
+    fn serialize_preserves_field_names() {
+        let doc: Description = serde_json::from_value(minimal()).unwrap();
+        let v = serde_json::to_value(&doc).unwrap();
+        assert_eq!(v["arazzo"], json!("1.0.1"));
+        assert!(v["sourceDescriptions"].is_array());
+        assert!(v["workflows"].is_array());
+        assert!(v.get("components").is_none());
+    }
+
+    #[test]
+    fn deserialize_rejects_wrong_version() {
+        let mut bad = minimal();
+        bad["arazzo"] = json!("2.0.0");
+        assert!(serde_json::from_value::<Description>(bad).is_err());
+    }
+
+    #[test]
+    fn empty_collections_fail_validation() {
+        let doc = Description {
+            arazzo: Version::V1_0_1(),
+            info: Info {
+                title: "T".into(),
+                version: "1".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = doc.validate(EnumSet::empty()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.sourceDescriptions: must contain at least one entry")
+        );
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e == "#.workflows: must contain at least one entry")
+        );
+    }
+
+    #[test]
+    fn duplicate_source_names_and_workflow_ids_fail() {
+        let doc: Description = serde_json::from_value(json!({
+            "arazzo": "1.0.1",
+            "info": { "title": "T", "version": "1" },
+            "sourceDescriptions": [
+                { "name": "dup", "url": "a" },
+                { "name": "dup", "url": "b" }
+            ],
+            "workflows": [
+                { "workflowId": "w", "steps": [ { "stepId": "s", "workflowId": "x" } ] },
+                { "workflowId": "w", "steps": [ { "stepId": "s", "workflowId": "y" } ] }
+            ]
+        }))
+        .unwrap();
+        let err = doc.validate(EnumSet::empty()).unwrap_err();
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("duplicate source name `dup`"))
+        );
+        assert!(
+            err.errors
+                .iter()
+                .any(|e| e.contains("duplicate workflowId `w`"))
+        );
+    }
+
+    #[test]
+    fn root_extensions_are_captured() {
+        let mut value = minimal();
+        value["x-internal"] = json!(true);
+        let doc: Description = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            doc.extensions.as_ref().unwrap().get("x-internal"),
+            Some(&json!(true))
+        );
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/failure_action.rs
+++ b/crates/roas-arazzo/src/v1_0/failure_action.rs
@@ -1,0 +1,147 @@
+//! Arazzo v1.0 `Failure Action` object.
+//!
+//! Per [Failure Action Object](https://spec.openapis.org/arazzo/v1.0.1.html#failure-action-object):
+//! what to do when a step fails — end, `goto`, or `retry`.
+
+use crate::v1_0::criterion::Criterion;
+use crate::v1_0::success_action::validate_goto_target;
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The action taken on step failure.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum FailureActionType {
+    #[default]
+    End,
+    Goto,
+    Retry,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct FailureAction {
+    /// **Required** The name of the failure action.
+    pub name: String,
+
+    /// **Required** The type of action to take.
+    #[serde(rename = "type")]
+    pub type_: FailureActionType,
+
+    /// The workflow to transfer to (required for `goto`, mutually
+    /// exclusive with `stepId`).
+    #[serde(rename = "workflowId", skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+
+    /// The step to transfer to (required for `goto`, mutually exclusive
+    /// with `workflowId`).
+    #[serde(rename = "stepId", skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
+
+    /// Non-negative seconds to wait before retrying.
+    #[serde(rename = "retryAfter", skip_serializing_if = "Option::is_none")]
+    pub retry_after: Option<f64>,
+
+    /// Non-negative number of retry attempts.
+    #[serde(rename = "retryLimit", skip_serializing_if = "Option::is_none")]
+    pub retry_limit: Option<u64>,
+
+    /// Assertions determining whether this action runs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub criteria: Vec<Criterion>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for FailureAction {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+        validate_goto_target(
+            self.type_ == FailureActionType::Goto,
+            self.workflow_id.is_some(),
+            self.step_id.is_some(),
+            ctx,
+            &path,
+        );
+        if self.retry_after.is_some_and(|n| n < 0.0) {
+            ctx.error(format!("{path}.retryAfter"), "must not be negative");
+        }
+        for (i, criterion) in self.criteria.iter().enumerate() {
+            criterion.validate_with_context(ctx, format!("{path}.criteria[{i}]"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(a: &FailureAction) -> Vec<String> {
+        let mut ctx = Context::new(EnumSet::empty());
+        a.validate_with_context(&mut ctx, "#.a".into());
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn retry_action_round_trips() {
+        let a: FailureAction = serde_json::from_value(json!({
+            "name": "retryStep",
+            "type": "retry",
+            "retryAfter": 1.5,
+            "retryLimit": 3,
+        }))
+        .unwrap();
+        assert_eq!(a.type_, FailureActionType::Retry);
+        assert_eq!(a.retry_after, Some(1.5));
+        assert_eq!(a.retry_limit, Some(3));
+        assert!(validate(&a).is_empty());
+    }
+
+    #[test]
+    fn goto_requires_exactly_one_target() {
+        let neither = FailureAction {
+            name: "g".into(),
+            type_: FailureActionType::Goto,
+            ..Default::default()
+        };
+        assert!(validate(&neither).iter().any(|e| e.contains("goto")));
+
+        let ok = FailureAction {
+            step_id: Some("s".into()),
+            ..neither
+        };
+        assert!(validate(&ok).is_empty());
+    }
+
+    #[test]
+    fn negative_retry_limit_is_rejected_on_parse() {
+        // `retryLimit` is a u64 at the type level, so a negative value
+        // fails to deserialize outright.
+        let err = serde_json::from_value::<FailureAction>(
+            json!({ "name": "n", "type": "retry", "retryLimit": -1 }),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("u64") || err.to_string().contains("invalid"));
+    }
+
+    #[test]
+    fn negative_retry_after_fails_validation() {
+        let a = FailureAction {
+            name: "n".into(),
+            type_: FailureActionType::Retry,
+            retry_after: Some(-1.0),
+            ..Default::default()
+        };
+        assert!(
+            validate(&a)
+                .iter()
+                .any(|e| e == "#.a.retryAfter: must not be negative")
+        );
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/info.rs
+++ b/crates/roas-arazzo/src/v1_0/info.rs
@@ -1,0 +1,125 @@
+//! Arazzo v1.0 `Info` object.
+//!
+//! Per [Info Object](https://spec.openapis.org/arazzo/v1.0.1.html#info-object):
+//! metadata about the Arazzo description, with required `title` and
+//! `version`, extensible via `x-` fields.
+
+use crate::validation::{
+    Context, ValidateWithContext, ValidationOptions, validate_required_string,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Info {
+    /// **Required** A human-readable title of the Arazzo description.
+    pub title: String,
+
+    /// A short summary of the Arazzo description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// A description of the purpose of the workflows defined. CommonMark
+    /// syntax MAY be used for rich text representation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// **Required** A version identifier for the Arazzo document
+    /// (distinct from the Arazzo Specification version).
+    pub version: String,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Info {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle) {
+            validate_required_string(&self.title, ctx, format!("{path}.title"));
+        }
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion) {
+            validate_required_string(&self.version, ctx, format!("{path}.version"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn ctx() -> Context {
+        Context::new(EnumSet::empty())
+    }
+
+    #[test]
+    fn deserialize_minimal_info_round_trips() {
+        let info: Info = serde_json::from_value(json!({ "title": "T", "version": "1.0" })).unwrap();
+        assert_eq!(info.title, "T");
+        assert_eq!(info.version, "1.0");
+        assert!(info.summary.is_none());
+        assert!(info.description.is_none());
+        assert!(info.extensions.is_none());
+
+        let v = serde_json::to_value(&info).unwrap();
+        assert_eq!(v, json!({ "title": "T", "version": "1.0" }));
+    }
+
+    #[test]
+    fn deserialize_full_info_keeps_optionals() {
+        let info: Info = serde_json::from_value(json!({
+            "title": "T",
+            "summary": "S",
+            "description": "D",
+            "version": "1.0",
+        }))
+        .unwrap();
+        assert_eq!(info.summary.as_deref(), Some("S"));
+        assert_eq!(info.description.as_deref(), Some("D"));
+    }
+
+    #[test]
+    fn deserialize_keeps_x_dash_extensions_and_drops_others() {
+        let info: Info = serde_json::from_value(json!({
+            "title": "T",
+            "version": "1.0",
+            "x-team": "platform",
+            "ignored": 42,
+        }))
+        .unwrap();
+        let ext = info.extensions.as_ref().unwrap();
+        assert_eq!(ext.get("x-team").unwrap(), &json!("platform"));
+        assert!(!ext.contains_key("ignored"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_title_and_version() {
+        let mut c = ctx();
+        let info = Info::default();
+        info.validate_with_context(&mut c, "#.info".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.info.title: must not be empty")
+        );
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.info.version: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_ignore_options_suppress_diagnostics() {
+        let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle)
+            | ValidationOptions::IgnoreEmptyInfoVersion;
+        let mut c = Context::new(opts);
+        let info = Info::default();
+        info.validate_with_context(&mut c, "#.info".into());
+        assert!(c.errors.is_empty());
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/mod.rs
+++ b/crates/roas-arazzo/src/v1_0/mod.rs
@@ -1,0 +1,33 @@
+//! Arazzo v1.0 — see
+//! <https://spec.openapis.org/arazzo/v1.0.1.html>.
+//!
+//! Authoritative JSON Schema:
+//! <https://spec.openapis.org/arazzo/1.0/schema/2025-10-15>.
+
+pub mod components;
+pub mod criterion;
+pub mod description;
+pub mod failure_action;
+pub mod info;
+pub mod parameter;
+pub mod request_body;
+pub mod reusable;
+pub mod source_description;
+pub mod step;
+pub mod success_action;
+pub mod version;
+pub mod workflow;
+
+pub use components::Components;
+pub use criterion::{Criterion, CriterionType};
+pub use description::Description;
+pub use failure_action::{FailureAction, FailureActionType};
+pub use info::Info;
+pub use parameter::{Parameter, ParameterLocation};
+pub use request_body::{PayloadReplacement, RequestBody};
+pub use reusable::{Reusable, ReusableOr};
+pub use source_description::{SourceDescription, SourceType};
+pub use step::Step;
+pub use success_action::{SuccessAction, SuccessActionType};
+pub use version::Version;
+pub use workflow::Workflow;

--- a/crates/roas-arazzo/src/v1_0/parameter.rs
+++ b/crates/roas-arazzo/src/v1_0/parameter.rs
@@ -1,0 +1,100 @@
+//! Arazzo v1.0 `Parameter` object.
+//!
+//! Per [Parameter Object](https://spec.openapis.org/arazzo/v1.0.1.html#parameter-object):
+//! a single named value passed to an operation or workflow. `in` is
+//! required when the enclosing step targets an `operationId` /
+//! `operationPath` (enforced in [`crate::v1_0::step`]).
+
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The named location a [`Parameter`] applies to.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ParameterLocation {
+    #[default]
+    Path,
+    Query,
+    Header,
+    Cookie,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Parameter {
+    /// **Required** The name of the parameter.
+    pub name: String,
+
+    /// The named location of the parameter. Required when the step
+    /// targets an operation.
+    #[serde(rename = "in", skip_serializing_if = "Option::is_none")]
+    pub in_: Option<ParameterLocation>,
+
+    /// **Required** The value to pass (any JSON type, typically a
+    /// runtime expression string).
+    pub value: serde_json::Value,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Parameter {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn deserialize_round_trips() {
+        let p: Parameter = serde_json::from_value(json!({
+            "name": "petId",
+            "in": "path",
+            "value": "$inputs.petId",
+        }))
+        .unwrap();
+        assert_eq!(p.name, "petId");
+        assert_eq!(p.in_, Some(ParameterLocation::Path));
+        assert_eq!(p.value, json!("$inputs.petId"));
+
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["in"], json!("path"));
+    }
+
+    #[test]
+    fn value_accepts_any_json_type() {
+        let p: Parameter =
+            serde_json::from_value(json!({ "name": "flags", "value": [1, 2, 3] })).unwrap();
+        assert_eq!(p.value, json!([1, 2, 3]));
+        assert!(p.in_.is_none());
+    }
+
+    #[test]
+    fn validate_rejects_empty_name() {
+        let mut c = Context::new(EnumSet::empty());
+        Parameter::default().validate_with_context(&mut c, "#.p".into());
+        assert!(c.errors.iter().any(|e| e == "#.p.name: must not be empty"));
+    }
+
+    #[test]
+    fn all_locations_round_trip() {
+        for (s, loc) in [
+            ("path", ParameterLocation::Path),
+            ("query", ParameterLocation::Query),
+            ("header", ParameterLocation::Header),
+            ("cookie", ParameterLocation::Cookie),
+        ] {
+            let p: Parameter =
+                serde_json::from_value(json!({ "name": "n", "in": s, "value": 1 })).unwrap();
+            assert_eq!(p.in_, Some(loc));
+        }
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/request_body.rs
+++ b/crates/roas-arazzo/src/v1_0/request_body.rs
@@ -1,0 +1,104 @@
+//! Arazzo v1.0 `Request Body` and `Payload Replacement` objects.
+//!
+//! Per [Request Body Object](https://spec.openapis.org/arazzo/v1.0.1.html#request-body-object)
+//! and [Payload Replacement Object](https://spec.openapis.org/arazzo/v1.0.1.html#payload-replacement-object).
+
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct RequestBody {
+    /// The `Content-Type` for the request content.
+    #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+
+    /// The request body payload (any JSON type, typically containing
+    /// runtime expressions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+
+    /// Locations and values to set within the payload.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub replacements: Vec<PayloadReplacement>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for RequestBody {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        for (i, replacement) in self.replacements.iter().enumerate() {
+            replacement.validate_with_context(ctx, format!("{path}.replacements[{i}]"));
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct PayloadReplacement {
+    /// **Required** A JSON Pointer or XPath expression resolved against
+    /// the request body.
+    pub target: String,
+
+    /// **Required** The value set within the target location.
+    pub value: String,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for PayloadReplacement {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.target, ctx, format!("{path}.target"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn deserialize_round_trips() {
+        let rb: RequestBody = serde_json::from_value(json!({
+            "contentType": "application/json",
+            "payload": { "id": "$inputs.id" },
+            "replacements": [ { "target": "/role", "value": "admin" } ],
+        }))
+        .unwrap();
+        assert_eq!(rb.content_type.as_deref(), Some("application/json"));
+        assert_eq!(rb.replacements.len(), 1);
+
+        let v = serde_json::to_value(&rb).unwrap();
+        assert_eq!(v["contentType"], json!("application/json"));
+    }
+
+    #[test]
+    fn empty_request_body_omits_optionals() {
+        let rb = RequestBody::default();
+        let v = serde_json::to_value(&rb).unwrap();
+        assert_eq!(v, json!({}));
+    }
+
+    #[test]
+    fn validate_recurses_into_replacements() {
+        let mut c = Context::new(EnumSet::empty());
+        let rb = RequestBody {
+            replacements: vec![PayloadReplacement::default()],
+            ..Default::default()
+        };
+        rb.validate_with_context(&mut c, "#.requestBody".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.requestBody.replacements[0].target: must not be empty")
+        );
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/reusable.rs
+++ b/crates/roas-arazzo/src/v1_0/reusable.rs
@@ -1,0 +1,116 @@
+//! Arazzo v1.0 `Reusable` object and the `ReusableOr<T>` wrapper.
+//!
+//! Per [Reusable Object](https://spec.openapis.org/arazzo/v1.0.1.html#reusable-object):
+//! a runtime-expression reference to an object held in
+//! [`Components`](crate::v1_0::Components), optionally overriding its
+//! `value`. Unlike every other object it does **not** allow `x-`
+//! extensions.
+//!
+//! Lists of parameters / success actions / failure actions accept
+//! either a concrete object or a `Reusable`; [`ReusableOr`] models that
+//! `oneOf`, analogous to `roas`'s `RefOr<T>`.
+
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Reusable {
+    /// **Required** A runtime expression referencing the desired object.
+    pub reference: String,
+
+    /// Sets a value for the referenced object (e.g. a parameter value).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+}
+
+impl ValidateWithContext for Reusable {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.reference, ctx, format!("{path}.reference"));
+    }
+}
+
+/// Either a concrete object `T` or a [`Reusable`] reference to one.
+///
+/// `Reusable` is tried first during deserialization; its required
+/// `reference` key distinguishes it from the concrete object, which has
+/// its own distinct required fields.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum ReusableOr<T> {
+    Reusable(Reusable),
+    Item(T),
+}
+
+impl<T: ValidateWithContext> ValidateWithContext for ReusableOr<T> {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        match self {
+            ReusableOr::Reusable(r) => r.validate_with_context(ctx, path),
+            ReusableOr::Item(t) => t.validate_with_context(ctx, path),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v1_0::parameter::Parameter;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn reusable_round_trips() {
+        let r: Reusable =
+            serde_json::from_value(json!({ "reference": "$components.parameters.foo" })).unwrap();
+        assert_eq!(r.reference, "$components.parameters.foo");
+        assert!(r.value.is_none());
+    }
+
+    #[test]
+    fn reusable_or_picks_reusable_for_reference_key() {
+        let v: ReusableOr<Parameter> = serde_json::from_value(
+            json!({ "reference": "$components.parameters.foo", "value": 1 }),
+        )
+        .unwrap();
+        match v {
+            ReusableOr::Reusable(r) => {
+                assert_eq!(r.reference, "$components.parameters.foo");
+                assert_eq!(r.value, Some(json!(1)));
+            }
+            ReusableOr::Item(_) => panic!("expected reusable variant"),
+        }
+    }
+
+    #[test]
+    fn reusable_or_picks_item_for_concrete_object() {
+        let v: ReusableOr<Parameter> =
+            serde_json::from_value(json!({ "name": "petId", "value": "$inputs.petId" })).unwrap();
+        match v {
+            ReusableOr::Item(p) => assert_eq!(p.name, "petId"),
+            ReusableOr::Reusable(_) => panic!("expected item variant"),
+        }
+    }
+
+    #[test]
+    fn validate_reusable_rejects_empty_reference() {
+        let mut c = Context::new(EnumSet::empty());
+        let v: ReusableOr<Parameter> = ReusableOr::Reusable(Reusable::default());
+        v.validate_with_context(&mut c, "#.parameters[0]".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.parameters[0].reference: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_item_delegates_to_inner() {
+        let mut c = Context::new(EnumSet::empty());
+        let v: ReusableOr<Parameter> = ReusableOr::Item(Parameter::default());
+        v.validate_with_context(&mut c, "#.parameters[0]".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.parameters[0].name: must not be empty")
+        );
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/source_description.rs
+++ b/crates/roas-arazzo/src/v1_0/source_description.rs
@@ -1,0 +1,122 @@
+//! Arazzo v1.0 `Source Description` object.
+//!
+//! Per [Source Description Object](https://spec.openapis.org/arazzo/v1.0.1.html#source-description-object):
+//! a named reference to an OpenAPI or Arazzo document used by one or
+//! more workflows.
+
+use crate::validation::{Context, ValidateWithContext, is_valid_name, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The kind of document a [`SourceDescription`] points at.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceType {
+    /// An Arazzo description.
+    Arazzo,
+    /// An OpenAPI description.
+    #[default]
+    Openapi,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct SourceDescription {
+    /// **Required** A unique name for the source description
+    /// (pattern `^[A-Za-z0-9_\-]+$`).
+    pub name: String,
+
+    /// **Required** A URL to the source description (URI reference).
+    pub url: String,
+
+    /// The type of source description.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub type_: Option<SourceType>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for SourceDescription {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+        if !self.name.is_empty() && !is_valid_name(&self.name) {
+            ctx.error(format!("{path}.name"), r"must match `^[A-Za-z0-9_\-]+$`");
+        }
+        validate_required_string(&self.url, ctx, format!("{path}.url"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn ctx() -> Context {
+        Context::new(EnumSet::empty())
+    }
+
+    #[test]
+    fn deserialize_round_trips_with_type() {
+        let sd: SourceDescription = serde_json::from_value(json!({
+            "name": "petStore",
+            "url": "openapi.yaml",
+            "type": "openapi",
+        }))
+        .unwrap();
+        assert_eq!(sd.name, "petStore");
+        assert_eq!(sd.type_, Some(SourceType::Openapi));
+
+        let v = serde_json::to_value(&sd).unwrap();
+        assert_eq!(v["type"], json!("openapi"));
+    }
+
+    #[test]
+    fn deserialize_arazzo_type() {
+        let sd: SourceDescription =
+            serde_json::from_value(json!({ "name": "wf", "url": "wf.yaml", "type": "arazzo" }))
+                .unwrap();
+        assert_eq!(sd.type_, Some(SourceType::Arazzo));
+    }
+
+    #[test]
+    fn type_is_omitted_when_absent() {
+        let sd: SourceDescription =
+            serde_json::from_value(json!({ "name": "n", "url": "u" })).unwrap();
+        assert!(sd.type_.is_none());
+        let v = serde_json::to_value(&sd).unwrap();
+        assert_eq!(v, json!({ "name": "n", "url": "u" }));
+    }
+
+    #[test]
+    fn validate_rejects_empty_name_and_url() {
+        let mut c = ctx();
+        SourceDescription::default()
+            .validate_with_context(&mut c, "#.sourceDescriptions[0]".into());
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.sourceDescriptions[0].name: must not be empty")
+        );
+        assert!(
+            c.errors
+                .iter()
+                .any(|e| e == "#.sourceDescriptions[0].url: must not be empty")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_bad_name_pattern() {
+        let mut c = ctx();
+        let sd = SourceDescription {
+            name: "bad name".into(),
+            url: "u".into(),
+            ..Default::default()
+        };
+        sd.validate_with_context(&mut c, "#.s".into());
+        assert!(c.errors.iter().any(|e| e.contains("must match")));
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/step.rs
+++ b/crates/roas-arazzo/src/v1_0/step.rs
@@ -1,0 +1,246 @@
+//! Arazzo v1.0 `Step` object.
+//!
+//! Per [Step Object](https://spec.openapis.org/arazzo/v1.0.1.html#step-object):
+//! a single call to an API operation or another workflow. Exactly one
+//! of `operationId`, `operationPath`, or `workflowId` must be set.
+
+use crate::v1_0::criterion::Criterion;
+use crate::v1_0::failure_action::FailureAction;
+use crate::v1_0::parameter::Parameter;
+use crate::v1_0::request_body::RequestBody;
+use crate::v1_0::reusable::ReusableOr;
+use crate::v1_0::success_action::SuccessAction;
+use crate::validation::{
+    Context, ValidateWithContext, validate_map_keys, validate_required_string,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Step {
+    /// **Required** Unique string identifying the step within its
+    /// workflow.
+    #[serde(rename = "stepId")]
+    pub step_id: String,
+
+    /// A description of the step. CommonMark MAY be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The `operationId` of an operation in one of the source
+    /// descriptions.
+    #[serde(rename = "operationId", skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+
+    /// A source reference combined with a JSON Pointer to an operation.
+    #[serde(rename = "operationPath", skip_serializing_if = "Option::is_none")]
+    pub operation_path: Option<String>,
+
+    /// The `workflowId` of another workflow to invoke.
+    #[serde(rename = "workflowId", skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+
+    /// Parameters passed to the operation or workflow.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<ReusableOr<Parameter>>,
+
+    /// The request body to pass to the operation.
+    #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<RequestBody>,
+
+    /// Assertions determining the success of the step.
+    #[serde(
+        rename = "successCriteria",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub success_criteria: Vec<Criterion>,
+
+    /// Actions to take when the step succeeds.
+    #[serde(rename = "onSuccess", default, skip_serializing_if = "Vec::is_empty")]
+    pub on_success: Vec<ReusableOr<SuccessAction>>,
+
+    /// Actions to take when the step fails.
+    #[serde(rename = "onFailure", default, skip_serializing_if = "Vec::is_empty")]
+    pub on_failure: Vec<ReusableOr<FailureAction>>,
+
+    /// A map of friendly output names to runtime expressions. Keys must
+    /// match `^[a-zA-Z0-9\.\-_]+$`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub outputs: BTreeMap<String, String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Step {
+    /// `true` when the step targets an operation (rather than another
+    /// workflow); operation parameters must then set `in`.
+    fn is_operation(&self) -> bool {
+        self.operation_id.is_some() || self.operation_path.is_some()
+    }
+}
+
+impl ValidateWithContext for Step {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.step_id, ctx, format!("{path}.stepId"));
+
+        // Exactly one of operationId / operationPath / workflowId.
+        let targets = [
+            self.operation_id.is_some(),
+            self.operation_path.is_some(),
+            self.workflow_id.is_some(),
+        ];
+        match targets.iter().filter(|set| **set).count() {
+            1 => {}
+            0 => ctx.error(
+                path.clone(),
+                "must set exactly one of `operationId`, `operationPath`, or `workflowId`",
+            ),
+            _ => ctx.error(
+                path.clone(),
+                "`operationId`, `operationPath`, and `workflowId` are mutually exclusive",
+            ),
+        }
+
+        let is_operation = self.is_operation();
+        for (i, parameter) in self.parameters.iter().enumerate() {
+            let param_path = format!("{path}.parameters[{i}]");
+            parameter.validate_with_context(ctx, param_path.clone());
+            if is_operation
+                && let ReusableOr::Item(p) = parameter
+                && p.in_.is_none()
+            {
+                ctx.error(
+                    format!("{param_path}.in"),
+                    "is required for operation steps",
+                );
+            }
+        }
+
+        if let Some(request_body) = &self.request_body {
+            request_body.validate_with_context(ctx, format!("{path}.requestBody"));
+        }
+        for (i, criterion) in self.success_criteria.iter().enumerate() {
+            criterion.validate_with_context(ctx, format!("{path}.successCriteria[{i}]"));
+        }
+        for (i, action) in self.on_success.iter().enumerate() {
+            action.validate_with_context(ctx, format!("{path}.onSuccess[{i}]"));
+        }
+        for (i, action) in self.on_failure.iter().enumerate() {
+            action.validate_with_context(ctx, format!("{path}.onFailure[{i}]"));
+        }
+        validate_map_keys(&self.outputs, ctx, &format!("{path}.outputs"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(step: &Step) -> Vec<String> {
+        let mut ctx = Context::new(EnumSet::empty());
+        step.validate_with_context(&mut ctx, "#.steps[0]".into());
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn operation_step_round_trips() {
+        let step: Step = serde_json::from_value(json!({
+            "stepId": "findPet",
+            "operationId": "getPetById",
+            "parameters": [ { "name": "petId", "in": "path", "value": "$inputs.petId" } ],
+            "successCriteria": [ { "condition": "$statusCode == 200" } ],
+            "outputs": { "pet": "$response.body" },
+        }))
+        .unwrap();
+        assert_eq!(step.step_id, "findPet");
+        assert_eq!(step.parameters.len(), 1);
+        assert!(validate(&step).is_empty());
+    }
+
+    #[test]
+    fn missing_operation_target_is_rejected() {
+        let step = Step {
+            step_id: "s".into(),
+            ..Default::default()
+        };
+        assert!(validate(&step).iter().any(|e| e.contains("exactly one of")));
+    }
+
+    #[test]
+    fn multiple_operation_targets_are_rejected() {
+        let step = Step {
+            step_id: "s".into(),
+            operation_id: Some("op".into()),
+            workflow_id: Some("wf".into()),
+            ..Default::default()
+        };
+        assert!(
+            validate(&step)
+                .iter()
+                .any(|e| e.contains("mutually exclusive"))
+        );
+    }
+
+    #[test]
+    fn operation_parameter_requires_in() {
+        let step = Step {
+            step_id: "s".into(),
+            operation_id: Some("op".into()),
+            parameters: vec![ReusableOr::Item(Parameter {
+                name: "p".into(),
+                value: json!("v"),
+                ..Default::default()
+            })],
+            ..Default::default()
+        };
+        assert!(
+            validate(&step)
+                .iter()
+                .any(|e| e == "#.steps[0].parameters[0].in: is required for operation steps")
+        );
+    }
+
+    #[test]
+    fn workflow_step_parameter_does_not_require_in() {
+        let step = Step {
+            step_id: "s".into(),
+            workflow_id: Some("wf".into()),
+            parameters: vec![ReusableOr::Item(Parameter {
+                name: "p".into(),
+                value: json!("v"),
+                ..Default::default()
+            })],
+            ..Default::default()
+        };
+        assert!(validate(&step).is_empty());
+    }
+
+    #[test]
+    fn reusable_parameter_skips_in_check() {
+        let step: Step = serde_json::from_value(json!({
+            "stepId": "s",
+            "operationId": "op",
+            "parameters": [ { "reference": "$components.parameters.petId" } ],
+        }))
+        .unwrap();
+        assert!(validate(&step).is_empty());
+    }
+
+    #[test]
+    fn bad_output_key_is_rejected() {
+        let step: Step = serde_json::from_value(json!({
+            "stepId": "s",
+            "workflowId": "wf",
+            "outputs": { "bad key": "$x" },
+        }))
+        .unwrap();
+        assert!(validate(&step).iter().any(|e| e.contains("key must match")));
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/success_action.rs
+++ b/crates/roas-arazzo/src/v1_0/success_action.rs
@@ -1,0 +1,139 @@
+//! Arazzo v1.0 `Success Action` object.
+//!
+//! Per [Success Action Object](https://spec.openapis.org/arazzo/v1.0.1.html#success-action-object):
+//! what to do when a step succeeds — end the workflow or `goto` another
+//! step / workflow.
+
+use crate::v1_0::criterion::Criterion;
+use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The action taken on step success.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SuccessActionType {
+    #[default]
+    End,
+    Goto,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct SuccessAction {
+    /// **Required** The name of the success action.
+    pub name: String,
+
+    /// **Required** The type of action to take.
+    #[serde(rename = "type")]
+    pub type_: SuccessActionType,
+
+    /// The workflow to transfer to (required for `goto`, mutually
+    /// exclusive with `stepId`).
+    #[serde(rename = "workflowId", skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+
+    /// The step to transfer to (required for `goto`, mutually exclusive
+    /// with `workflowId`).
+    #[serde(rename = "stepId", skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
+
+    /// Assertions determining whether this action runs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub criteria: Vec<Criterion>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for SuccessAction {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.name, ctx, format!("{path}.name"));
+        validate_goto_target(
+            self.type_ == SuccessActionType::Goto,
+            self.workflow_id.is_some(),
+            self.step_id.is_some(),
+            ctx,
+            &path,
+        );
+        for (i, criterion) in self.criteria.iter().enumerate() {
+            criterion.validate_with_context(ctx, format!("{path}.criteria[{i}]"));
+        }
+    }
+}
+
+/// Shared `goto`-target rule used by both success and failure actions:
+/// a `goto` requires exactly one of `workflowId` / `stepId`.
+pub(crate) fn validate_goto_target(
+    is_goto: bool,
+    has_workflow_id: bool,
+    has_step_id: bool,
+    ctx: &mut Context,
+    path: &str,
+) {
+    if is_goto && !(has_workflow_id ^ has_step_id) {
+        ctx.error(
+            path.to_owned(),
+            "`goto` requires exactly one of `workflowId` or `stepId`",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(a: &SuccessAction) -> Vec<String> {
+        let mut ctx = Context::new(EnumSet::empty());
+        a.validate_with_context(&mut ctx, "#.a".into());
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn end_action_round_trips() {
+        let a: SuccessAction =
+            serde_json::from_value(json!({ "name": "done", "type": "end" })).unwrap();
+        assert_eq!(a.type_, SuccessActionType::End);
+        assert!(validate(&a).is_empty());
+
+        let v = serde_json::to_value(&a).unwrap();
+        assert_eq!(v, json!({ "name": "done", "type": "end" }));
+    }
+
+    #[test]
+    fn goto_requires_exactly_one_target() {
+        let neither = SuccessAction {
+            name: "g".into(),
+            type_: SuccessActionType::Goto,
+            ..Default::default()
+        };
+        assert!(validate(&neither).iter().any(|e| e.contains("goto")));
+
+        let both = SuccessAction {
+            workflow_id: Some("w".into()),
+            step_id: Some("s".into()),
+            ..neither.clone()
+        };
+        assert!(validate(&both).iter().any(|e| e.contains("goto")));
+
+        let ok = SuccessAction {
+            workflow_id: Some("w".into()),
+            ..neither
+        };
+        assert!(validate(&ok).is_empty());
+    }
+
+    #[test]
+    fn validate_recurses_into_criteria() {
+        let a = SuccessAction {
+            name: "n".into(),
+            criteria: vec![Criterion::default()],
+            ..Default::default()
+        };
+        assert!(validate(&a).iter().any(|e| e.contains("condition")));
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/version.rs
+++ b/crates/roas-arazzo/src/v1_0/version.rs
@@ -1,0 +1,185 @@
+//! Version newtype for Arazzo v1.0 (`arazzo: "1.0.x"`).
+//!
+//! The field is a string at the wire level but constrained to the
+//! schema pattern `^1\.0\.\d+(-.+)?$`
+//! ([JSON Schema](https://spec.openapis.org/arazzo/1.0/schema/2025-10-15)).
+//! Deserialization rejects non-1.0 values up front so callers don't have
+//! to revalidate. A trailing pre-release suffix (`1.0.0-rc1`) is allowed.
+
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version(String);
+
+impl Default for Version {
+    fn default() -> Self {
+        Self("1.0.1".to_owned())
+    }
+}
+
+impl Version {
+    /// Canonical `1.0.1` value (the latest published v1.0 patch).
+    #[allow(non_snake_case)]
+    pub fn V1_0_1() -> Self {
+        Self("1.0.1".to_owned())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+const VERSION_SCHEMA_DESCRIPTION: &str = "`1.0.<patch>` with optional `-suffix` (Arazzo v1.0)";
+
+/// Schema pattern is `^1\.0\.\d+(-.+)?$` — hand-rolled to avoid pulling
+/// in a regex engine for one check.
+fn matches_arazzo_1_0_version(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix("1.0.") else {
+        return false;
+    };
+    let (digits, suffix) = match rest.split_once('-') {
+        Some((digits, suffix)) => (digits, Some(suffix)),
+        None => (rest, None),
+    };
+    // At least one patch digit, all-ASCII-digits, and any pre-release
+    // suffix (the `-.+` group) must be non-empty when present.
+    !digits.is_empty()
+        && digits.bytes().all(|b| b.is_ascii_digit())
+        && suffix.is_none_or(|s| !s.is_empty())
+}
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &VERSION_SCHEMA_DESCRIPTION,
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidVersion(pub String);
+
+impl Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "arazzo version {:?} must be {VERSION_SCHEMA_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if matches_arazzo_1_0_version(s) {
+            Ok(Version(s.to_owned()))
+        } else {
+            Err(InvalidVersion(s.to_owned()))
+        }
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if matches_arazzo_1_0_version(&s) {
+            Ok(Version(s))
+        } else {
+            Err(InvalidVersion(s))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_1_0_1() {
+        assert_eq!(Version::default().as_str(), "1.0.1");
+    }
+
+    #[test]
+    fn accepts_matching_patch_versions() {
+        assert!("1.0.0".parse::<Version>().is_ok());
+        assert!("1.0.1".parse::<Version>().is_ok());
+        assert!("1.0.42".parse::<Version>().is_ok());
+    }
+
+    #[test]
+    fn accepts_prerelease_suffix() {
+        assert!("1.0.0-rc1".parse::<Version>().is_ok());
+        assert!("1.0.3-beta.2".parse::<Version>().is_ok());
+    }
+
+    #[test]
+    fn rejects_non_matching_versions() {
+        for bad in ["1.1.0", "2.0.0", "1.0", "1.0.x", "v1.0.0", "1.0.0-", ""] {
+            let err = bad.parse::<Version>().unwrap_err();
+            assert_eq!(err.0, bad);
+            let msg = err.to_string();
+            assert!(msg.contains(bad), "msg should echo input: {msg}");
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_wrong_minor() {
+        let err = serde_json::from_value::<Version>(serde_json::json!("1.1.0")).unwrap_err();
+        assert!(
+            err.to_string().contains("1.0"),
+            "expected schema description in error: {err}"
+        );
+    }
+
+    #[test]
+    fn serialize_round_trips_through_string() {
+        let v = Version::V1_0_1();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#""1.0.1""#);
+        let back: Version = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn display_renders_inner_string() {
+        let v: Version = "1.0.3".parse().unwrap();
+        assert_eq!(format!("{v}"), "1.0.3");
+    }
+
+    #[test]
+    fn try_from_str_and_string_match_from_str() {
+        assert_eq!(Version::try_from("1.0.1").unwrap(), Version::V1_0_1());
+        assert!(Version::try_from("2.0.0").is_err());
+
+        let owned_ok = Version::try_from(String::from("1.0.7")).unwrap();
+        assert_eq!(owned_ok.as_str(), "1.0.7");
+        let owned_err = Version::try_from(String::from("nope")).unwrap_err();
+        assert_eq!(owned_err.0, "nope");
+    }
+}

--- a/crates/roas-arazzo/src/v1_0/workflow.rs
+++ b/crates/roas-arazzo/src/v1_0/workflow.rs
@@ -1,0 +1,166 @@
+//! Arazzo v1.0 `Workflow` object.
+//!
+//! Per [Workflow Object](https://spec.openapis.org/arazzo/v1.0.1.html#workflow-object):
+//! an ordered list of steps achieving an objective across one or more
+//! APIs.
+
+use crate::v1_0::failure_action::FailureAction;
+use crate::v1_0::parameter::Parameter;
+use crate::v1_0::reusable::ReusableOr;
+use crate::v1_0::step::Step;
+use crate::v1_0::success_action::SuccessAction;
+use crate::validation::{
+    Context, ValidateWithContext, validate_map_keys, validate_required_string,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Workflow {
+    /// **Required** Unique string identifying the workflow.
+    #[serde(rename = "workflowId")]
+    pub workflow_id: String,
+
+    /// A summary of the purpose or objective of the workflow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// A description of the workflow. CommonMark MAY be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// A JSON Schema 2020-12 object describing the workflow inputs. Kept
+    /// as opaque JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inputs: Option<serde_json::Value>,
+
+    /// Workflows that MUST complete before this one runs.
+    #[serde(rename = "dependsOn", default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+
+    /// **Required** Ordered, non-empty list of steps.
+    pub steps: Vec<Step>,
+
+    /// Success actions applicable to every step in the workflow.
+    #[serde(
+        rename = "successActions",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub success_actions: Vec<ReusableOr<SuccessAction>>,
+
+    /// Failure actions applicable to every step in the workflow.
+    #[serde(
+        rename = "failureActions",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub failure_actions: Vec<ReusableOr<FailureAction>>,
+
+    /// A map of friendly output names to runtime expressions. Keys must
+    /// match `^[a-zA-Z0-9\.\-_]+$`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub outputs: BTreeMap<String, String>,
+
+    /// Parameters applicable to every step in the workflow.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<ReusableOr<Parameter>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Workflow {
+    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+        validate_required_string(&self.workflow_id, ctx, format!("{path}.workflowId"));
+
+        if self.steps.is_empty() {
+            ctx.error(format!("{path}.steps"), "must contain at least one entry");
+        }
+
+        let mut seen_step_ids = std::collections::BTreeSet::new();
+        for (i, step) in self.steps.iter().enumerate() {
+            let step_path = format!("{path}.steps[{i}]");
+            step.validate_with_context(ctx, step_path.clone());
+            if !step.step_id.is_empty() && !seen_step_ids.insert(step.step_id.as_str()) {
+                ctx.error(
+                    format!("{step_path}.stepId"),
+                    format!("duplicate stepId `{}`", step.step_id),
+                );
+            }
+        }
+
+        for (i, parameter) in self.parameters.iter().enumerate() {
+            parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
+        }
+        for (i, action) in self.success_actions.iter().enumerate() {
+            action.validate_with_context(ctx, format!("{path}.successActions[{i}]"));
+        }
+        for (i, action) in self.failure_actions.iter().enumerate() {
+            action.validate_with_context(ctx, format!("{path}.failureActions[{i}]"));
+        }
+        validate_map_keys(&self.outputs, ctx, &format!("{path}.outputs"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(wf: &Workflow) -> Vec<String> {
+        let mut ctx = Context::new(EnumSet::empty());
+        wf.validate_with_context(&mut ctx, "#.workflows[0]".into());
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn minimal_workflow_round_trips() {
+        let wf: Workflow = serde_json::from_value(json!({
+            "workflowId": "getPet",
+            "steps": [ { "stepId": "s1", "workflowId": "other" } ],
+        }))
+        .unwrap();
+        assert_eq!(wf.workflow_id, "getPet");
+        assert_eq!(wf.steps.len(), 1);
+        assert!(validate(&wf).is_empty());
+
+        let v = serde_json::to_value(&wf).unwrap();
+        assert_eq!(v["workflowId"], json!("getPet"));
+        assert!(v.get("parameters").is_none());
+    }
+
+    #[test]
+    fn empty_steps_is_rejected() {
+        let wf = Workflow {
+            workflow_id: "w".into(),
+            ..Default::default()
+        };
+        assert!(
+            validate(&wf)
+                .iter()
+                .any(|e| e == "#.workflows[0].steps: must contain at least one entry")
+        );
+    }
+
+    #[test]
+    fn duplicate_step_ids_are_rejected() {
+        let wf: Workflow = serde_json::from_value(json!({
+            "workflowId": "w",
+            "steps": [
+                { "stepId": "dup", "workflowId": "a" },
+                { "stepId": "dup", "workflowId": "b" }
+            ],
+        }))
+        .unwrap();
+        assert!(
+            validate(&wf)
+                .iter()
+                .any(|e| e == "#.workflows[0].steps[1].stepId: duplicate stepId `dup`")
+        );
+    }
+}

--- a/crates/roas-arazzo/src/validation.rs
+++ b/crates/roas-arazzo/src/validation.rs
@@ -1,0 +1,305 @@
+//! Validation framework for Arazzo documents.
+//!
+//! Modeled after [`roas::validation`] / `roas-overlay`: a public
+//! [`Validate`] trait drives a recursive descent through a
+//! crate-internal trait; each component pushes diagnostics into a
+//! context keyed by a JSONPath-flavor path string. Errors collect
+//! rather than fail fast.
+//!
+//! [`roas::validation`]: https://docs.rs/roas/latest/roas/validation/index.html
+
+use enumset::{EnumSet, EnumSetType};
+use std::collections::BTreeMap;
+use std::fmt::{self, Display};
+
+/// A single validation finding.
+///
+/// `path` is a human-readable locator (e.g. `#.workflows[0].steps[1].stepId`),
+/// not an RFC 6901 JSON Pointer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ValidationError {
+    pub path: String,
+    pub message: String,
+}
+
+impl ValidationError {
+    pub(crate) fn new(path: String, message: String) -> Self {
+        Self { path, message }
+    }
+
+    /// Substring search across path and message (and the rendered
+    /// boundary). Mirrors the helper of the same name in `roas` for
+    /// consistency.
+    pub fn contains(&self, needle: &str) -> bool {
+        if self.path.contains(needle) || self.message.contains(needle) {
+            return true;
+        }
+        self.to_string().contains(needle)
+    }
+}
+
+impl Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.path, self.message)
+    }
+}
+
+impl PartialEq<str> for ValidationError {
+    fn eq(&self, other: &str) -> bool {
+        let plen = self.path.len();
+        let sep = ": ";
+        other.len() == plen + sep.len() + self.message.len()
+            && other.starts_with(&self.path)
+            && other[plen..].starts_with(sep)
+            && other[plen + sep.len()..] == self.message
+    }
+}
+
+impl PartialEq<&str> for ValidationError {
+    fn eq(&self, other: &&str) -> bool {
+        <ValidationError as PartialEq<str>>::eq(self, other)
+    }
+}
+
+/// The accumulated outcome of a validation pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Error {
+    pub errors: Vec<ValidationError>,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{} errors found:", self.errors.len())?;
+        for error in &self.errors {
+            writeln!(f, "- {error}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Per-call validation toggles.
+///
+/// Each option suppresses one shallow check so callers can opt out of
+/// individual diagnostics without disabling the whole validator.
+#[derive(EnumSetType, Debug)]
+pub enum ValidationOptions {
+    /// Allow `info.title` to be empty (still required to be present).
+    IgnoreEmptyInfoTitle,
+    /// Allow `info.version` to be empty (still required to be present).
+    IgnoreEmptyInfoVersion,
+}
+
+#[cfg(feature = "clap")]
+impl clap::ValueEnum for ValidationOptions {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            ValidationOptions::IgnoreEmptyInfoTitle,
+            ValidationOptions::IgnoreEmptyInfoVersion,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        let (name, help) = match self {
+            ValidationOptions::IgnoreEmptyInfoTitle => {
+                ("empty-info-title", "Allow empty `info.title`")
+            }
+            ValidationOptions::IgnoreEmptyInfoVersion => {
+                ("empty-info-version", "Allow empty `info.version`")
+            }
+        };
+        Some(clap::builder::PossibleValue::new(name).help(help))
+    }
+}
+
+/// Validate an Arazzo document, collecting every diagnostic.
+pub trait Validate {
+    fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error>;
+}
+
+/// Crate-internal: implemented by every component type.
+pub(crate) trait ValidateWithContext {
+    fn validate_with_context(&self, ctx: &mut Context, path: String);
+}
+
+pub(crate) struct Context {
+    pub options: EnumSet<ValidationOptions>,
+    pub errors: Vec<ValidationError>,
+}
+
+impl Context {
+    pub fn new(options: EnumSet<ValidationOptions>) -> Self {
+        Self {
+            options,
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn is_option(&self, option: ValidationOptions) -> bool {
+        self.options.contains(option)
+    }
+
+    pub fn error(&mut self, path: String, message: impl Into<String>) {
+        self.errors.push(ValidationError::new(path, message.into()));
+    }
+
+    pub fn into_result(self) -> Result<(), Error> {
+        if self.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(Error {
+                errors: self.errors,
+            })
+        }
+    }
+}
+
+/// Validate that a required string is not empty.
+pub(crate) fn validate_required_string(s: &str, ctx: &mut Context, path: String) {
+    if s.is_empty() {
+        ctx.error(path, "must not be empty");
+    }
+}
+
+/// Source-description `name` pattern `^[A-Za-z0-9_\-]+$` (non-empty,
+/// ASCII alphanumerics plus `_` and `-`). Hand-rolled to avoid pulling
+/// in a regex engine for one check.
+pub(crate) fn is_valid_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// Component / output key pattern `^[a-zA-Z0-9\.\-_]+$` (non-empty,
+/// ASCII alphanumerics plus `.`, `-`, `_`).
+pub(crate) fn is_valid_key(s: &str) -> bool {
+    !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-' || b == b'_')
+}
+
+/// Validate that every key in a map matches the component / output key
+/// pattern `^[a-zA-Z0-9\.\-_]+$`.
+pub(crate) fn validate_map_keys<V>(map: &BTreeMap<String, V>, ctx: &mut Context, path: &str) {
+    for key in map.keys() {
+        if !is_valid_key(key) {
+            ctx.error(
+                format!("{path}.{key}"),
+                r"key must match `^[a-zA-Z0-9\.\-_]+$`",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_renders_with_count_and_bullets() {
+        let err = Error {
+            errors: vec![
+                ValidationError::new("#.a".into(), "first".into()),
+                ValidationError::new("#.b".into(), "second".into()),
+            ],
+        };
+        assert_eq!(
+            format!("{err}"),
+            "2 errors found:\n- #.a: first\n- #.b: second\n",
+        );
+    }
+
+    #[test]
+    fn error_zero_count_still_renders_header() {
+        let err = Error { errors: vec![] };
+        assert_eq!(format!("{err}"), "0 errors found:\n");
+    }
+
+    #[test]
+    fn validation_error_partial_eq_against_str_matches_display_form() {
+        let e = ValidationError::new("#.info.title".into(), "must not be empty".into());
+        assert!(e == "#.info.title: must not be empty");
+        let owned = String::from("#.info.title: must not be empty");
+        assert!(e == *owned.as_str());
+        assert!(e != "different");
+    }
+
+    #[test]
+    fn validation_error_contains_matches_across_boundary() {
+        let e = ValidationError::new("#.info.title".into(), "must not be empty".into());
+        assert!(e.contains("title: must"));
+        assert!(e.contains("#.info"));
+        assert!(e.contains("must not"));
+        assert!(!e.contains("nowhere"));
+    }
+
+    #[test]
+    fn context_collects_errors_and_converts_to_result() {
+        let mut ctx = Context::new(EnumSet::empty());
+        ctx.error("#.x".into(), "kaboom");
+        let r = ctx.into_result();
+        let err = r.unwrap_err();
+        assert_eq!(err.errors.len(), 1);
+    }
+
+    #[test]
+    fn context_with_no_errors_returns_ok() {
+        let ctx = Context::new(EnumSet::empty());
+        assert!(ctx.into_result().is_ok());
+    }
+
+    #[test]
+    fn context_is_option_reflects_set_membership() {
+        let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle);
+        let ctx = Context::new(opts);
+        assert!(ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle));
+        assert!(!ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion));
+    }
+
+    #[test]
+    fn validate_required_string_pushes_error_for_empty() {
+        let mut ctx = Context::new(EnumSet::empty());
+        validate_required_string("", &mut ctx, "#.info.title".into());
+        validate_required_string("ok", &mut ctx, "#.info.version".into());
+        assert_eq!(ctx.errors.len(), 1);
+        assert!(ctx.errors[0] == "#.info.title: must not be empty");
+    }
+
+    #[test]
+    fn is_valid_name_accepts_word_chars_and_rejects_others() {
+        assert!(is_valid_name("petStore"));
+        assert!(is_valid_name("pet_store-1"));
+        assert!(!is_valid_name(""));
+        assert!(!is_valid_name("pet.store"));
+        assert!(!is_valid_name("pet store"));
+    }
+
+    #[test]
+    fn is_valid_key_allows_dots_and_rejects_others() {
+        assert!(is_valid_key("my.output_value-1"));
+        assert!(!is_valid_key(""));
+        assert!(!is_valid_key("has space"));
+        assert!(!is_valid_key("slash/key"));
+    }
+}
+
+#[cfg(all(test, feature = "clap"))]
+mod clap_tests {
+    use super::*;
+    use clap::ValueEnum;
+
+    #[test]
+    fn value_variants_round_trip_through_kebab_case_names() {
+        for v in <ValidationOptions as ValueEnum>::value_variants() {
+            let pv = v.to_possible_value().expect("possible value");
+            let name = pv.get_name();
+            let parsed = <ValidationOptions as ValueEnum>::from_str(name, false).expect("parses");
+            assert_eq!(parsed, *v);
+            assert!(
+                name.bytes().all(|b| b.is_ascii_lowercase() || b == b'-'),
+                "name `{name}` must be kebab-case",
+            );
+        }
+    }
+}

--- a/crates/roas-arazzo/tests/v1_0_data/bad_duplicate_workflow_id.json
+++ b/crates/roas-arazzo/tests/v1_0_data/bad_duplicate_workflow_id.json
@@ -1,0 +1,9 @@
+{
+  "arazzo": "1.0.1",
+  "info": { "title": "T", "version": "1.0.0" },
+  "sourceDescriptions": [ { "name": "src", "url": "openapi.yaml" } ],
+  "workflows": [
+    { "workflowId": "dup", "steps": [ { "stepId": "s", "workflowId": "a" } ] },
+    { "workflowId": "dup", "steps": [ { "stepId": "s", "workflowId": "b" } ] }
+  ]
+}

--- a/crates/roas-arazzo/tests/v1_0_data/bad_empty_workflows.json
+++ b/crates/roas-arazzo/tests/v1_0_data/bad_empty_workflows.json
@@ -1,0 +1,6 @@
+{
+  "arazzo": "1.0.1",
+  "info": { "title": "T", "version": "1.0.0" },
+  "sourceDescriptions": [ { "name": "src", "url": "openapi.yaml" } ],
+  "workflows": []
+}

--- a/crates/roas-arazzo/tests/v1_0_data/bad_goto_missing_target.json
+++ b/crates/roas-arazzo/tests/v1_0_data/bad_goto_missing_target.json
@@ -1,0 +1,20 @@
+{
+  "arazzo": "1.0.1",
+  "info": { "title": "T", "version": "1.0.0" },
+  "sourceDescriptions": [ { "name": "src", "url": "openapi.yaml" } ],
+  "workflows": [
+    {
+      "workflowId": "wf",
+      "steps": [
+        {
+          "stepId": "s",
+          "operationId": "op",
+          "parameters": [ { "name": "p", "in": "query", "value": 1 } ],
+          "onSuccess": [
+            { "name": "jump", "type": "goto" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/roas-arazzo/tests/v1_0_data/bad_step_no_operation.json
+++ b/crates/roas-arazzo/tests/v1_0_data/bad_step_no_operation.json
@@ -1,0 +1,13 @@
+{
+  "arazzo": "1.0.1",
+  "info": { "title": "T", "version": "1.0.0" },
+  "sourceDescriptions": [ { "name": "src", "url": "openapi.yaml" } ],
+  "workflows": [
+    {
+      "workflowId": "wf",
+      "steps": [
+        { "stepId": "noTarget" }
+      ]
+    }
+  ]
+}

--- a/crates/roas-arazzo/tests/v1_0_data/full_workflow.yaml
+++ b/crates/roas-arazzo/tests/v1_0_data/full_workflow.yaml
@@ -1,0 +1,89 @@
+arazzo: 1.0.1
+info:
+  title: Pet purchasing workflow
+  summary: Buy a pet
+  description: Exercises every Arazzo v1.0 object kind.
+  version: "1.0.0"
+  x-owner: platform-team
+sourceDescriptions:
+  - name: petStore
+    url: https://api.example.com/openapi.json
+    type: openapi
+  - name: subWorkflows
+    url: ./other.arazzo.yaml
+    type: arazzo
+workflows:
+  - workflowId: buyPet
+    summary: Find then order a pet
+    dependsOn:
+      - authenticate
+    inputs:
+      type: object
+      properties:
+        petId:
+          type: string
+    parameters:
+      - name: Authorization
+        in: header
+        value: $inputs.token
+      - reference: $components.parameters.locale
+    steps:
+      - stepId: findPet
+        description: Look up a pet by id
+        operationId: getPetById
+        parameters:
+          - name: petId
+            in: path
+            value: $inputs.petId
+        successCriteria:
+          - condition: $statusCode == 200
+          - context: $response.body
+            condition: $[?count(@.tags) > 0]
+            type: jsonpath
+            version: draft-goessner-dispatch-jsonpath-00
+        onSuccess:
+          - name: gotoOrder
+            type: goto
+            stepId: orderPet
+        onFailure:
+          - name: retryFind
+            type: retry
+            retryAfter: 1.5
+            retryLimit: 3
+            criteria:
+              - condition: $statusCode == 503
+          - reference: $components.failureActions.notifyOps
+        outputs:
+          foundPet: $response.body
+      - stepId: orderPet
+        operationId: placeOrder
+        requestBody:
+          contentType: application/json
+          payload:
+            petId: $steps.findPet.outputs.foundPet.id
+          replacements:
+            - target: /quantity
+              value: "1"
+        outputs:
+          orderId: $response.body.id
+    successActions:
+      - name: done
+        type: end
+    failureActions:
+      - name: abort
+        type: end
+    outputs:
+      order: $steps.orderPet.outputs.orderId
+components:
+  parameters:
+    locale:
+      name: locale
+      in: header
+      value: en-US
+  failureActions:
+    notifyOps:
+      name: notifyOps
+      type: end
+  inputs:
+    token:
+      type: string

--- a/crates/roas-arazzo/tests/v1_0_data/minimal.json
+++ b/crates/roas-arazzo/tests/v1_0_data/minimal.json
@@ -1,0 +1,31 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "Minimal",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://api.example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "getPet",
+      "steps": [
+        {
+          "stepId": "findPet",
+          "operationId": "getPetById",
+          "parameters": [
+            { "name": "petId", "in": "path", "value": "$inputs.petId" }
+          ],
+          "successCriteria": [
+            { "condition": "$statusCode == 200" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/roas-arazzo/tests/v1_0_test.rs
+++ b/crates/roas-arazzo/tests/v1_0_test.rs
@@ -1,0 +1,100 @@
+//! Integration tests for Arazzo v1.0: load fixtures from
+//! `tests/v1_0_data/`, parse them (JSON and YAML), and validate.
+
+#![cfg(feature = "v1_0")]
+
+use enumset::EnumSet;
+use roas_arazzo::v1_0::Description;
+use roas_arazzo::validation::Validate;
+use std::path::{Path, PathBuf};
+
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("v1_0_data")
+}
+
+fn read(name: &str) -> String {
+    let path = data_dir().join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn load_json(name: &str) -> Description {
+    serde_json::from_str(&read(name)).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+fn load_yaml(name: &str) -> Description {
+    serde_yaml_ng::from_str(&read(name)).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+#[test]
+fn minimal_description_parses_and_validates() {
+    let doc = load_json("minimal.json");
+    doc.validate(EnumSet::empty()).expect("must validate");
+    assert_eq!(doc.workflows[0].workflow_id, "getPet");
+}
+
+#[test]
+fn full_workflow_yaml_parses_and_validates() {
+    let doc = load_yaml("full_workflow.yaml");
+    doc.validate(EnumSet::empty()).expect("must validate");
+
+    // Spot-check that the rich structure round-tripped.
+    assert_eq!(doc.source_descriptions.len(), 2);
+    let wf = &doc.workflows[0];
+    assert_eq!(wf.steps.len(), 2);
+    assert!(wf.steps[1].request_body.is_some());
+    let components = doc.components.as_ref().expect("components present");
+    assert!(components.parameters.contains_key("locale"));
+    assert!(components.failure_actions.contains_key("notifyOps"));
+
+    // Re-serialize to JSON and back; the document must survive a round trip.
+    let json = serde_json::to_string(&doc).expect("serialize");
+    let reparsed: Description = serde_json::from_str(&json).expect("reparse");
+    assert_eq!(reparsed, doc);
+}
+
+#[test]
+fn empty_workflows_fixture_fails_validation() {
+    let err = load_json("bad_empty_workflows.json")
+        .validate(EnumSet::empty())
+        .unwrap_err();
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e == "#.workflows: must contain at least one entry"),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn step_without_operation_fixture_fails_validation() {
+    let err = load_json("bad_step_no_operation.json")
+        .validate(EnumSet::empty())
+        .unwrap_err();
+    assert!(
+        err.errors.iter().any(|e| e.contains("exactly one of")),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn duplicate_workflow_id_fixture_fails_validation() {
+    let err = load_json("bad_duplicate_workflow_id.json")
+        .validate(EnumSet::empty())
+        .unwrap_err();
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e.contains("duplicate workflowId `dup`")),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn goto_without_target_fixture_fails_validation() {
+    let err = load_json("bad_goto_missing_target.json")
+        .validate(EnumSet::empty())
+        .unwrap_err();
+    assert!(err.errors.iter().any(|e| e.contains("goto")), "got: {err}",);
+}


### PR DESCRIPTION
New `roas-arazzo` crate implementing the OpenAPI Arazzo Specification v1.0, mirroring `roas-overlay` conventions.

- Typed v1.0 document model (`Description`, `Workflow`, `Step`, actions, `Criterion`, `Components`, `Reusable`/`ReusableOr<T>`, `Version` newtype) with JSON/YAML serde and `x-` extensions.
- Collecting `Validate` framework: required/non-empty fields, name & key patterns, uniqueness (source names, workflowIds, stepIds), Step exactly-one-operation + operation-param `in`, Criterion `type`→`context` and expression-version constants, `goto` target requirement. `ValidationOptions` gains `clap::ValueEnum` behind the `clap` feature.

Scope: parse + validate only. v1.1.x, CLI wiring, runtime-expression grammar, and `sourceDescriptions`/`$ref` resolution are deferred to follow-up PRs.

Verification: `cargo fmt`, clippy `--all-features --all-targets -D warnings`, 85 crate tests, doctests, and `cargo doc` all pass.
