### PR TITLE
fix(doctests): make crate-level examples build without v1_0

### DIFF
--- a/crates/roas-arazzo/src/lib.rs
+++ b/crates/roas-arazzo/src/lib.rs
@@ -17,6 +17,11 @@
 //! ## Parsing and validating
 //!
 //! ```rust
+//! # // Gate the example on the v1_0 feature so it stays valid under any
+//! # // feature combination (e.g. `--no-default-features --features v1_1`).
+//! # // The hidden cfg block is removed entirely when v1_0 is off, so the
+//! # // doctest compiles to an empty `fn main()` in that case.
+//! # #[cfg(feature = "v1_0")] {
 //! use enumset::EnumSet;
 //! use roas_arazzo::v1_0::Description;
 //! use roas_arazzo::validation::Validate;
@@ -44,6 +49,7 @@
 //!
 //! doc.validate(EnumSet::empty()).expect("description is well-formed");
 //! assert_eq!(doc.workflows[0].workflow_id, "getPet");
+//! # }
 //! ```
 //!
 //! YAML descriptions work the same way — parse with `serde_yaml_ng` (or

--- a/crates/roas-overlay/src/lib.rs
+++ b/crates/roas-overlay/src/lib.rs
@@ -21,6 +21,11 @@
 //! ## Applying an overlay
 //!
 //! ```no_run
+//! # // Gate the example on the v1_0 feature so it stays valid under any
+//! # // feature combination (e.g. `--no-default-features --features v1_1`).
+//! # // The hidden cfg block is removed entirely when v1_0 is off, so the
+//! # // doctest compiles to an empty `fn main()` in that case.
+//! # #[cfg(feature = "v1_0")] {
 //! use enumset::EnumSet;
 //! use roas_overlay::apply::Apply;
 //! use roas_overlay::v1_0::Overlay;
@@ -45,6 +50,7 @@
 //! let report = overlay.apply(&mut target, EnumSet::empty()).unwrap();
 //! assert_eq!(report.actions.len(), 1);
 //! assert_eq!(target["info"]["description"], "Patched.");
+//! # }
 //! ```
 
 pub mod apply;


### PR DESCRIPTION
The `roas-overlay` and `roas-arazzo` crate-level doctests in `lib.rs` use the v1.0 types unconditionally (`roas_overlay::v1_0::Overlay`, `roas_arazzo::v1_0::Description`). When `v1_0` is disabled — e.g. `cargo test -p roas-arazzo --no-default-features --features=v1_1 --no-fail-fast --verbose` — the modules are configured out and the doctests fail with `E0432: unresolved import`.

CI missed it because `cargo llvm-cov nextest` does not run doctests at all — they need rustdoc's harness, not nextest's. A follow-up PR adds a `cargo test --doc` step so this class of regression gets caught going forward.

**Fix:** wrap each example body with a hidden `#[cfg(feature = "v1_0")] { ... }` block. Hidden `# ` lines are stripped from rendered docs but compiled; under `v1_0` off the block is removed entirely and the doctest compiles to an empty `fn main()`.

Verified `cargo test --doc -p <crate>` for every relevant combo — `v1_0`, `v1_1`, `v1_0,v1_1` — on both crates. The originally failing command now passes:

```
cargo test --package=roas-arazzo --features=v1_1 --no-default-features --no-fail-fast --verbose
# test result: ok. 2 passed; 0 failed
```