### PR TITLE
docs: add CLAUDE.md pointing to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md


### PR DESCRIPTION
Claude Code reads CLAUDE.md rather than AGENTS.md, so this adds a one-line CLAUDE.md that imports AGENTS.md instead of duplicating the instructions.