### PR TITLE
chore(roas-overlay): bump to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "roas-overlay"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas-overlay/Cargo.toml
+++ b/crates/roas-overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-overlay"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumps \`roas-overlay\` 0.1.0 → 0.2.0.

0.1.0 is published on crates.io. The merged #195 added `#[non_exhaustive]` to the public `Error` / `ValidationError` / `ValidationOptions` types — a breaking change for downstream consumers — so the minor is bumped per semver for 0.x crates.

Lockfile-only otherwise; `roas-cli` depends via `>=0.1`, so no dependent edits are needed and the workspace builds.
