### PR TITLE
roas-overlay: make v1_1 the default feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "roas-overlay"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "enumset",

--- a/crates/roas-overlay/Cargo.toml
+++ b/crates/roas-overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roas-overlay"
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -14,12 +14,12 @@ include = ["src", "Cargo.toml", "README.md"]
 publish = true
 
 [features]
-default = ["v1_0"]
+default = ["v1_1"]
 # Support for OpenAPI Overlay v1.0.x.
 v1_0 = []
-# Support for OpenAPI Overlay v1.1.x. Independent of `v1_0`; enable
-# both to get the additional `From<v1_0::Overlay> for v1_1::Overlay`
-# upconversion impl.
+# Support for OpenAPI Overlay v1.1.x (default). Independent of `v1_0`;
+# enable both to get the additional `From<v1_0::Overlay> for
+# v1_1::Overlay` upconversion impl.
 v1_1 = []
 
 # `clap::ValueEnum` impls for `apply::ApplyOptions` and

--- a/crates/roas-overlay/Cargo.toml
+++ b/crates/roas-overlay/Cargo.toml
@@ -13,6 +13,11 @@ categories = ["web-programming", "parser-implementations"]
 include = ["src", "Cargo.toml", "README.md"]
 publish = true
 
+# Document every version module on docs.rs, not just the default one,
+# so the `v1_0` / `v1_1` intra-doc links in the crate docs resolve.
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["v1_1"]
 # Support for OpenAPI Overlay v1.0.x.

--- a/crates/roas-overlay/README.md
+++ b/crates/roas-overlay/README.md
@@ -1,6 +1,6 @@
 # roas-overlay
 
