### PR TITLE
roas-arazzo: make v1_1 the default feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "roas-arazzo"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas-arazzo/Cargo.toml
+++ b/crates/roas-arazzo/Cargo.toml
@@ -13,6 +13,11 @@ categories = ["web-programming", "parser-implementations"]
 include = ["src", "Cargo.toml", "README.md"]
 publish = true
 
+# Document every version module on docs.rs, not just the default one,
+# so the `v1_0` / `v1_1` intra-doc links in the crate docs resolve.
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["v1_1"]
 # Support for Arazzo v1.0.x.

--- a/crates/roas-arazzo/Cargo.toml
+++ b/crates/roas-arazzo/Cargo.toml
@@ -7,19 +7,19 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 keywords = ["openapi", "arazzo", "workflow", "swagger", "validation"]
-description = "Rust implementation of the OpenAPI Arazzo Specification v1.0 — parse and validate"
+description = "Rust implementation of the OpenAPI Arazzo Specification v1.0 / v1.1 — parse and validate"
 readme = "README.md"
 categories = ["web-programming", "parser-implementations"]
 include = ["src", "Cargo.toml", "README.md"]
 publish = true
 
 [features]
-default = ["v1_0"]
+default = ["v1_1"]
 # Support for Arazzo v1.0.x.
 v1_0 = []
-# Support for Arazzo v1.1.x. Independent of `v1_0`; enable both to get
-# the additional `From<v1_0::Description> for v1_1::Description`
-# upconversion impl.
+# Support for Arazzo v1.1.x (default). Independent of `v1_0`; enable
+# both to get the additional `From<v1_0::Description> for
+# v1_1::Description` upconversion impl.
 v1_1 = []
 
 # `clap::ValueEnum` impls for `validation::ValidationOptions`, for

--- a/crates/roas-arazzo/Cargo.toml
+++ b/crates/roas-arazzo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-arazzo"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/roas-arazzo/README.md
+++ b/crates/roas-arazzo/README.md
@@ -1,6 +1,6 @@
 # roas-arazzo
 
