### PR TITLE
ci(checks): run doctests so feature-combo regressions get caught

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -88,6 +88,13 @@ jobs:
       - run: cargo install-tools
       - name: Run tests
         run: cargo llvm-cov nextest ${{ matrix.args }} --all-targets --no-fail-fast --no-tests=pass --verbose
+      # nextest does not execute doctests, so run them with the
+      # standard test harness. Doctests don't contribute to the
+      # llvm-cov report (stable `cargo llvm-cov` skips them), but they
+      # must still be exercised — otherwise a v1_0-only doctest
+      # against a v1_1-only feature combo silently never runs.
+      - name: Run doctests
+        run: cargo test --doc ${{ matrix.args }} --no-fail-fast --verbose
       - name: Prepare coverage report
         if: ${{ !cancelled() }}
         run: cargo llvm-cov report --lcov --output-path coverage.lcov

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -94,8 +94,25 @@ jobs:
       # llvm-cov report (stable `cargo llvm-cov` skips them), but they
       # must still be exercised — otherwise a v1_0-only doctest
       # against a v1_1-only feature combo silently never runs.
+      #
+      # Bin-only crates (e.g. `roas-cli`) have no library target, and
+      # `cargo test --doc` bails with "no library targets found" before
+      # it even starts. Treat that specific error as a skip; surface
+      # every other failure.
       - name: Run doctests
-        run: cargo test --doc ${{ matrix.args }} --no-fail-fast --verbose
+        shell: bash
+        run: |
+          log=$(cargo test --doc ${{ matrix.args }} --no-fail-fast --verbose 2>&1) || rc=$?
+          rc=${rc:-0}
+          printf '%s\n' "$log"
+          if [[ $rc -eq 0 ]]; then
+            exit 0
+          fi
+          if grep -qF "no library targets found" <<< "$log"; then
+            echo "::notice::doctests skipped — package has no library target"
+            exit 0
+          fi
+          exit $rc
       - name: Prepare coverage report
         if: ${{ !cancelled() }}
         run: cargo llvm-cov report --lcov --output-path coverage.lcov


### PR DESCRIPTION
**Depends on #215** — that PR fixes the crate-level doctests so this step has nothing to fail on once both land.

## What

Adds a `cargo test --doc ${{ matrix.args }} --no-fail-fast --verbose` step in `TestJob` right after the nextest run. `cargo llvm-cov nextest` does not execute doctests (they need rustdoc's harness, not nextest's), so the existing matrix never exercised them — that's exactly how the broken roas-arazzo / roas-overlay crate-level doctests slipped through under `--no-default-features --features v1_1`.

## Trade-off

Doctests do not contribute to the llvm-cov coverage report (stable `cargo llvm-cov` skips them; `--doctests` is experimental and nightly-only). That's the right call for now — correctness coverage matters more than doctest line-coverage attribution, and the existing nextest coverage is unchanged.

## Merge order

#215 first, then this. Until #215 lands, this PR's own checks will catch the very bug #215 fixes (which is, in a sense, the point — it demonstrates the new step works).