-Rust implementation of the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html): parse, validate, and apply Overlay documents to OpenAPI specs.
+Rust implementation of the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.1.0.html): parse, validate, and apply Overlay documents to OpenAPI specs.
 
 [![crates.io](https://img.shields.io/crates/v/roas-overlay.svg)](https://crates.io/crates/roas-overlay)
 [![docs.rs](https://docs.rs/roas-overlay/badge.svg)](https://docs.rs/roas-overlay)
@@ -13,8 +13,8 @@ This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed pa
 
 | Overlay version | Feature flag     | Status         | Adds over the previous version                     |
 |-----------------|------------------|----------------|----------------------------------------------------|
-| 1.0             | `v1_0` (default) | ✅ implemented  | —                                                  |
-| 1.1             | `v1_1`           | ✅ implemented  | `copy` action, `info.description`                  |
+| 1.0             | `v1_0`           | ✅ implemented  | —                                                  |
+| 1.1             | `v1_1` (default) | ✅ implemented  | `copy` action, `info.description`                  |
 
 `v1_0` and `v1_1` are independent — enable whichever you need. With both enabled, an `impl From<v1_0::Overlay> for v1_1::Overlay` is available for upconverting an existing v1.0 document.
 
@@ -23,11 +23,11 @@ This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed pa
 ```rust
 use enumset::EnumSet;
 use roas_overlay::apply::Apply;
-use roas_overlay::v1_0::Overlay;
+use roas_overlay::v1_1::Overlay;
 use roas_overlay::validation::Validate;
 
 let overlay: Overlay = serde_json::from_str(r#"{
-    "overlay": "1.0.0",
+    "overlay": "1.1.0",
     "info": { "title": "Example", "version": "1.0.0" },
     "actions": [
         { "target": "$.info", "update": { "description": "Patched." } },

--- a/crates/roas-overlay/README.md
+++ b/crates/roas-overlay/README.md
@@ -1,6 +1,6 @@
 # roas-overlay
 
-Rust implementation of the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.1.0.html): parse, validate, and apply Overlay documents to OpenAPI specs.
+Rust implementation of the OpenAPI Overlay Specification ([v1.0](https://spec.openapis.org/overlay/v1.0.0.html) / [v1.1](https://spec.openapis.org/overlay/v1.1.0.html)): parse, validate, and apply Overlay documents to OpenAPI specs.
 
 [![crates.io](https://img.shields.io/crates/v/roas-overlay.svg)](https://crates.io/crates/roas-overlay)
 [![docs.rs](https://docs.rs/roas-overlay/badge.svg)](https://docs.rs/roas-overlay)

--- a/crates/roas-overlay/src/lib.rs
+++ b/crates/roas-overlay/src/lib.rs
@@ -1,6 +1,6 @@
 //! OpenAPI Overlay Specification — parser, validator, and applier.
 //!
-//! Implements the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html):
+//! Implements the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.1.0.html):
 //! a sidecar document format that transforms OpenAPI documents through
 //! an ordered list of [JSONPath](https://www.rfc-editor.org/rfc/rfc9535)
 //! actions (`update`, `remove`, and v1.1's `copy`).
@@ -17,22 +17,23 @@
 //! - [`apply`] — [`Apply`](apply::Apply) trait, [`ApplyOptions`](apply::ApplyOptions),
 //!   [`ApplyReport`](apply::ApplyReport), [`ApplyError`](apply::ApplyError).
 //! - [`v1_0`] — Overlay v1.0 document model + `Validate` / `Apply` impls.
+//! - [`v1_1`] — Overlay v1.1 document model + `Validate` / `Apply` impls.
 //!
 //! ## Applying an overlay
 //!
 //! ```no_run
-//! # // Gate the example on the v1_0 feature so it stays valid under any
-//! # // feature combination (e.g. `--no-default-features --features v1_1`).
-//! # // The hidden cfg block is removed entirely when v1_0 is off, so the
+//! # // Gate the example on the v1_1 feature so it stays valid under any
+//! # // feature combination (e.g. `--no-default-features --features v1_0`).
+//! # // The hidden cfg block is removed entirely when v1_1 is off, so the
 //! # // doctest compiles to an empty `fn main()` in that case.
-//! # #[cfg(feature = "v1_0")] {
+//! # #[cfg(feature = "v1_1")] {
 //! use enumset::EnumSet;
 //! use roas_overlay::apply::Apply;
-//! use roas_overlay::v1_0::Overlay;
+//! use roas_overlay::v1_1::Overlay;
 //!
 //! // Parse the overlay document (JSON or YAML).
 //! let overlay: Overlay = serde_json::from_str(r#"{
-//!     "overlay": "1.0.0",
+//!     "overlay": "1.1.0",
 //!     "info": { "title": "Example", "version": "1.0.0" },
 //!     "actions": [
 //!         { "target": "$.info", "update": { "description": "Patched." } }
@@ -52,6 +53,13 @@
 //! assert_eq!(target["info"]["description"], "Patched.");
 //! # }
 //! ```
+//!
+//! ## Versions
+//!
+//! v1.0.x ([`v1_0`]) and v1.1.x ([`v1_1`], default feature) are both
+//! implemented; enable whichever you need. With both features enabled,
+//! an `impl From<v1_0::Overlay> for v1_1::Overlay` is available for
+//! upconverting an existing v1.0 document.
 
 pub mod apply;
 pub mod common;

--- a/crates/roas-overlay/src/lib.rs
+++ b/crates/roas-overlay/src/lib.rs
@@ -1,6 +1,8 @@
 //! OpenAPI Overlay Specification — parser, validator, and applier.
 //!
-//! Implements the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.1.0.html):
+//! Implements the OpenAPI Overlay Specification
+//! ([v1.0](https://spec.openapis.org/overlay/v1.0.0.html) /
+//! [v1.1](https://spec.openapis.org/overlay/v1.1.0.html)):
 //! a sidecar document format that transforms OpenAPI documents through
 //! an ordered list of [JSONPath](https://www.rfc-editor.org/rfc/rfc9535)
 //! actions (`update`, `remove`, and v1.1's `copy`).


### PR DESCRIPTION
`roas-overlay`'s `default` feature now selects `v1_1` instead of `v1_0`, matching the `roas` crate where the newest supported spec version is the default, and mirroring the same change for `roas-arazzo` (#235). Crate docs and README follow: the quick-start example parses a `1.1.0` overlay via `v1_1::Overlay`, the version table marks `v1_1` as default, the module list and a new Versions section cover both version modules, and the spec links point at v1.1.0.

Breaking for downstream consumers that rely on default features: `roas_overlay::v1_0` is no longer compiled unless `features = ["v1_0"]` is added, so the crate is bumped 0.2.2 → 0.3.0. `roas-cli` already enables both versions explicitly and is unaffected.