-Rust implementation of the [OpenAPI Arazzo Specification](https://spec.openapis.org/arazzo/v1.1.0.html): parse and validate Arazzo workflow descriptions.
+Rust implementation of the OpenAPI Arazzo Specification ([v1.0](https://spec.openapis.org/arazzo/v1.0.1.html) / [v1.1](https://spec.openapis.org/arazzo/v1.1.0.html)): parse and validate Arazzo workflow descriptions.
 
 [![crates.io](https://img.shields.io/crates/v/roas-arazzo.svg)](https://crates.io/crates/roas-arazzo)
 [![docs.rs](https://docs.rs/roas-arazzo/badge.svg)](https://docs.rs/roas-arazzo)

--- a/crates/roas-arazzo/README.md
+++ b/crates/roas-arazzo/README.md
@@ -1,6 +1,6 @@
 # roas-arazzo
 
-Rust implementation of the [OpenAPI Arazzo Specification](https://spec.openapis.org/arazzo/v1.0.1.html): parse and validate Arazzo workflow descriptions.
+Rust implementation of the [OpenAPI Arazzo Specification](https://spec.openapis.org/arazzo/v1.1.0.html): parse and validate Arazzo workflow descriptions.
 
 [![crates.io](https://img.shields.io/crates/v/roas-arazzo.svg)](https://crates.io/crates/roas-arazzo)
 [![docs.rs](https://docs.rs/roas-arazzo/badge.svg)](https://docs.rs/roas-arazzo)
@@ -13,8 +13,8 @@ This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed pa
 
 | Arazzo version | Feature flag     | Status         | Adds over the previous version                                              |
 |----------------|------------------|----------------|-----------------------------------------------------------------------------|
-| 1.0            | `v1_0` (default) | ✅ implemented  | —                                                                           |
-| 1.1            | `v1_1`           | ✅ implemented  | `$self`, AsyncAPI steps, selectors, expression types, action `parameters`  |
+| 1.0            | `v1_0`           | ✅ implemented  | —                                                                           |
+| 1.1            | `v1_1` (default) | ✅ implemented  | `$self`, AsyncAPI steps, selectors, expression types, action `parameters`  |
 
 `v1_0` and `v1_1` are independent — enable whichever you need. With both enabled, an `impl From<v1_0::Description> for v1_1::Description` upconverts an existing v1.0 description.
 
@@ -24,11 +24,11 @@ Authoritative JSON Schemas: [v1.0](https://spec.openapis.org/arazzo/1.0/schema/2
 
 ```rust
 use enumset::EnumSet;
-use roas_arazzo::v1_0::Description;
+use roas_arazzo::v1_1::Description;
 use roas_arazzo::validation::Validate;
 
 let doc: Description = serde_json::from_str(r#"{
-    "arazzo": "1.0.1",
+    "arazzo": "1.1.0",
     "info": { "title": "Example", "version": "1.0.0" },
     "sourceDescriptions": [
         { "name": "petStore", "url": "https://api.example.com/openapi.json", "type": "openapi" }

--- a/crates/roas-arazzo/src/lib.rs
+++ b/crates/roas-arazzo/src/lib.rs
@@ -1,6 +1,6 @@
 //! OpenAPI Arazzo Specification — parser and validator.
 //!
-//! Implements the [Arazzo Specification](https://spec.openapis.org/arazzo/v1.0.1.html):
+//! Implements the [Arazzo Specification](https://spec.openapis.org/arazzo/v1.1.0.html):
 //! a document format that describes sequences of API calls (*workflows*)
 //! and their dependencies, independent of the underlying OpenAPI
 //! descriptions they orchestrate.
@@ -13,22 +13,23 @@
 //!   [`ValidationOptions`](validation::ValidationOptions) flag set,
 //!   `Context` / `ValidationError` types.
 //! - [`v1_0`] — Arazzo v1.0 document model + `Validate` impls.
+//! - [`v1_1`] — Arazzo v1.1 document model + `Validate` impls.
 //!
 //! ## Parsing and validating
 //!
 //! ```rust
-//! # // Gate the example on the v1_0 feature so it stays valid under any
-//! # // feature combination (e.g. `--no-default-features --features v1_1`).
-//! # // The hidden cfg block is removed entirely when v1_0 is off, so the
+//! # // Gate the example on the v1_1 feature so it stays valid under any
+//! # // feature combination (e.g. `--no-default-features --features v1_0`).
+//! # // The hidden cfg block is removed entirely when v1_1 is off, so the
 //! # // doctest compiles to an empty `fn main()` in that case.
-//! # #[cfg(feature = "v1_0")] {
+//! # #[cfg(feature = "v1_1")] {
 //! use enumset::EnumSet;
-//! use roas_arazzo::v1_0::Description;
+//! use roas_arazzo::v1_1::Description;
 //! use roas_arazzo::validation::Validate;
 //!
 //! // Parse an Arazzo description (JSON or YAML).
 //! let doc: Description = serde_json::from_str(r#"{
-//!     "arazzo": "1.0.1",
+//!     "arazzo": "1.1.0",
 //!     "info": { "title": "Example", "version": "1.0.0" },
 //!     "sourceDescriptions": [
 //!         { "name": "petStore", "url": "https://api.example.com/openapi.json", "type": "openapi" }
@@ -53,11 +54,11 @@
 //! ```
 //!
 //! YAML descriptions work the same way — parse with `serde_yaml_ng` (or
-//! any other YAML crate) into [`v1_0::Description`].
+//! any other YAML crate) into [`v1_1::Description`].
 //!
 //! ## Versions
 //!
-//! v1.0.x ([`v1_0`], default feature) and v1.1.x ([`v1_1`]) are both
+//! v1.0.x ([`v1_0`]) and v1.1.x ([`v1_1`], default feature) are both
 //! implemented; enable whichever you need. With both features enabled,
 //! an `impl From<v1_0::Description> for v1_1::Description` is available
 //! for upconverting an existing v1.0 description.

--- a/crates/roas-arazzo/src/lib.rs
+++ b/crates/roas-arazzo/src/lib.rs
@@ -1,6 +1,8 @@
 //! OpenAPI Arazzo Specification — parser and validator.
 //!
-//! Implements the [Arazzo Specification](https://spec.openapis.org/arazzo/v1.1.0.html):
+//! Implements the Arazzo Specification
+//! ([v1.0](https://spec.openapis.org/arazzo/v1.0.1.html) /
+//! [v1.1](https://spec.openapis.org/arazzo/v1.1.0.html)):
 //! a document format that describes sequences of API calls (*workflows*)
 //! and their dependencies, independent of the underlying OpenAPI
 //! descriptions they orchestrate.


### PR DESCRIPTION
`roas-arazzo`'s `default` feature now selects `v1_1` instead of `v1_0`, matching the `roas` crate where the newest supported spec version is the default. Crate docs and README follow: the quick-start example parses a `1.1.0` description via `v1_1::Description`, the version table marks `v1_1` as default, the module list mentions both version modules, and the crate description/spec links cover v1.0 and v1.1.

Breaking for downstream consumers that rely on default features: `roas_arazzo::v1_0` is no longer compiled unless `features = ["v1_0"]` is added, so the crate is bumped 0.1.2 → 0.2.0. `roas-cli` already enables both versions explicitly and is unaffected.

The same change for `roas-overlay` is #236.