### PR TITLE
chore(roas-cli): bump to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumps `roas-cli` 0.9.0 → 0.10.0 (minor).

Note: main was already at 0.9.0 — the arazzo subcommand PR (#201) bundled that bump — so a fresh minor bump lands at 0.10.0. Published on crates.io is still 0.8.0, so this release will carry both the arazzo group and the doc-link fix (#202).

Lockfile + `Cargo.toml` only.
