### PR TITLE
perf(roas-arazzo): path-buffer validator + one-pass ReusableOr

### DIFF
--- a/crates/roas-arazzo/src/common/extensions.rs
+++ b/crates/roas-arazzo/src/common/extensions.rs
@@ -28,7 +28,7 @@
 
 use serde::de::{Error, MapAccess, Visitor};
 use serde::ser::SerializeMap;
-use serde::{Deserializer, Serialize, Serializer};
+use serde::{Deserializer, Serializer};
 use std::collections::BTreeMap;
 use std::fmt;
 
@@ -84,7 +84,7 @@ where
         }
         map.end()
     } else {
-        None::<BTreeMap<String, serde_json::Value>>.serialize(serializer)
+        serializer.serialize_none()
     }
 }
 

--- a/crates/roas-arazzo/src/v1_0/components.rs
+++ b/crates/roas-arazzo/src/v1_0/components.rs
@@ -8,7 +8,7 @@
 use crate::v1_0::failure_action::FailureAction;
 use crate::v1_0::parameter::Parameter;
 use crate::v1_0::success_action::SuccessAction;
-use crate::validation::{Context, ValidateWithContext, validate_map_keys};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -47,28 +47,26 @@ pub struct Components {
 }
 
 impl ValidateWithContext for Components {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_map_keys(&self.inputs, ctx, &format!("{path}.inputs"));
-        validate_map_keys(&self.parameters, ctx, &format!("{path}.parameters"));
-        validate_map_keys(
-            &self.success_actions,
-            ctx,
-            &format!("{path}.successActions"),
-        );
-        validate_map_keys(
-            &self.failure_actions,
-            ctx,
-            &format!("{path}.failureActions"),
-        );
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.validate_map_keys("inputs", &self.inputs);
+        ctx.validate_map_keys("parameters", &self.parameters);
+        ctx.validate_map_keys("successActions", &self.success_actions);
+        ctx.validate_map_keys("failureActions", &self.failure_actions);
 
         for (name, parameter) in &self.parameters {
-            parameter.validate_with_context(ctx, format!("{path}.parameters.{name}"));
+            ctx.in_key("parameters", name, |ctx| {
+                parameter.validate_with_context(ctx)
+            });
         }
         for (name, action) in &self.success_actions {
-            action.validate_with_context(ctx, format!("{path}.successActions.{name}"));
+            ctx.in_key("successActions", name, |ctx| {
+                action.validate_with_context(ctx)
+            });
         }
         for (name, action) in &self.failure_actions {
-            action.validate_with_context(ctx, format!("{path}.failureActions.{name}"));
+            ctx.in_key("failureActions", name, |ctx| {
+                action.validate_with_context(ctx)
+            });
         }
     }
 }
