### PR TITLE
docs(roas-cli): fix unresolved intra-doc link to hyper

### DIFF
--- a/crates/roas-cli/src/preview.rs
+++ b/crates/roas-cli/src/preview.rs
@@ -14,7 +14,7 @@
 //!     page-side `EventSource` subscriber calls `window.location.reload()` on
 //!     every event.
 //!
-//! Backed by [`axum`] on top of [`tokio`] / [`hyper`]; the per-process tokio
+//! Backed by [`axum`] on top of [`tokio`] / `hyper`; the per-process tokio
 //! runtime is constructed inside [`run_preview`] so the rest of the CLI
 //! stays sync.
 


### PR DESCRIPTION
`hyper` is a transitive (not direct) dependency of `roas-cli`, so the `[`hyper`]` shortcut intra-doc link in `preview.rs` does not resolve — it breaks `cargo doc` under `-D warnings` (pre-existing, surfaced while documenting the new arazzo module).

Drops the link brackets while keeping the code formatting; `axum` / `tokio` stay linked since they are direct deps.

Verified: `RUSTDOCFLAGS="-D warnings" cargo doc -p roas-cli --no-deps` is now clean.
