### PR TITLE
chore(release): bump all crates for dependency-floor refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "roas"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "clap",
  "enumset",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "roas-arazzo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "enumset",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "roas-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "roas-file-fetcher"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "roas",
  "serde",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "roas-http-fetcher"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "reqwest",
  "roas",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "roas-overlay"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas-arazzo/Cargo.toml
+++ b/crates/roas-arazzo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-arazzo"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas-cli/Cargo.toml
+++ b/crates/roas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-cli"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas-file-fetcher/Cargo.toml
+++ b/crates/roas-file-fetcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-file-fetcher"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas-http-fetcher/Cargo.toml
+++ b/crates/roas-http-fetcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-http-fetcher"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas-overlay/Cargo.toml
+++ b/crates/roas-overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-overlay"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas/Cargo.toml
+++ b/crates/roas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas"
-version = "0.17.2"
+version = "0.17.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Patch bumps across the workspace so crates.io picks up the refreshed dependency floors merged since the last round of tags.

- roas 0.17.2 → 0.17.3
- roas-arazzo 0.1.1 → 0.1.2
- roas-overlay 0.2.1 → 0.2.2
- roas-file-fetcher 0.1.1 → 0.1.2
- roas-http-fetcher 0.2.1 → 0.2.2
- roas-cli 0.9.1 → 0.9.2

No runtime behavior changes for any consumer. The only published deltas are the workspace dependency floors (serde_json 1.0.143 → 1.0.150, reqwest 0.13.3 → 0.13.4) and the doctest cfg-gate in the roas-arazzo and roas-overlay crate-level docs from #215. Everything else merged in the range was CI workflows, Actions bumps, and Cargo.lock.

Tags should be pushed in dependency order after this merges: roas / roas-overlay / roas-arazzo first, then the two fetchers, then roas-cli last so its binaries build against the published libs.