@@ -96,14 +94,14 @@ mod tests {
 
     #[test]
     fn validate_rejects_bad_key_and_recurses() {
-        let mut ctx = Context::new(EnumSet::empty());
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.components");
         let mut parameters = BTreeMap::new();
         parameters.insert("bad key".to_owned(), Parameter::default());
         let c = Components {
             parameters,
             ..Default::default()
         };
-        c.validate_with_context(&mut ctx, "#.components".into());
+        c.validate_with_context(&mut ctx);
         let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
         assert!(msgs.iter().any(|e| e.contains("key must match")));
         // recursion reaches the empty parameter name

--- a/crates/roas-arazzo/src/v1_0/criterion.rs
+++ b/crates/roas-arazzo/src/v1_0/criterion.rs
@@ -7,7 +7,7 @@
 //! criterion via `anyOf`, so `type` and `version` are flat optional
 //! fields here rather than a nested object.
 
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -54,12 +54,12 @@ pub struct Criterion {
 }
 
 impl ValidateWithContext for Criterion {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.condition, ctx, format!("{path}.condition"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("condition", &self.condition);
 
         // `dependentRequired`: a `type` requires a `context`.
         if self.type_.is_some() && self.context.is_none() {
-            ctx.error(format!("{path}.context"), "is required when `type` is set");
+            ctx.error_field("context", "is required when `type` is set");
         }
 
         // `version` belongs to the expression-type form (jsonpath/xpath)
@@ -67,22 +67,19 @@ impl ValidateWithContext for Criterion {
         if let Some(version) = &self.version {
             match self.type_ {
                 Some(CriterionType::Jsonpath) if version != JSONPATH_VERSION => {
-                    ctx.error(
-                        format!("{path}.version"),
+                    ctx.error_field(
+                        "version",
                         format!("must be `{JSONPATH_VERSION}` for type `jsonpath`"),
                     );
                 }
                 Some(CriterionType::Xpath) if !XPATH_VERSIONS.contains(&version.as_str()) => {
-                    ctx.error(
-                        format!("{path}.version"),
+                    ctx.error_field(
+                        "version",
                         "must be one of `xpath-10`, `xpath-20`, `xpath-30` for type `xpath`",
                     );
                 }
                 Some(CriterionType::Jsonpath | CriterionType::Xpath) => {}
-                _ => ctx.error(
-                    format!("{path}.version"),
-                    "is only valid with type `jsonpath` or `xpath`",
-                ),
+                _ => ctx.error_field("version", "is only valid with type `jsonpath` or `xpath`"),
             }
         }
     }
@@ -95,8 +92,8 @@ mod tests {
     use serde_json::json;
 
     fn validate(c: &Criterion) -> Vec<String> {
-        let mut ctx = Context::new(EnumSet::empty());
-        c.validate_with_context(&mut ctx, "#.c".into());
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.c");
+        c.validate_with_context(&mut ctx);
         ctx.errors.iter().map(ToString::to_string).collect()
     }
 

--- a/crates/roas-arazzo/src/v1_0/description.rs
+++ b/crates/roas-arazzo/src/v1_0/description.rs
@@ -43,51 +43,42 @@ pub struct Description {
 impl Description {
     fn validate_inner(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
         let mut ctx = Context::new(options);
-        let path = "#".to_owned();
 
-        self.info
-            .validate_with_context(&mut ctx, format!("{path}.info"));
+        ctx.in_field("info", |ctx| self.info.validate_with_context(ctx));
 
         if self.source_descriptions.is_empty() {
-            ctx.error(
-                format!("{path}.sourceDescriptions"),
-                "must contain at least one entry",
-            );
+            ctx.error_field("sourceDescriptions", "must contain at least one entry");
         }
         let mut seen_names = BTreeSet::new();
         for (i, source) in self.source_descriptions.iter().enumerate() {
-            let source_path = format!("{path}.sourceDescriptions[{i}]");
-            source.validate_with_context(&mut ctx, source_path.clone());
-            if !source.name.is_empty() && !seen_names.insert(source.name.as_str()) {
-                ctx.error(
-                    format!("{source_path}.name"),
-                    format!("duplicate source name `{}`", source.name),
-                );
-            }
+            ctx.in_index("sourceDescriptions", i, |ctx| {
+                source.validate_with_context(ctx);
+                if !source.name.is_empty() && !seen_names.insert(source.name.as_str()) {
+                    ctx.error_field("name", format!("duplicate source name `{}`", source.name));
+                }
+            });
         }
 
         if self.workflows.is_empty() {
-            ctx.error(
-                format!("{path}.workflows"),
-                "must contain at least one entry",
-            );
+            ctx.error_field("workflows", "must contain at least one entry");
         }
         let mut seen_workflow_ids = BTreeSet::new();
         for (i, workflow) in self.workflows.iter().enumerate() {
-            let workflow_path = format!("{path}.workflows[{i}]");
-            workflow.validate_with_context(&mut ctx, workflow_path.clone());
-            if !workflow.workflow_id.is_empty()
-                && !seen_workflow_ids.insert(workflow.workflow_id.as_str())
-            {
-                ctx.error(
-                    format!("{workflow_path}.workflowId"),
-                    format!("duplicate workflowId `{}`", workflow.workflow_id),
-                );
-            }
+            ctx.in_index("workflows", i, |ctx| {
+                workflow.validate_with_context(ctx);
+                if !workflow.workflow_id.is_empty()
+                    && !seen_workflow_ids.insert(workflow.workflow_id.as_str())
+                {
+                    ctx.error_field(
+                        "workflowId",
+                        format!("duplicate workflowId `{}`", workflow.workflow_id),
+                    );
+                }
+            });
         }
 
         if let Some(components) = &self.components {
-            components.validate_with_context(&mut ctx, format!("{path}.components"));
+            ctx.in_field("components", |ctx| components.validate_with_context(ctx));
         }
 
         ctx.into_result()

--- a/crates/roas-arazzo/src/v1_0/failure_action.rs
+++ b/crates/roas-arazzo/src/v1_0/failure_action.rs
@@ -5,7 +5,7 @@
 
 use crate::v1_0::criterion::Criterion;
 use crate::v1_0::success_action::validate_goto_target;
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -58,20 +58,20 @@ pub struct FailureAction {
 }
 
 impl ValidateWithContext for FailureAction {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.name, ctx, format!("{path}.name"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("name", &self.name);
         validate_goto_target(
             self.type_ == FailureActionType::Goto,
             self.workflow_id.is_some(),
             self.step_id.is_some(),
             ctx,
-            &path,
         );
-        if self.retry_after.is_some_and(|n| n < 0.0) {
-            ctx.error(format!("{path}.retryAfter"), "must not be negative");
+        // Reject negatives and NaN (the schema requires `minimum: 0`).
+        if self.retry_after.is_some_and(|n| n < 0.0 || n.is_nan()) {
+            ctx.error_field("retryAfter", "must not be negative");
         }
         for (i, criterion) in self.criteria.iter().enumerate() {
-            criterion.validate_with_context(ctx, format!("{path}.criteria[{i}]"));
+            ctx.in_index("criteria", i, |ctx| criterion.validate_with_context(ctx));
         }
     }
 }
@@ -83,8 +83,8 @@ mod tests {
     use serde_json::json;
 
     fn validate(a: &FailureAction) -> Vec<String> {
-        let mut ctx = Context::new(EnumSet::empty());
-        a.validate_with_context(&mut ctx, "#.a".into());
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.a");
+        a.validate_with_context(&mut ctx);
         ctx.errors.iter().map(ToString::to_string).collect()
     }
 
@@ -136,6 +136,21 @@ mod tests {
             name: "n".into(),
             type_: FailureActionType::Retry,
             retry_after: Some(-1.0),
+            ..Default::default()
+        };
+        assert!(
+            validate(&a)
+                .iter()
+                .any(|e| e == "#.a.retryAfter: must not be negative")
+        );
+    }
+
+    #[test]
+    fn nan_retry_after_fails_validation() {
+        let a = FailureAction {
+            name: "n".into(),
+            type_: FailureActionType::Retry,
+            retry_after: Some(f64::NAN),
             ..Default::default()
         };
         assert!(

--- a/crates/roas-arazzo/src/v1_0/info.rs
+++ b/crates/roas-arazzo/src/v1_0/info.rs
@@ -4,9 +4,7 @@
 //! metadata about the Arazzo description, with required `title` and
 //! `version`, extensible via `x-` fields.
 
-use crate::validation::{
-    Context, ValidateWithContext, ValidationOptions, validate_required_string,
-};
+use crate::validation::{Context, ValidateWithContext, ValidationOptions};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -36,12 +34,12 @@ pub struct Info {
 }
 
 impl ValidateWithContext for Info {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+    fn validate_with_context(&self, ctx: &mut Context) {
         if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle) {
-            validate_required_string(&self.title, ctx, format!("{path}.title"));
+            ctx.require_non_empty("title", &self.title);
         }
         if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion) {
-            validate_required_string(&self.version, ctx, format!("{path}.version"));
+            ctx.require_non_empty("version", &self.version);
         }
     }
 }
@@ -53,7 +51,7 @@ mod tests {
     use serde_json::json;
 
     fn ctx() -> Context {
-        Context::new(EnumSet::empty())
+        Context::with_path(EnumSet::empty(), "#.info")
     }
 
     #[test]
@@ -100,7 +98,7 @@ mod tests {
     fn validate_rejects_empty_title_and_version() {
         let mut c = ctx();
         let info = Info::default();
-        info.validate_with_context(&mut c, "#.info".into());
+        info.validate_with_context(&mut c);
         assert!(
             c.errors
                 .iter()
@@ -117,9 +115,9 @@ mod tests {
     fn validate_ignore_options_suppress_diagnostics() {
         let opts = EnumSet::only(ValidationOptions::IgnoreEmptyInfoTitle)
             | ValidationOptions::IgnoreEmptyInfoVersion;
-        let mut c = Context::new(opts);
+        let mut c = Context::with_path(opts, "#.info");
         let info = Info::default();
-        info.validate_with_context(&mut c, "#.info".into());
+        info.validate_with_context(&mut c);
         assert!(c.errors.is_empty());
     }
 }

--- a/crates/roas-arazzo/src/v1_0/parameter.rs
+++ b/crates/roas-arazzo/src/v1_0/parameter.rs
@@ -5,7 +5,7 @@
 //! required when the enclosing step targets an `operationId` /
 //! `operationPath` (enforced in [`crate::v1_0::step`]).
 
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -42,8 +42,8 @@ pub struct Parameter {
 }
 
 impl ValidateWithContext for Parameter {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.name, ctx, format!("{path}.name"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("name", &self.name);
     }
 }
 
@@ -79,8 +79,8 @@ mod tests {
 
     #[test]
     fn validate_rejects_empty_name() {
-        let mut c = Context::new(EnumSet::empty());
-        Parameter::default().validate_with_context(&mut c, "#.p".into());
+        let mut c = Context::with_path(EnumSet::empty(), "#.p");
+        Parameter::default().validate_with_context(&mut c);
         assert!(c.errors.iter().any(|e| e == "#.p.name: must not be empty"));
     }
 

--- a/crates/roas-arazzo/src/v1_0/request_body.rs
+++ b/crates/roas-arazzo/src/v1_0/request_body.rs
@@ -3,7 +3,7 @@
 //! Per [Request Body Object](https://spec.openapis.org/arazzo/v1.0.1.html#request-body-object)
 //! and [Payload Replacement Object](https://spec.openapis.org/arazzo/v1.0.1.html#payload-replacement-object).
 
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -30,9 +30,11 @@ pub struct RequestBody {
 }
 
 impl ValidateWithContext for RequestBody {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+    fn validate_with_context(&self, ctx: &mut Context) {
         for (i, replacement) in self.replacements.iter().enumerate() {
-            replacement.validate_with_context(ctx, format!("{path}.replacements[{i}]"));
+            ctx.in_index("replacements", i, |ctx| {
+                replacement.validate_with_context(ctx)
+            });
         }
     }
 }
@@ -54,8 +56,8 @@ pub struct PayloadReplacement {
 }
 
 impl ValidateWithContext for PayloadReplacement {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.target, ctx, format!("{path}.target"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("target", &self.target);
     }
 }
 
@@ -89,12 +91,12 @@ mod tests {
 
     #[test]
     fn validate_recurses_into_replacements() {
-        let mut c = Context::new(EnumSet::empty());
+        let mut c = Context::with_path(EnumSet::empty(), "#.requestBody");
         let rb = RequestBody {
             replacements: vec![PayloadReplacement::default()],
             ..Default::default()
         };
-        rb.validate_with_context(&mut c, "#.requestBody".into());
+        rb.validate_with_context(&mut c);
         assert!(
             c.errors
                 .iter()

--- a/crates/roas-arazzo/src/v1_0/reusable.rs
+++ b/crates/roas-arazzo/src/v1_0/reusable.rs
@@ -10,8 +10,9 @@
 //! either a concrete object or a `Reusable`; [`ReusableOr`] models that
 //! `oneOf`, analogous to `roas`'s `RefOr<T>`.
 
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
-use serde::{Deserialize, Serialize};
+use crate::validation::{Context, ValidateWithContext};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Reusable {
@@ -24,28 +25,52 @@ pub struct Reusable {
 }
 
 impl ValidateWithContext for Reusable {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.reference, ctx, format!("{path}.reference"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("reference", &self.reference);
     }
 }
 
 /// Either a concrete object `T` or a [`Reusable`] reference to one.
 ///
-/// `Reusable` is tried first during deserialization; its required
-/// `reference` key distinguishes it from the concrete object, which has
-/// its own distinct required fields.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+/// Serializes untagged (the inner object directly). Deserialization is
+/// hand-written rather than `#[serde(untagged)]`: it dispatches on the
+/// presence of the discriminating `reference` key in a single pass and
+/// then deserializes only the chosen variant, so a malformed `Item`
+/// surfaces its real error (e.g. `missing field \`name\``) instead of
+/// the opaque "data did not match any variant".
+#[derive(Clone, Debug, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum ReusableOr<T> {
     Reusable(Reusable),
     Item(T),
 }
 
+impl<'de, T> Deserialize<'de> for ReusableOr<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if value.get("reference").is_some() {
+            serde_json::from_value(value)
+                .map(ReusableOr::Reusable)
+                .map_err(serde::de::Error::custom)
+        } else {
+            serde_json::from_value(value)
+                .map(ReusableOr::Item)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+}
+
 impl<T: ValidateWithContext> ValidateWithContext for ReusableOr<T> {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
+    fn validate_with_context(&self, ctx: &mut Context) {
         match self {
-            ReusableOr::Reusable(r) => r.validate_with_context(ctx, path),
-            ReusableOr::Item(t) => t.validate_with_context(ctx, path),
+            ReusableOr::Reusable(r) => r.validate_with_context(ctx),
+            ReusableOr::Item(t) => t.validate_with_context(ctx),
         }
     }
 }
@@ -91,10 +116,32 @@ mod tests {
     }
 
     #[test]
+    fn malformed_item_surfaces_inner_error_not_opaque_variant_error() {
+        // No `reference` key, so this dispatches to `Item(Parameter)` and
+        // fails with the real missing-field error rather than the
+        // untagged-enum catch-all.
+        let err =
+            serde_json::from_value::<ReusableOr<Parameter>>(json!({ "in": "path" })).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing field"), "got: {msg}");
+        assert!(!msg.contains("did not match any variant"), "got: {msg}");
+    }
+
+    #[test]
+    fn round_trips_through_yaml() {
+        let v: ReusableOr<Parameter> =
+            serde_yaml_ng::from_str("name: petId\nin: query\nvalue: 1\n").unwrap();
+        assert!(matches!(v, ReusableOr::Item(_)));
+        let r: ReusableOr<Parameter> =
+            serde_yaml_ng::from_str("reference: $components.parameters.foo\n").unwrap();
+        assert!(matches!(r, ReusableOr::Reusable(_)));
+    }
+
+    #[test]
     fn validate_reusable_rejects_empty_reference() {
-        let mut c = Context::new(EnumSet::empty());
+        let mut c = Context::with_path(EnumSet::empty(), "#.parameters[0]");
         let v: ReusableOr<Parameter> = ReusableOr::Reusable(Reusable::default());
-        v.validate_with_context(&mut c, "#.parameters[0]".into());
+        v.validate_with_context(&mut c);
         assert!(
             c.errors
                 .iter()
@@ -104,9 +151,9 @@ mod tests {
 
     #[test]
     fn validate_item_delegates_to_inner() {
-        let mut c = Context::new(EnumSet::empty());
+        let mut c = Context::with_path(EnumSet::empty(), "#.parameters[0]");
         let v: ReusableOr<Parameter> = ReusableOr::Item(Parameter::default());
-        v.validate_with_context(&mut c, "#.parameters[0]".into());
+        v.validate_with_context(&mut c);
         assert!(
             c.errors
                 .iter()

--- a/crates/roas-arazzo/src/v1_0/source_description.rs
+++ b/crates/roas-arazzo/src/v1_0/source_description.rs
@@ -4,7 +4,7 @@
 //! a named reference to an OpenAPI or Arazzo document used by one or
 //! more workflows.
 
-use crate::validation::{Context, ValidateWithContext, is_valid_name, validate_required_string};
+use crate::validation::{Context, ValidateWithContext, is_valid_name};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -40,12 +40,12 @@ pub struct SourceDescription {
 }
 
 impl ValidateWithContext for SourceDescription {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.name, ctx, format!("{path}.name"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("name", &self.name);
         if !self.name.is_empty() && !is_valid_name(&self.name) {
-            ctx.error(format!("{path}.name"), r"must match `^[A-Za-z0-9_\-]+$`");
+            ctx.error_field("name", r"must match `^[A-Za-z0-9_\-]+$`");
         }
-        validate_required_string(&self.url, ctx, format!("{path}.url"));
+        ctx.require_non_empty("url", &self.url);
     }
 }
 
@@ -54,10 +54,6 @@ mod tests {
     use super::*;
     use enumset::EnumSet;
     use serde_json::json;
-
-    fn ctx() -> Context {
-        Context::new(EnumSet::empty())
-    }
 
     #[test]
     fn deserialize_round_trips_with_type() {
@@ -93,9 +89,8 @@ mod tests {
 
     #[test]
     fn validate_rejects_empty_name_and_url() {
-        let mut c = ctx();
-        SourceDescription::default()
-            .validate_with_context(&mut c, "#.sourceDescriptions[0]".into());
+        let mut c = Context::with_path(EnumSet::empty(), "#.sourceDescriptions[0]");
+        SourceDescription::default().validate_with_context(&mut c);
         assert!(
             c.errors
                 .iter()
@@ -110,13 +105,13 @@ mod tests {
 
     #[test]
     fn validate_rejects_bad_name_pattern() {
-        let mut c = ctx();
+        let mut c = Context::with_path(EnumSet::empty(), "#.s");
         let sd = SourceDescription {
             name: "bad name".into(),
             url: "u".into(),
             ..Default::default()
         };
-        sd.validate_with_context(&mut c, "#.s".into());
+        sd.validate_with_context(&mut c);
         assert!(c.errors.iter().any(|e| e.contains("must match")));
     }
 }

--- a/crates/roas-arazzo/src/v1_0/step.rs
+++ b/crates/roas-arazzo/src/v1_0/step.rs
@@ -10,9 +10,7 @@ use crate::v1_0::parameter::Parameter;
 use crate::v1_0::request_body::RequestBody;
 use crate::v1_0::reusable::ReusableOr;
 use crate::v1_0::success_action::SuccessAction;
-use crate::validation::{
-    Context, ValidateWithContext, validate_map_keys, validate_required_string,
-};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -85,8 +83,8 @@ impl Step {
 }
 
 impl ValidateWithContext for Step {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.step_id, ctx, format!("{path}.stepId"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("stepId", &self.step_id);
 
         // Exactly one of operationId / operationPath / workflowId.
         let targets = [
@@ -96,44 +94,42 @@ impl ValidateWithContext for Step {
         ];
         match targets.iter().filter(|set| **set).count() {
             1 => {}
-            0 => ctx.error(
-                path.clone(),
-                "must set exactly one of `operationId`, `operationPath`, or `workflowId`",
-            ),
-            _ => ctx.error(
-                path.clone(),
-                "`operationId`, `operationPath`, and `workflowId` are mutually exclusive",
-            ),
+            0 => {
+                ctx.error("must set exactly one of `operationId`, `operationPath`, or `workflowId`")
+            }
+            _ => {
+                ctx.error("`operationId`, `operationPath`, and `workflowId` are mutually exclusive")
+            }
         }
 
         let is_operation = self.is_operation();
         for (i, parameter) in self.parameters.iter().enumerate() {
-            let param_path = format!("{path}.parameters[{i}]");
-            parameter.validate_with_context(ctx, param_path.clone());
-            if is_operation
-                && let ReusableOr::Item(p) = parameter
-                && p.in_.is_none()
-            {
-                ctx.error(
-                    format!("{param_path}.in"),
-                    "is required for operation steps",
-                );
-            }
+            ctx.in_index("parameters", i, |ctx| {
+                parameter.validate_with_context(ctx);
+                if is_operation
+                    && let ReusableOr::Item(p) = parameter
+                    && p.in_.is_none()
+                {
+                    ctx.error_field("in", "is required for operation steps");
+                }
+            });
         }
 
         if let Some(request_body) = &self.request_body {
-            request_body.validate_with_context(ctx, format!("{path}.requestBody"));
+            ctx.in_field("requestBody", |ctx| request_body.validate_with_context(ctx));
         }
         for (i, criterion) in self.success_criteria.iter().enumerate() {
-            criterion.validate_with_context(ctx, format!("{path}.successCriteria[{i}]"));
+            ctx.in_index("successCriteria", i, |ctx| {
+                criterion.validate_with_context(ctx)
+            });
         }
         for (i, action) in self.on_success.iter().enumerate() {
-            action.validate_with_context(ctx, format!("{path}.onSuccess[{i}]"));
+            ctx.in_index("onSuccess", i, |ctx| action.validate_with_context(ctx));
         }
         for (i, action) in self.on_failure.iter().enumerate() {
-            action.validate_with_context(ctx, format!("{path}.onFailure[{i}]"));
+            ctx.in_index("onFailure", i, |ctx| action.validate_with_context(ctx));
         }
-        validate_map_keys(&self.outputs, ctx, &format!("{path}.outputs"));
+        ctx.validate_map_keys("outputs", &self.outputs);
     }
 }
 
@@ -144,8 +140,8 @@ mod tests {
     use serde_json::json;
 
     fn validate(step: &Step) -> Vec<String> {
-        let mut ctx = Context::new(EnumSet::empty());
-        step.validate_with_context(&mut ctx, "#.steps[0]".into());
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.steps[0]");
+        step.validate_with_context(&mut ctx);
         ctx.errors.iter().map(ToString::to_string).collect()
     }
 

--- a/crates/roas-arazzo/src/v1_0/success_action.rs
+++ b/crates/roas-arazzo/src/v1_0/success_action.rs
@@ -5,7 +5,7 @@
 //! step / workflow.
 
 use crate::v1_0::criterion::Criterion;
-use crate::validation::{Context, ValidateWithContext, validate_required_string};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -49,35 +49,31 @@ pub struct SuccessAction {
 }
 
 impl ValidateWithContext for SuccessAction {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.name, ctx, format!("{path}.name"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("name", &self.name);
         validate_goto_target(
             self.type_ == SuccessActionType::Goto,
             self.workflow_id.is_some(),
             self.step_id.is_some(),
             ctx,
-            &path,
         );
         for (i, criterion) in self.criteria.iter().enumerate() {
-            criterion.validate_with_context(ctx, format!("{path}.criteria[{i}]"));
+            ctx.in_index("criteria", i, |ctx| criterion.validate_with_context(ctx));
         }
     }
 }
 
 /// Shared `goto`-target rule used by both success and failure actions:
-/// a `goto` requires exactly one of `workflowId` / `stepId`.
+/// a `goto` requires exactly one of `workflowId` / `stepId`. Reported at
+/// the action's current path.
 pub(crate) fn validate_goto_target(
     is_goto: bool,
     has_workflow_id: bool,
     has_step_id: bool,
     ctx: &mut Context,
-    path: &str,
 ) {
     if is_goto && !(has_workflow_id ^ has_step_id) {
-        ctx.error(
-            path.to_owned(),
-            "`goto` requires exactly one of `workflowId` or `stepId`",
-        );
+        ctx.error("`goto` requires exactly one of `workflowId` or `stepId`");
     }
 }
 
@@ -88,8 +84,8 @@ mod tests {
     use serde_json::json;
 
     fn validate(a: &SuccessAction) -> Vec<String> {
-        let mut ctx = Context::new(EnumSet::empty());
-        a.validate_with_context(&mut ctx, "#.a".into());
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.a");
+        a.validate_with_context(&mut ctx);
         ctx.errors.iter().map(ToString::to_string).collect()
     }
 

--- a/crates/roas-arazzo/src/v1_0/workflow.rs
+++ b/crates/roas-arazzo/src/v1_0/workflow.rs
@@ -9,9 +9,7 @@ use crate::v1_0::parameter::Parameter;
 use crate::v1_0::reusable::ReusableOr;
 use crate::v1_0::step::Step;
 use crate::v1_0::success_action::SuccessAction;
-use crate::validation::{
-    Context, ValidateWithContext, validate_map_keys, validate_required_string,
-};
+use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -74,35 +72,33 @@ pub struct Workflow {
 }
 
 impl ValidateWithContext for Workflow {
-    fn validate_with_context(&self, ctx: &mut Context, path: String) {
-        validate_required_string(&self.workflow_id, ctx, format!("{path}.workflowId"));
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("workflowId", &self.workflow_id);
 
         if self.steps.is_empty() {
-            ctx.error(format!("{path}.steps"), "must contain at least one entry");
+            ctx.error_field("steps", "must contain at least one entry");
         }
 
         let mut seen_step_ids = std::collections::BTreeSet::new();
         for (i, step) in self.steps.iter().enumerate() {
-            let step_path = format!("{path}.steps[{i}]");
-            step.validate_with_context(ctx, step_path.clone());
-            if !step.step_id.is_empty() && !seen_step_ids.insert(step.step_id.as_str()) {
-                ctx.error(
-                    format!("{step_path}.stepId"),
-                    format!("duplicate stepId `{}`", step.step_id),
-                );
-            }
+            ctx.in_index("steps", i, |ctx| {
+                step.validate_with_context(ctx);
+                if !step.step_id.is_empty() && !seen_step_ids.insert(step.step_id.as_str()) {
+                    ctx.error_field("stepId", format!("duplicate stepId `{}`", step.step_id));
+                }
+            });
         }
 
         for (i, parameter) in self.parameters.iter().enumerate() {
-            parameter.validate_with_context(ctx, format!("{path}.parameters[{i}]"));
+            ctx.in_index("parameters", i, |ctx| parameter.validate_with_context(ctx));
         }
         for (i, action) in self.success_actions.iter().enumerate() {
-            action.validate_with_context(ctx, format!("{path}.successActions[{i}]"));
+            ctx.in_index("successActions", i, |ctx| action.validate_with_context(ctx));
         }
         for (i, action) in self.failure_actions.iter().enumerate() {
-            action.validate_with_context(ctx, format!("{path}.failureActions[{i}]"));
+            ctx.in_index("failureActions", i, |ctx| action.validate_with_context(ctx));
         }
-        validate_map_keys(&self.outputs, ctx, &format!("{path}.outputs"));
+        ctx.validate_map_keys("outputs", &self.outputs);
     }
 }
 
@@ -113,8 +109,8 @@ mod tests {
     use serde_json::json;
 
     fn validate(wf: &Workflow) -> Vec<String> {
-        let mut ctx = Context::new(EnumSet::empty());
-        wf.validate_with_context(&mut ctx, "#.workflows[0]".into());
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.workflows[0]");
+        wf.validate_with_context(&mut ctx);
         ctx.errors.iter().map(ToString::to_string).collect()
     }
 

--- a/crates/roas-arazzo/src/validation.rs
+++ b/crates/roas-arazzo/src/validation.rs
@@ -2,21 +2,25 @@
 //!
 //! Modeled after [`roas::validation`] / `roas-overlay`: a public
 //! [`Validate`] trait drives a recursive descent through a
-//! crate-internal trait; each component pushes diagnostics into a
-//! context keyed by a JSONPath-flavor path string. Errors collect
+//! crate-internal trait. The current location is held as a single
+//! mutable path buffer on the [`Context`]; nodes `enter` a child
+//! segment, recurse, and the segment is truncated on the way out. The
+//! path string is cloned only when an error is actually recorded, so a
+//! valid document allocates no per-node path strings. Errors collect
 //! rather than fail fast.
 //!
 //! [`roas::validation`]: https://docs.rs/roas/latest/roas/validation/index.html
 
 use enumset::{EnumSet, EnumSetType};
 use std::collections::BTreeMap;
-use std::fmt::{self, Display};
+use std::fmt::{self, Display, Write};
 
 /// A single validation finding.
 ///
 /// `path` is a human-readable locator (e.g. `#.workflows[0].steps[1].stepId`),
 /// not an RFC 6901 JSON Pointer.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub struct ValidationError {
     pub path: String,
     pub message: String,
@@ -63,6 +67,7 @@ impl PartialEq<&str> for ValidationError {
 
 /// The accumulated outcome of a validation pass.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct Error {
     pub errors: Vec<ValidationError>,
 }
@@ -82,8 +87,10 @@ impl std::error::Error for Error {}
 /// Per-call validation toggles.
 ///
 /// Each option suppresses one shallow check so callers can opt out of
-/// individual diagnostics without disabling the whole validator.
+/// individual diagnostics without disabling the whole validator. Marked
+/// `#[non_exhaustive]` so future toggles are non-breaking additions.
 #[derive(EnumSetType, Debug)]
+#[non_exhaustive]
 pub enum ValidationOptions {
     /// Allow `info.title` to be empty (still required to be present).
     IgnoreEmptyInfoTitle,
@@ -118,14 +125,18 @@ pub trait Validate {
     fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error>;
 }
 
-/// Crate-internal: implemented by every component type.
+/// Crate-internal: implemented by every component type. The location is
+/// carried by [`Context`]'s path buffer rather than a per-call string.
 pub(crate) trait ValidateWithContext {
-    fn validate_with_context(&self, ctx: &mut Context, path: String);
+    fn validate_with_context(&self, ctx: &mut Context);
 }
 
 pub(crate) struct Context {
-    pub options: EnumSet<ValidationOptions>,
+    options: EnumSet<ValidationOptions>,
     pub errors: Vec<ValidationError>,
+    /// The current location, e.g. `#.workflows[0].steps[1]`. Mutated in
+    /// place via `in_*`; only cloned when an error is recorded.
+    path: String,
 }
 
 impl Context {
@@ -133,6 +144,7 @@ impl Context {
         Self {
             options,
             errors: Vec::new(),
+            path: "#".to_owned(),
         }
     }
 
@@ -140,8 +152,71 @@ impl Context {
         self.options.contains(option)
     }
 
-    pub fn error(&mut self, path: String, message: impl Into<String>) {
-        self.errors.push(ValidationError::new(path, message.into()));
+    /// Record an error at the current path.
+    pub fn error(&mut self, message: impl Into<String>) {
+        self.errors
+            .push(ValidationError::new(self.path.clone(), message.into()));
+    }
+
+    /// Record an error at `<current>.<field>` without descending into it.
+    pub fn error_field(&mut self, field: &str, message: impl Into<String>) {
+        let mark = self.path.len();
+        self.push_field(field);
+        self.error(message);
+        self.path.truncate(mark);
+    }
+
+    /// Push `.<field>` for the duration of `f`.
+    pub fn in_field<R>(&mut self, field: &str, f: impl FnOnce(&mut Self) -> R) -> R {
+        let mark = self.path.len();
+        self.push_field(field);
+        let result = f(self);
+        self.path.truncate(mark);
+        result
+    }
+
+    /// Push `.<field>[<index>]` for the duration of `f`.
+    pub fn in_index<R>(&mut self, field: &str, index: usize, f: impl FnOnce(&mut Self) -> R) -> R {
+        let mark = self.path.len();
+        self.push_field(field);
+        let _ = write!(self.path, "[{index}]");
+        let result = f(self);
+        self.path.truncate(mark);
+        result
+    }
+
+    /// Push `.<field>.<key>` for the duration of `f` (for map entries).
+    pub fn in_key<R>(&mut self, field: &str, key: &str, f: impl FnOnce(&mut Self) -> R) -> R {
+        let mark = self.path.len();
+        self.push_field(field);
+        self.push_field(key);
+        let result = f(self);
+        self.path.truncate(mark);
+        result
+    }
+
+    /// Error at `<current>.<field>` if the required string is empty.
+    pub fn require_non_empty(&mut self, field: &str, value: &str) {
+        if value.is_empty() {
+            self.error_field(field, "must not be empty");
+        }
+    }
+
+    /// Validate that every key in a map matches the component / output
+    /// key pattern `^[a-zA-Z0-9\.\-_]+$`, reported under `.<field>`.
+    pub fn validate_map_keys<V>(&mut self, field: &str, map: &BTreeMap<String, V>) {
+        self.in_field(field, |ctx| {
+            for key in map.keys() {
+                if !is_valid_key(key) {
+                    ctx.error_field(key, r"key must match `^[a-zA-Z0-9\.\-_]+$`");
+                }
+            }
+        });
+    }
+
+    fn push_field(&mut self, field: &str) {
+        self.path.push('.');
+        self.path.push_str(field);
     }
 
     pub fn into_result(self) -> Result<(), Error> {
@@ -153,12 +228,14 @@ impl Context {
             })
         }
     }
-}
 
-/// Validate that a required string is not empty.
-pub(crate) fn validate_required_string(s: &str, ctx: &mut Context, path: String) {
-    if s.is_empty() {
-        ctx.error(path, "must not be empty");
+    #[cfg(test)]
+    pub fn with_path(options: EnumSet<ValidationOptions>, path: &str) -> Self {
+        Self {
+            options,
+            errors: Vec::new(),
+            path: path.to_owned(),
+        }
     }
 }
 
@@ -177,19 +254,6 @@ pub(crate) fn is_valid_key(s: &str) -> bool {
     !s.is_empty()
         && s.bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-' || b == b'_')
-}
-
-/// Validate that every key in a map matches the component / output key
-/// pattern `^[a-zA-Z0-9\.\-_]+$`.
-pub(crate) fn validate_map_keys<V>(map: &BTreeMap<String, V>, ctx: &mut Context, path: &str) {
-    for key in map.keys() {
-        if !is_valid_key(key) {
-            ctx.error(
-                format!("{path}.{key}"),
-                r"key must match `^[a-zA-Z0-9\.\-_]+$`",
-            );
-        }
-    }
 }
 
 #[cfg(test)]
@@ -235,12 +299,34 @@ mod tests {
     }
 
     #[test]
-    fn context_collects_errors_and_converts_to_result() {
+    fn error_records_at_current_path() {
         let mut ctx = Context::new(EnumSet::empty());
-        ctx.error("#.x".into(), "kaboom");
-        let r = ctx.into_result();
-        let err = r.unwrap_err();
-        assert_eq!(err.errors.len(), 1);
+        ctx.error("kaboom");
+        assert!(ctx.errors[0] == "#: kaboom");
+    }
+
+    #[test]
+    fn in_scopes_compose_and_truncate() {
+        let mut ctx = Context::new(EnumSet::empty());
+        ctx.in_index("workflows", 0, |ctx| {
+            ctx.in_index("steps", 1, |ctx| {
+                ctx.error_field("stepId", "bad");
+            });
+            // back to #.workflows[0] after inner scope
+            ctx.error("here");
+        });
+        // back to # after outer scope
+        ctx.error("root");
+        assert!(ctx.errors[0] == "#.workflows[0].steps[1].stepId: bad");
+        assert!(ctx.errors[1] == "#.workflows[0]: here");
+        assert!(ctx.errors[2] == "#: root");
+    }
+
+    #[test]
+    fn in_key_appends_dotted_key() {
+        let mut ctx = Context::new(EnumSet::empty());
+        ctx.in_key("parameters", "petId", |ctx| ctx.error("oops"));
+        assert!(ctx.errors[0] == "#.parameters.petId: oops");
     }
 
     #[test]
@@ -258,10 +344,12 @@ mod tests {
     }
 
     #[test]
-    fn validate_required_string_pushes_error_for_empty() {
+    fn require_non_empty_pushes_error_for_empty_only() {
         let mut ctx = Context::new(EnumSet::empty());
-        validate_required_string("", &mut ctx, "#.info.title".into());
-        validate_required_string("ok", &mut ctx, "#.info.version".into());
+        ctx.in_field("info", |ctx| {
+            ctx.require_non_empty("title", "");
+            ctx.require_non_empty("version", "ok");
+        });
         assert_eq!(ctx.errors.len(), 1);
         assert!(ctx.errors[0] == "#.info.title: must not be empty");
     }


### PR DESCRIPTION
Performance / idiom follow-up from the review on #193, applied to `roas-arazzo`. (Companion PRs apply the same changes to `roas` and `roas-overlay`.)

- **Validator allocates no per-node path strings.** `Context` now holds a single mutable path buffer; nodes `enter` a child segment, recurse, and the segment is truncated on the way out. The path is cloned only when an error is actually recorded. `ValidateWithContext` drops its `path` argument.
- **`ReusableOr<T>` one-pass `Deserialize`.** Replaces `#[serde(untagged)]` with a hand-written impl that dispatches on the discriminating `reference` key, then deserializes only the chosen variant — no double-parse, and a malformed `Item` surfaces its real error (e.g. `missing field \`name\``) instead of "data did not match any variant".
- **`#[non_exhaustive]`** on the public `Error` / `ValidationError` / `ValidationOptions` so future additions are non-breaking.
- **`serializer.serialize_none()`** on the extensions `None` path.
- **`FailureAction.retryAfter`** now rejects `NaN` as well as negatives.

No behavior change to valid/invalid outcomes or diagnostic paths. Verified: `cargo fmt`, clippy `--all-features --all-targets -D warnings`, 90 crate tests, doctests, and a full `--workspace` build all pass.
