### PR TITLE
chore(roas-cli): raise minimum roas-crate dependency versions

### DIFF
--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -18,10 +18,10 @@ name = "roas"
 path = "src/main.rs"
 
 [dependencies]
-roas = { version = ">=0.15", path = "../roas", features = ["clap", "v2", "v3_0", "v3_1", "v3_2"] }
-roas-overlay = { version = ">=0.1", path = "../roas-overlay", features = ["clap", "v1_0", "v1_1"] }
+roas = { version = ">=0.17", path = "../roas", features = ["clap", "v2", "v3_0", "v3_1", "v3_2"] }
+roas-overlay = { version = ">=0.2", path = "../roas-overlay", features = ["clap", "v1_0", "v1_1"] }
 roas-file-fetcher = { version = ">=0.1", path = "../roas-file-fetcher", features = ["yaml"] }
-roas-http-fetcher = { version = ">=0.1", path = "../roas-http-fetcher", features = ["yaml"] }
+roas-http-fetcher = { version = ">=0.2", path = "../roas-http-fetcher", features = ["yaml"] }
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true


### PR DESCRIPTION
All roas-family crates are published at newer versions; raise roas-cli's minimum dependency requirements to the current release lines.

| dependency | before | after | published |
|---|---|---|---|
| `roas` | `>=0.15` | `>=0.17` | 0.17.1 |
| `roas-overlay` | `>=0.1` | `>=0.2` | 0.2.0 |
| `roas-http-fetcher` | `>=0.1` | `>=0.2` | 0.2.0 |
| `roas-file-fetcher` | `>=0.1` | _(unchanged)_ | 0.1.0 |

Minor-granular floors, matching the existing style. `Cargo.lock` is unchanged (path deps already resolve to these). `roas-cli` itself is not bumped here — its next release will carry the tightened requirements.
