### PR TITLE
chore(roas): bump to 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "roas"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas/Cargo.toml
+++ b/crates/roas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.17.0"
+version = "0.17.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumps \`roas\` 0.17.0 → 0.17.1 (patch).

Picks up the enumset 1.1.12 → 1.1.13 bump (#197), a shared workspace dependency `roas` uses for `EnumSet<Options>`. No source changes in `roas` itself.

Lockfile + `Cargo.toml` only; dependents use `>=` requirements, so the workspace resolves and builds unchanged.
