### PR TITLE
ci(checks): allow manual runs via workflow_dispatch

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
   workflow_call:
     secrets:
       CODECOV_TOKEN:


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `.github/workflows/checks.yaml` so the **Rust** workflow can be triggered manually from the Actions UI (or `gh workflow run checks.yaml`). The existing `push` / `pull_request` / `workflow_call` / `schedule` triggers are unchanged.