### PR TITLE
fix(ci): pin cosign to v2.6.3 (unbreak release signing)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -192,6 +192,10 @@ jobs:
       # / `gh attestation verify` both work.
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin to the 2.6 line for parity with release-stage.yaml and to
+          # avoid cosign 3.x default-behavior changes in keyless signing.
+          cosign-release: "v2.6.3"
 
       - name: Sign roas-cli container image with cosign (keyless)
         env:

--- a/.github/workflows/release-stage.yaml
+++ b/.github/workflows/release-stage.yaml
@@ -272,6 +272,12 @@ jobs:
       #     <archive>
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin to the 2.6 line. cosign 3.0.0 flipped `sign-blob` to the
+          # new protobuf bundle format by default, which ignores
+          # `--output-signature` / `--output-certificate` and breaks the
+          # `<archive>.sig` / `<archive>.crt` outputs this job relies on.
+          cosign-release: "v2.6.3"
       - name: Sign release tarballs with cosign (keyless)
         env:
           COSIGN_YES: "true"


### PR DESCRIPTION
## Problem

The release `AttachRoasCliBinaries` job failed at the cosign signing step:

```
Error: signing artifacts/roas-0.9.0-aarch64-apple-darwin.tar.gz: create bundle file: open : no such file or directory
```

**Root cause:** [cosign 3.0.0](https://github.com/sigstore/cosign/releases) made the new protobuf *bundle* format the default for `sign-blob`. In that mode the deprecated `--output-signature` / `--output-certificate` flags are ignored and cosign expects `--bundle <path>`; with none given it tries to open an empty path and dies. The `cosign-installer` step was pinned by SHA but did **not** pin the cosign *binary*, so CI silently upgraded to 3.x.

## Fix

Pin cosign to the maintained **v2.6.3** line (released April 2026, alongside v3.0.6) in both `release-stage.yaml` and `publish.yaml`. v2.6.x predates the default flip, so the existing signing command, the `<archive>.sig` / `<archive>.crt` release assets, and the documented `verify-blob` recipe all stay unchanged.

## Follow-up (not in this PR)

Migrating to cosign 3.x + `--bundle` is the longer-term path, but it changes the public release artifacts (`.sig`/`.crt` → `.bundle`) and the verification recipe — worth a deliberate PR with release notes rather than a hotfix.
