### PR TITLE
schemas: vendor JSON Schemas for every supported spec version

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,76 @@
+# Spec JSON Schemas
+
+Vendored copies of the authoritative JSON Schemas for every specification version implemented in this
+workspace. They are reference material for the typed models and validators — nothing in the build reads
+them.
+
+Each file is the latest published iteration as of 2026-08-02, downloaded verbatim from its source URL.
+
+## OpenAPI (`roas`)
+
+| Version | File                            | Source                                                       |
+|---------|---------------------------------|--------------------------------------------------------------|
+| 2.0     | `oas/2.0/schema.json`           | <https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/_archive_/schemas/v2.0/schema.json> |
+| 3.0.x   | `oas/3.0/schema.json`           | <https://spec.openapis.org/oas/3.0/schema/2024-10-18>         |
+| 3.1.x   | `oas/3.1/schema.json`           | <https://spec.openapis.org/oas/3.1/schema/2025-11-23>         |
+| 3.1.x   | `oas/3.1/schema-base.json`      | <https://spec.openapis.org/oas/3.1/schema-base/2025-11-23>    |
+| 3.1.x   | `oas/3.1/dialect.json`          | <https://spec.openapis.org/oas/3.1/dialect/2024-11-10>        |
+| 3.1.x   | `oas/3.1/meta.json`             | <https://spec.openapis.org/oas/3.1/meta/2024-11-10>           |
+| 3.2.x   | `oas/3.2/schema.json`           | <https://spec.openapis.org/oas/3.2/schema/2025-11-23>         |
+| 3.2.x   | `oas/3.2/schema-base.json`      | <https://spec.openapis.org/oas/3.2/schema-base/2025-11-23>    |
+| 3.2.x   | `oas/3.2/dialect.json`          | <https://spec.openapis.org/oas/3.2/dialect/2025-09-17>        |
+| 3.2.x   | `oas/3.2/meta.json`             | <https://spec.openapis.org/oas/3.2/meta/2025-09-17>           |
+
+OpenAPI 2.0 has no schema published on `spec.openapis.org`; the copy above is the archived
+`swagger.io/v2/schema.json` kept in the OpenAPI-Specification repository.
+
+For 3.1 and 3.2, `schema.json` validates a description against the base vocabulary, while
+`schema-base.json` additionally requires the OAS dialect (`dialect.json`, whose vocabulary is described
+by `meta.json`) for every embedded Schema Object.
+
+## Arazzo (`roas-arazzo`)
+
+| Version | File                      | Source                                                  |
+|---------|---------------------------|----------------------------------------------------------|
+| 1.0.x   | `arazzo/1.0/schema.json`  | <https://spec.openapis.org/arazzo/1.0/schema/2025-10-15> |
+| 1.1.x   | `arazzo/1.1/schema.json`  | <https://spec.openapis.org/arazzo/1.1/schema/2026-04-15> |
+
+## Overlay (`roas-overlay`)
+
+| Version | File                       | Source                                                    |
+|---------|----------------------------|------------------------------------------------------------|
+| 1.0.x   | `overlay/1.0/schema.json`  | <https://spec.openapis.org/overlay/1.0/schema/2026-04-01>  |
+| 1.1.x   | `overlay/1.1/schema.json`  | <https://spec.openapis.org/overlay/1.1/schema/2026-04-01>  |
+
+## AsyncAPI
+
+Reference material for the AsyncAPI documents that Arazzo v1.1 workflows can point at (AsyncAPI source
+descriptions and channel steps); no crate here parses AsyncAPI itself.
+
+| Version | File                        | Source                                                              |
+|---------|-----------------------------|----------------------------------------------------------------------|
+| 2.6.0   | `asyncapi/2.6.0/schema.json` | `asyncapi/spec-json-schemas` → `schemas/2.6.0.json` |
+| 3.0.0   | `asyncapi/3.0.0/schema.json` | `asyncapi/spec-json-schemas` → `schemas/3.0.0.json` |
+| 3.1.0   | `asyncapi/3.1.0/schema.json` | `asyncapi/spec-json-schemas` → `schemas/3.1.0.json` |
+
+Taken from [`asyncapi/spec-json-schemas`](https://github.com/asyncapi/spec-json-schemas) at commit
+`61cc6add7cf3467f56d1fbb55b1a2b78b4ae6323`; byte-identical to what
+<https://asyncapi.com/schema-store/> serves. These are the `$id`-bearing documents
+(`http://asyncapi.com/definitions/<version>/asyncapi.json`) — the repository also carries
+`-without-$id` twins, which are what
+[`all.schema-store.json`](https://www.asyncapi.com/schema-store/all.schema-store.json) `$ref`s so that
+schemastore.org can bundle every version in one file.
+
+Each document is self-contained: unlike the OpenAPI schemas, all bindings and Schema Object definitions
+are inlined, which is why they are an order of magnitude larger.
+
+## Refreshing
+
+The OpenAPI Initiative publishes dated schema *iterations* — the spec version stays fixed while the
+schema is corrected. Newly published iterations for a given version are listed in the
+[`OAI/spec.openapis.org`](https://github.com/OAI/spec.openapis.org) repository (e.g.
+`oas/3.2/schema/`); to update a file here, download the newest date from that directory and refresh the
+matching row above.
+
+AsyncAPI has no dated iterations — a given version's schema is corrected in place — so refreshing means
+re-downloading from a newer commit of `asyncapi/spec-json-schemas` and updating the pinned SHA above.

--- a/schemas/arazzo/1.0/schema.json
+++ b/schemas/arazzo/1.0/schema.json
@@ -1,0 +1,792 @@
+{
+  "$id": "https://spec.openapis.org/arazzo/1.0/schema/2025-10-15",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of Arazzo v1.0.x documents",
+  "type": "object",
+  "properties": {
+    "arazzo": {
+      "description": "The version number of the Arazzo Specification",
+      "type": "string",
+      "pattern": "^1\\.0\\.\\d+(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "sourceDescriptions": {
+      "description": "A list of source descriptions such as Arazzo or OpenAPI",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/source-description-object"
+      }
+    },
+    "workflows": {
+      "description": "A list of workflows",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/workflow-object"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components-object"
+    }
+  },
+  "required": [
+    "arazzo",
+    "info",
+    "sourceDescriptions",
+    "workflows"
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#info-object",
+      "description": "Provides metadata about the Arazzo description",
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "A human readable title of the Arazzo Description",
+          "type": "string"
+        },
+        "summary": {
+          "description": "A short summary of the Arazzo Description",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the purpose of the workflows defined. CommonMark syntax MAY be used for rich text representation",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version identifier of the Arazzo document (which is distinct from the Arazzo Specification version)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "source-description-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#source-description-object",
+      "description": "Describes a source description (such as an OpenAPI description)\nthat will be referenced by one or more workflows described within\nan Arazzo description",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "A unique name for the source description",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_\\-]+$"
+        },
+        "url": {
+          "description": "A URL to a source description to be used by a workflow",
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "type": {
+          "description": "The type of source description",
+          "enum": [
+            "arazzo",
+            "openapi"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "workflow-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#workflow-object",
+      "description": "Describes the steps to be taken across one or more APIs to achieve an objective",
+      "type": "object",
+      "properties": {
+        "workflowId": {
+          "description": "Unique string to represent the workflow",
+          "$anchor": "workflowId",
+          "type": "string"
+        },
+        "summary": {
+          "description": "A summary of the purpose or objective of the workflow",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the workflow. CommonMark syntax MAY be used for rich text representation",
+          "type": "string"
+        },
+        "inputs": {
+          "description": "A JSON Schema 2020-12 object representing the input parameters used by this workflow",
+          "$ref": "#/$defs/schema"
+        },
+        "dependsOn": {
+          "description": "A list of workflows that MUST be completed before this workflow can be processed",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "steps": {
+          "description": "An ordered list of steps where each step represents a call to an API operation or to another workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/step-object"
+          }
+        },
+        "successActions": {
+          "description": "A list of success actions that are applicable for all steps described under this workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/success-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "failureActions": {
+          "description": "A list of failure actions that are applicable for all steps described under this workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/failure-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "outputs": {
+          "description": "A map between a friendly name and a dynamic output value",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "type": "string"
+            }
+          }
+        },
+        "parameters": {
+          "description": "A list of parameters that are applicable for all steps described under this workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/parameter-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "workflowId",
+        "steps"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "step-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#step-object'",
+      "description": "Describes a single workflow step which MAY be a call to an\nAPI operation (OpenAPI Operation Object or another Workflow Object)",
+      "type": "object",
+      "properties": {
+        "stepId": {
+          "description": "Unique string to represent the step",
+          "$anchor": "stepId",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the step. CommonMark syntax MAY be used for rich text representation",
+          "type": "string"
+        },
+        "operationId": {
+          "description": "The name of an existing, resolvable operation, as defined with a unique operationId and existing within one of the sourceDescriptions",
+          "type": "string"
+        },
+        "operationPath": {
+          "description": "A reference to a Source combined with a JSON Pointer to reference an operation",
+          "type": "string"
+        },
+        "workflowId": {
+          "description": "The workflowId referencing an existing workflow within the Arazzo description",
+          "$ref": "#workflowId"
+        },
+        "parameters": {
+          "description": "A list of parameters that MUST be passed to an operation or workflow as referenced by operationId, operationPath, or workflowId",
+          "type": "array",
+          "uniqueItems": true,
+          "items": true
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-object"
+        },
+        "successCriteria": {
+          "description": "A list of assertions to determine the success of the step",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/criterion-object"
+          }
+        },
+        "onSuccess": {
+          "description": "An array of success action objects that specify what to do upon step success",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/success-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "onFailure": {
+          "description": "An array of failure action objects that specify what to do upon step failure",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/failure-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "outputs": {
+          "description": "A map between a friendly name and a dynamic output value defined using a runtime expression",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "stepId"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "operationId"
+          ]
+        },
+        {
+          "required": [
+            "operationPath"
+          ]
+        },
+        {
+          "required": [
+            "workflowId"
+          ]
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "oneOf": [
+              {
+                "required": [
+                  "operationPath"
+                ]
+              },
+              {
+                "required": [
+                  "operationId"
+                ]
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "parameters": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/$defs/reusable-object"
+                    },
+                    {
+                      "$ref": "#/$defs/parameter-object",
+                      "required": [
+                        "in"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "workflowId"
+            ]
+          },
+          "then": {
+            "properties": {
+              "parameters": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/$defs/parameter-object"
+                    },
+                    {
+                      "$ref": "#/$defs/reusable-object"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#request-body-object",
+      "description": "The request body to pass to an operation as referenced by operationId or operationPath",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "description": "The Content-Type for the request content",
+          "type": "string"
+        },
+        "payload": true,
+        "replacements": {
+          "description": "A list of locations and values to set within a payload",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/payload-replacement-object"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "criterion-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#criterion-object",
+      "description": "An object used to specify the context, conditions, and condition types\nthat can be used to prove or satisfy assertions specified in Step Object successCriteria,\nSuccess Action Object criteria, and Failure Action Object criteria",
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "A runtime expression used to set the context for the condition to be applied on",
+          "type": "string"
+        },
+        "condition": {
+          "description": "The condition to apply",
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "The type of condition to be applied",
+              "enum": [
+                "simple",
+                "regex",
+                "jsonpath",
+                "xpath"
+              ],
+              "default": "simple"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/criterion-expression-type-object"
+        }
+      ],
+      "required": [
+        "condition"
+      ],
+      "dependentRequired": {
+        "type": [
+          "context"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "criterion-expression-type-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#criterion-expression-type-object",
+      "description": "An object used to describe the type and version of an expression used within a Criterion Object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of condition to be applied",
+          "enum": [
+            "jsonpath",
+            "xpath"
+          ]
+        },
+        "version": {
+          "description": "A short hand string representing the version of the expression type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "version"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "const": "jsonpath"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "version": {
+                "const": "draft-goessner-dispatch-jsonpath-00"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "const": "xpath"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "version": {
+                "enum": [
+                  "xpath-10",
+                  "xpath-20",
+                  "xpath-30"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions"
+    },
+    "success-action-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#success-action-object",
+      "description": "A single success action which describes an action to take upon success of a workflow step",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the success action",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of action to take",
+          "enum": [
+            "end",
+            "goto"
+          ]
+        },
+        "workflowId": {
+          "description": "The workflowId referencing an existing workflow within the Arazzo description to transfer to upon success of the step",
+          "$ref": "#workflowId"
+        },
+        "stepId": {
+          "description": "The stepId to transfer to upon success of the step",
+          "$ref": "#stepId"
+        },
+        "criteria": {
+          "description": "A list of assertions to determine if this action SHALL be executed",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/criterion-object"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "goto"
+              }
+            }
+          },
+          "then": {
+            "oneOf": [
+              {
+                "required": [
+                  "workflowId"
+                ]
+              },
+              {
+                "required": [
+                  "stepId"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "required": [
+        "name",
+        "type"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "failure-action-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#failure-action-object",
+      "description": "A single failure action which describes an action to take upon failure of a workflow step",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the failure action",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of action to take",
+          "enum": [
+            "end",
+            "goto",
+            "retry"
+          ]
+        },
+        "workflowId": {
+          "description": "The workflowId referencing an existing workflow within the Arazzo description to transfer to upon failure of the step",
+          "$ref": "#workflowId"
+        },
+        "stepId": {
+          "description": "The stepId to transfer to upon failure of the step",
+          "$ref": "#stepId"
+        },
+        "retryAfter": {
+          "description": "A non-negative decimal indicating the seconds to delay after the step failure before another attempt SHALL be made",
+          "type": "number",
+          "minimum": 0
+        },
+        "retryLimit": {
+          "description": "A non-negative integer indicating how many attempts to retry the step MAY be attempted before failing the overall step",
+          "type": "integer",
+          "minimum": 0
+        },
+        "criteria": {
+          "description": "A list of assertions to determine if this action SHALL be executed",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/criterion-object"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "goto"
+                ]
+              }
+            }
+          },
+          "then": {
+            "oneOf": [
+              {
+                "required": [
+                  "workflowId"
+                ]
+              },
+              {
+                "required": [
+                  "stepId"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "required": [
+        "name",
+        "type"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reusable-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#reusable-object",
+      "description": "A simple object to allow referencing of objects contained within the Components Object",
+      "type": "object",
+      "properties": {
+        "reference": {
+          "description": "A runtime expression used to reference the desired object",
+          "type": "string"
+        },
+        "value": {
+          "description": "Sets a value of the referenced parameter",
+          "type": [
+            "string",
+            "boolean",
+            "object",
+            "array",
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "reference"
+      ],
+      "unevaluatedProperties": false
+    },
+    "parameter-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#parameter-object",
+      "description": "Describes a single step parameter",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the parameter",
+          "type": "string"
+        },
+        "in": {
+          "description": "The named location of the parameter",
+          "enum": [
+            "path",
+            "query",
+            "header",
+            "cookie"
+          ]
+        },
+        "value": {
+          "description": "The value to pass in the parameter",
+          "type": [
+            "string",
+            "boolean",
+            "object",
+            "array",
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "payload-replacement-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#payload-replacement-object",
+      "description": "Describes a location within a payload (e.g., a request body) and a value to set within the location",
+      "type": "object",
+      "properties": {
+        "target": {
+          "description": "A JSON Pointer or XPath Expression which MUST be resolved against the request body",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value set within the target location",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target",
+        "value"
+      ],
+      "unevaluatedProperties": false,
+      "$ref": "#/$defs/specification-extensions"
+    },
+    "components-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#components-object",
+      "description": "Holds a set of reusable objects for different aspects of the Arazzo Specification",
+      "type": "object",
+      "properties": {
+        "inputs": {
+          "description": "An object to hold reusable JSON Schema 2020-12 schemas to be referenced from workflow inputs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/schema"
+          }
+        },
+        "parameters": {
+          "description": "An object to hold reusable Parameter Objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-object"
+          }
+        },
+        "successActions": {
+          "description": "An object to hold reusable Success Actions Objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/success-action-object"
+          }
+        },
+        "failureActions": {
+          "description": "An object to hold reusable Failure Actions Objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/failure-action-object"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(inputs|parameters|successActions|failureActions)$": {
+          "$comment": "Enumerating all of the property names in the regex is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9\\.\\-_]+$"
+          }
+        }
+      },
+      "unevaluatedProperties": false,
+      "$ref": "#/$defs/specification-extensions"
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#specification-extensions",
+      "description": "While the Arazzo Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.0#schema-object",
+      "$ref": "https://json-schema.org/draft/2020-12/schema"
+    }
+  }
+}

--- a/schemas/arazzo/1.1/schema.json
+++ b/schemas/arazzo/1.1/schema.json
@@ -1,0 +1,1042 @@
+{
+  "$id": "https://spec.openapis.org/arazzo/1.1/schema/2026-04-15",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of Arazzo v1.1.x documents",
+  "type": "object",
+  "properties": {
+    "arazzo": {
+      "description": "The version number of the Arazzo Specification",
+      "type": "string",
+      "pattern": "^1\\.1\\.\\d+(-.+)?$"
+    },
+    "$self": {
+      "type": "string",
+      "format": "uri-reference",
+      "$comment": "MUST NOT contain a fragment",
+      "pattern": "^[^#]*$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "sourceDescriptions": {
+      "description": "A list of source descriptions such as Arazzo or OpenAPI",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/source-description-object"
+      }
+    },
+    "workflows": {
+      "description": "A list of workflows",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/workflow-object"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components-object"
+    }
+  },
+  "required": [
+    "arazzo",
+    "info",
+    "sourceDescriptions",
+    "workflows"
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#info-object",
+      "description": "Provides metadata about the Arazzo description",
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "A human readable title of the Arazzo Description",
+          "type": "string"
+        },
+        "summary": {
+          "description": "A short summary of the Arazzo Description",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the purpose of the workflows defined. CommonMark syntax MAY be used for rich text representation",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version identifier of the Arazzo document (which is distinct from the Arazzo Specification version)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "source-description-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#source-description-object",
+      "description": "Describes a source description (such as an OpenAPI description)\nthat will be referenced by one or more workflows described within\nan Arazzo description",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "A unique name for the source description",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_\\-]+$"
+        },
+        "url": {
+          "description": "A URL to a source description to be used by a workflow",
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "type": {
+          "description": "The type of source description",
+          "enum": [
+            "arazzo",
+            "openapi",
+            "asyncapi"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "workflow-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#workflow-object",
+      "description": "Describes the steps to be taken across one or more APIs to achieve an objective",
+      "type": "object",
+      "properties": {
+        "workflowId": {
+          "description": "Unique string to represent the workflow",
+          "$anchor": "workflowId",
+          "type": "string"
+        },
+        "summary": {
+          "description": "A summary of the purpose or objective of the workflow",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the workflow. CommonMark syntax MAY be used for rich text representation",
+          "type": "string"
+        },
+        "inputs": {
+          "description": "A JSON Schema 2020-12 object representing the input parameters used by this workflow",
+          "$ref": "#/$defs/schema"
+        },
+        "dependsOn": {
+          "description": "A list of workflows that MUST be completed before this workflow can be processed",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "steps": {
+          "description": "An ordered list of steps where each step represents a call to an API operation or to another workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/step-object"
+          }
+        },
+        "successActions": {
+          "description": "A list of success actions that are applicable for all steps described under this workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/success-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "failureActions": {
+          "description": "A list of failure actions that are applicable for all steps described under this workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/failure-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "outputs": {
+          "description": "A map between a friendly name and a dynamic output value defined using a Runtime Expression or Selector Object. Keys must match the regex: ^[a-zA-Z0-9\\.\\-_]+$\n",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/$defs/selector-object"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "description": "A list of parameters that are applicable for all steps described under this workflow",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/parameter-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "workflowId",
+        "steps"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "step-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#step-object'",
+      "description": "Describes a single workflow step which MAY be a call to an\nAPI operation (OpenAPI Operation Object or AsyncAPI Operation Object or another Workflow Object)",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/openapi-step-object"
+        },
+        {
+          "$ref": "#/$defs/asyncapi-step-object"
+        },
+        {
+          "$ref": "#/$defs/workflow-step-object"
+        }
+      ]
+    },
+    "step-object-base": {
+      "type": "object",
+      "properties": {
+        "stepId": {
+          "description": "Unique string to represent the step",
+          "$anchor": "stepId",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the step. CommonMark syntax MAY be used for rich text representation",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "The duration in milliseconds to wait before timing out the step",
+          "type": "integer"
+        },
+        "dependsOn": {
+          "description": "Specifies a list of step identifiers that must complete (or be waited for) before the current step can begin execution. `dependsOn` only establishes a prerequisite relationship for the current step and does not trigger execution of the referenced steps. Steps referred by dependsOn SHOULD be non-blocking/async steps. Steps in the current workflow MUST be referenced directly by stepId. Steps in another workflow in the same Arazzo document MUST use $workflows.<workflowId>.steps.<stepId>. Steps in another Arazzo document MUST use $sourceDescriptions.<name>.<workflowId>.steps.<stepId>.",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!\\$).+$"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\$workflows\\.[^.]+\\.steps\\.[^.]+$"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\$sourceDescriptions\\.[^.]+\\.[^.]+\\.steps\\.[^.]+$"
+              }
+            ]
+          }
+        },
+        "parameters": {
+          "description": "A list of parameters that MUST be passed to an operation or workflow as referenced by operationId, operationPath, or workflowId",
+          "type": "array",
+          "uniqueItems": true,
+          "items": true
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-object"
+        },
+        "successCriteria": {
+          "description": "A list of assertions to determine the success of the step",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/criterion-object"
+          }
+        },
+        "onSuccess": {
+          "description": "An array of success action objects that specify what to do upon step success",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/success-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "onFailure": {
+          "description": "An array of failure action objects that specify what to do upon step failure",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/failure-action-object"
+              },
+              {
+                "$ref": "#/$defs/reusable-object"
+              }
+            ]
+          }
+        },
+        "outputs": {
+          "description": "A map between a friendly name and a dynamic output value defined using a Runtime Expression or Selector Object. Keys must match the regex: ^[a-zA-Z0-9\\.\\-_]+$\n",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/$defs/selector-object"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "required": [
+        "stepId"
+      ]
+    },
+    "operation-step-parameters": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/reusable-object"
+          },
+          {
+            "$ref": "#/$defs/parameter-object",
+            "required": [
+              "in"
+            ]
+          }
+        ]
+      }
+    },
+    "openapi-step-object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/step-object-base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operationId": {
+              "description": "The name of an existing, resolvable operation, as defined with a unique operationId and existing within one of the sourceDescriptions",
+              "type": "string"
+            },
+            "operationPath": {
+              "description": "A reference to a Source combined with a JSON Pointer to reference an operation",
+              "type": "string"
+            },
+            "parameters": {
+              "$ref": "#/$defs/operation-step-parameters"
+            }
+          }
+        },
+        {
+          "oneOf": [
+            {
+              "required": [
+                "operationId"
+              ]
+            },
+            {
+              "required": [
+                "operationPath"
+              ]
+            }
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "asyncapi-step-object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/step-object-base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operationId": {
+              "description": "The name of an existing, resolvable operation, as defined with a unique operationId and existing within one of the sourceDescriptions",
+              "type": "string"
+            },
+            "channelPath": {
+              "description": "A reference to a Source combined with a JSON Pointer to reference an async channel",
+              "type": "string"
+            },
+            "correlationId": {
+              "description": "ID to correlate async responses with their requests, only specified for async receive steps",
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "object",
+                "array"
+              ]
+            },
+            "action": {
+              "description": "Specifies the intended operation on the async channel, indicating whether the action is sending data to the channel or receiving data from the channel",
+              "enum": [
+                "send",
+                "receive"
+              ]
+            },
+            "parameters": {
+              "$ref": "#/$defs/operation-step-parameters"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "if": {
+            "required": [
+              "correlationId"
+            ]
+          },
+          "then": {
+            "properties": {
+              "action": {
+                "const": "receive"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "oneOf": [
+            {
+              "required": [
+                "operationId"
+              ]
+            },
+            {
+              "required": [
+                "channelPath"
+              ]
+            }
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "workflow-step-object": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/step-object-base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "workflowId": {
+              "description": "The workflowId referencing an existing workflow within the Arazzo description",
+              "$ref": "#workflowId"
+            },
+            "parameters": {
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/parameter-object"
+                  },
+                  {
+                    "$ref": "#/$defs/reusable-object"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "workflowId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#request-body-object",
+      "description": "The request body to pass to an operation as referenced by operationId or operationPath or channelPath",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "description": "The Content-Type for the request content",
+          "type": "string"
+        },
+        "payload": true,
+        "replacements": {
+          "description": "A list of locations and values to set within a payload",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/payload-replacement-object"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "criterion-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#criterion-object",
+      "description": "An object used to specify the context, conditions, and condition types\nthat can be used to prove or satisfy assertions specified in Step Object successCriteria,\nSuccess Action Object criteria, and Failure Action Object criteria",
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "A runtime expression used to set the context for the condition to be applied on",
+          "type": "string"
+        },
+        "condition": {
+          "description": "The condition to apply",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of condition to be applied or a reference to an expression type object",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "simple",
+                "regex",
+                "jsonpath",
+                "xpath"
+              ],
+              "default": "simple"
+            },
+            {
+              "$ref": "#/$defs/expression-type-object"
+            }
+          ]
+        }
+      },
+      "required": [
+        "condition"
+      ],
+      "dependentRequired": {
+        "type": [
+          "context"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "expression-type-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#expression-type-object",
+      "description": "An object used to describe the type and version of an expression used within a Criterion Object or Selector Object. If the `version` is omitted, a default value is assumed based on the expression `type`",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of selector to use",
+          "enum": [
+            "jsonpath",
+            "xpath",
+            "jsonpointer"
+          ]
+        },
+        "version": {
+          "description": "A short hand string representing the version of the expression type. If omitted, the default for the selected type will be used.\n",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "version"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "const": "jsonpath"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "version": {
+                "enum": [
+                  "rfc9535",
+                  "draft-goessner-dispatch-jsonpath-00"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "const": "xpath"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "version": {
+                "enum": [
+                  "xpath-10",
+                  "xpath-20",
+                  "xpath-30",
+                  "xpath-31"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "jsonpointer"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "version": {
+                "const": "rfc6901"
+              }
+            }
+          }
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions"
+    },
+    "success-action-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#success-action-object",
+      "description": "A single success action which describes an action to take upon success of a workflow step",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the success action",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of action to take",
+          "enum": [
+            "end",
+            "goto"
+          ]
+        },
+        "workflowId": {
+          "description": "The workflowId referencing an existing workflow within the Arazzo description to transfer to upon success of the step",
+          "$ref": "#workflowId"
+        },
+        "stepId": {
+          "description": "The stepId to transfer to upon success of the step",
+          "$ref": "#stepId"
+        },
+        "parameters": {
+          "description": "A list of parameters that MUST be passed to a workflow as referenced by workflowId",
+          "type": "array",
+          "uniqueItems": true,
+          "items": true
+        },
+        "criteria": {
+          "description": "A list of assertions to determine if this action SHALL be executed",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/criterion-object"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "goto"
+              }
+            }
+          },
+          "then": {
+            "oneOf": [
+              {
+                "required": [
+                  "workflowId"
+                ]
+              },
+              {
+                "required": [
+                  "stepId"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "parameters"
+            ]
+          },
+          "then": {
+            "required": [
+              "workflowId"
+            ]
+          }
+        }
+      ],
+      "required": [
+        "name",
+        "type"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "failure-action-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#failure-action-object",
+      "description": "A single failure action which describes an action to take upon failure of a workflow step",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the failure action",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of action to take",
+          "enum": [
+            "end",
+            "goto",
+            "retry"
+          ]
+        },
+        "workflowId": {
+          "description": "The workflowId referencing an existing workflow within the Arazzo description to transfer to upon failure of the step",
+          "$ref": "#workflowId"
+        },
+        "stepId": {
+          "description": "The stepId to transfer to upon failure of the step",
+          "$ref": "#stepId"
+        },
+        "parameters": {
+          "description": "A list of parameters that MUST be passed to a workflow as referenced by workflowId",
+          "type": "array",
+          "uniqueItems": true,
+          "items": true
+        },
+        "retryAfter": {
+          "description": "A non-negative decimal indicating the seconds to delay after the step failure before another attempt SHALL be made",
+          "type": "number",
+          "minimum": 0
+        },
+        "retryLimit": {
+          "description": "A non-negative integer indicating how many attempts to retry the step MAY be attempted before failing the overall step",
+          "type": "integer",
+          "minimum": 0
+        },
+        "criteria": {
+          "description": "A list of assertions to determine if this action SHALL be executed",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/criterion-object"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "goto"
+                ]
+              }
+            }
+          },
+          "then": {
+            "oneOf": [
+              {
+                "required": [
+                  "workflowId"
+                ]
+              },
+              {
+                "required": [
+                  "stepId"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "parameters"
+            ]
+          },
+          "then": {
+            "required": [
+              "workflowId"
+            ]
+          }
+        }
+      ],
+      "required": [
+        "name",
+        "type"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reusable-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#reusable-object",
+      "description": "A simple object to allow referencing of objects contained within the Components Object",
+      "type": "object",
+      "properties": {
+        "reference": {
+          "description": "A runtime expression used to reference the desired object",
+          "type": "string"
+        },
+        "value": {
+          "description": "Sets a value of the referenced parameter",
+          "type": [
+            "string",
+            "boolean",
+            "object",
+            "array",
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "reference"
+      ],
+      "unevaluatedProperties": false
+    },
+    "parameter-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#parameter-object",
+      "description": "Describes a single step parameter",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the parameter",
+          "type": "string"
+        },
+        "in": {
+          "description": "The named location of the parameter",
+          "enum": [
+            "path",
+            "query",
+            "querystring",
+            "header",
+            "cookie",
+            "channel"
+          ]
+        },
+        "value": {
+          "description": "The value to pass in the parameter",
+          "oneOf": [
+            {
+              "type": [
+                "string",
+                "boolean",
+                "array",
+                "number",
+                "null"
+              ]
+            },
+            {
+              "$ref": "#/$defs/selector-object"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "payload-replacement-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#payload-replacement-object",
+      "description": "Describes a location within a payload (e.g., a request body) and a value to set within the location",
+      "type": "object",
+      "properties": {
+        "target": {
+          "description": "A JSONPath, JSON Pointer, or XPath Expression which MUST be resolved against the request body",
+          "type": "string"
+        },
+        "targetSelectorType": {
+          "description": "The selector expression type to use (e.g., `jsonpath`, `xpath`, or `jsonpointer`). Should an alternate version be required, the Expression Type Object may be used instead. If omitted, defaults to JSON Pointer for `application/json` or XPath for XML-based media types.\n",
+          "$ref": "#/$defs/selector-type"
+        },
+        "value": {
+          "description": "The value to set at the location defined by the target. May be a literal, a runtime expression string, or a selector object.\n",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/selector-object"
+            }
+          ]
+        }
+      },
+      "required": [
+        "target",
+        "value"
+      ],
+      "unevaluatedProperties": false,
+      "$ref": "#/$defs/specification-extensions"
+    },
+    "selector-type": {
+      "description": "A selector expression type that may be a simple string enum or an Expression Type Object for version-specific support",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "jsonpointer",
+            "jsonpath",
+            "xpath"
+          ]
+        },
+        {
+          "$ref": "#/$defs/expression-type-object"
+        }
+      ]
+    },
+    "selector-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#selector-object",
+      "description": "An object which enables fine-grained traversal and precise data selection from structured data",
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "A valid Runtime Expression which MUST evaluate to structured data (e.g., `$response.body`), and sets the context for the selector to be applied on",
+          "type": "string"
+        },
+        "selector": {
+          "description": "A selector expression (e.g., `$.items[0].id`, `/Envelope/Item`) in the form of JSONPath expression, XPath expression, or JSON Pointer expression",
+          "type": "string"
+        },
+        "type": {
+          "description": "The selector expression type to use (e.g., `jsonpath`, `xpath`, or `jsonpointer`) or an Expression Type Object for older version support",
+          "$ref": "#/$defs/selector-type"
+        }
+      },
+      "required": [
+        "context",
+        "selector",
+        "type"
+      ],
+      "unevaluatedProperties": false,
+      "$ref": "#/$defs/specification-extensions"
+    },
+    "components-object": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#components-object",
+      "description": "Holds a set of reusable objects for different aspects of the Arazzo Specification",
+      "type": "object",
+      "properties": {
+        "inputs": {
+          "description": "An object to hold reusable JSON Schema 2020-12 schemas to be referenced from workflow inputs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/schema"
+          }
+        },
+        "parameters": {
+          "description": "An object to hold reusable Parameter Objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-object"
+          }
+        },
+        "successActions": {
+          "description": "An object to hold reusable Success Actions Objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/success-action-object"
+          }
+        },
+        "failureActions": {
+          "description": "An object to hold reusable Failure Actions Objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/failure-action-object"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(inputs|parameters|successActions|failureActions)$": {
+          "$comment": "Enumerating all of the property names in the regex is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9\\.\\-_]+$"
+          }
+        }
+      },
+      "unevaluatedProperties": false,
+      "$ref": "#/$defs/specification-extensions"
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#specification-extensions",
+      "description": "While the Arazzo Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/arazzo/v1.1#schema-object",
+      "$ref": "https://json-schema.org/draft/2020-12/schema"
+    }
+  }
+}

--- a/schemas/asyncapi/2.6.0/schema.json
+++ b/schemas/asyncapi/2.6.0/schema.json
@@ -1,0 +1,3229 @@
+{
+    "$id": "http://asyncapi.com/definitions/2.6.0/asyncapi.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "AsyncAPI 2.6.0 schema.",
+    "type": "object",
+    "required": [
+        "asyncapi",
+        "info",
+        "channels"
+    ],
+    "additionalProperties": false,
+    "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+            "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+        }
+    },
+    "properties": {
+        "asyncapi": {
+            "type": "string",
+            "enum": [
+                "2.6.0"
+            ],
+            "description": "The AsyncAPI specification version of this document."
+        },
+        "id": {
+            "type": "string",
+            "description": "A unique id representing the application.",
+            "format": "uri"
+        },
+        "info": {
+            "$ref": "http://asyncapi.com/definitions/2.6.0/info.json"
+        },
+        "servers": {
+            "$ref": "http://asyncapi.com/definitions/2.6.0/servers.json"
+        },
+        "defaultContentType": {
+            "type": "string"
+        },
+        "channels": {
+            "$ref": "http://asyncapi.com/definitions/2.6.0/channels.json"
+        },
+        "components": {
+            "$ref": "http://asyncapi.com/definitions/2.6.0/components.json"
+        },
+        "tags": {
+            "type": "array",
+            "items": {
+                "$ref": "http://asyncapi.com/definitions/2.6.0/tag.json"
+            },
+            "uniqueItems": true
+        },
+        "externalDocs": {
+            "$ref": "http://asyncapi.com/definitions/2.6.0/externalDocs.json"
+        }
+    },
+    "definitions": {
+        "http://asyncapi.com/definitions/2.6.0/specificationExtension.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json",
+            "description": "Any property starting with x- is valid.",
+            "additionalProperties": true,
+            "additionalItems": true
+        },
+        "http://asyncapi.com/definitions/2.6.0/info.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/info.json",
+            "type": "object",
+            "description": "The object provides metadata about the API. The metadata can be used by the clients if needed.",
+            "required": [
+                "version",
+                "title"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "A unique and precise title of the API."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "A semantic version number of the API."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the API. Should be different from the title. CommonMark is allowed."
+                },
+                "termsOfService": {
+                    "type": "string",
+                    "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+                    "format": "uri"
+                },
+                "contact": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/contact.json"
+                },
+                "license": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/license.json"
+                }
+            },
+            "examples": [
+                {
+                    "title": "AsyncAPI Sample App",
+                    "description": "This is a sample server.",
+                    "termsOfService": "https://asyncapi.org/terms/",
+                    "contact": {
+                        "name": "API Support",
+                        "url": "https://www.example.com/support",
+                        "email": "support@example.com"
+                    },
+                    "license": {
+                        "name": "Apache 2.0",
+                        "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/contact.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/contact.json",
+            "type": "object",
+            "description": "Contact information for the exposed API.",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The identifying name of the contact person/organization."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the contact information.",
+                    "format": "uri"
+                },
+                "email": {
+                    "type": "string",
+                    "description": "The email address of the contact person/organization.",
+                    "format": "email"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "API Support",
+                    "url": "https://www.example.com/support",
+                    "email": "support@example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/license.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/license.json",
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "description": "License information for the exposed API.",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the license.",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "Apache 2.0",
+                    "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/servers.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/servers.json",
+            "description": "The Servers Object is a map of Server Objects.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/server.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "development": {
+                        "url": "development.gigantic-server.com",
+                        "description": "Development server",
+                        "protocol": "amqp",
+                        "protocolVersion": "0.9.1",
+                        "tags": [
+                            {
+                                "name": "env:development",
+                                "description": "This environment is meant for developers to run their own tests"
+                            }
+                        ]
+                    },
+                    "staging": {
+                        "url": "staging.gigantic-server.com",
+                        "description": "Staging server",
+                        "protocol": "amqp",
+                        "protocolVersion": "0.9.1",
+                        "tags": [
+                            {
+                                "name": "env:staging",
+                                "description": "This environment is a replica of the production environment"
+                            }
+                        ]
+                    },
+                    "production": {
+                        "url": "api.gigantic-server.com",
+                        "description": "Production server",
+                        "protocol": "amqp",
+                        "protocolVersion": "0.9.1",
+                        "tags": [
+                            {
+                                "name": "env:production",
+                                "description": "This environment is the live environment available for final users"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/Reference.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/Reference.json",
+            "type": "object",
+            "required": [
+                "$ref"
+            ],
+            "properties": {
+                "$ref": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/ReferenceObject.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.6.0/ReferenceObject.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/ReferenceObject.json",
+            "type": "string",
+            "description": "A simple object to allow referencing other components in the specification, internally and externally.",
+            "format": "uri-reference",
+            "examples": [
+                {
+                    "$ref": "#/components/schemas/Pet"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/server.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/server.json",
+            "type": "object",
+            "description": "An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data",
+            "required": [
+                "url",
+                "protocol"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the AsyncAPI document is being served."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional string describing the host designated by the URL. CommonMark syntax MAY be used for rich text representation."
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "The protocol this URL supports for connection. Supported protocol include, but are not limited to: amqp, amqps, http, https, ibmmq, jms, kafka, kafka-secure, anypointmq, mqtt, secure-mqtt, solace, stomp, stomps, ws, wss, mercure, googlepubsub."
+                },
+                "protocolVersion": {
+                    "type": "string",
+                    "description": "The version of the protocol used for connection. For instance: AMQP 0.9.1, HTTP 2.0, Kafka 1.0.0, etc."
+                },
+                "variables": {
+                    "description": "A map between a variable name and its value. The value is used for substitution in the server's URL template.",
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/serverVariables.json"
+                },
+                "security": {
+                    "type": "array",
+                    "description": "A declaration of which security mechanisms can be used with this server. The list of values includes alternative security requirement objects that can be used. ",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/SecurityRequirement.json"
+                    }
+                },
+                "bindings": {
+                    "description": "A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the server.",
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping and categorization of servers.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/tag.json"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "examples": [
+                {
+                    "url": "development.gigantic-server.com",
+                    "description": "Development server",
+                    "protocol": "kafka",
+                    "protocolVersion": "1.0.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/serverVariables.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/serverVariables.json",
+            "type": "object",
+            "description": "A map between a variable name and its value. The value is used for substitution in the server's URL template.",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/serverVariable.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/2.6.0/serverVariable.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/serverVariable.json",
+            "type": "object",
+            "description": "An object representing a Server Variable for server URL template substitution.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "enum": {
+                    "type": "array",
+                    "description": "An enumeration of string values to be used if the substitution options are from a limited set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "default": {
+                    "type": "string",
+                    "description": "The default value to use for substitution, and to send, if an alternate value is not supplied."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional description for the server variable. "
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "An array of examples of the server variable.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.6.0/SecurityRequirement.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/SecurityRequirement.json",
+            "type": "object",
+            "description": "Lists of the required security schemes that can be used to execute an operation",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "uniqueItems": true
+            },
+            "examples": [
+                {
+                    "petstore_auth": [
+                        "write:pets",
+                        "read:pets"
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/bindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for a server.",
+            "additionalProperties": true,
+            "properties": {
+                "http": {},
+                "ws": {},
+                "amqp": {},
+                "amqp1": {},
+                "mqtt": {},
+                "mqtt5": {},
+                "kafka": {},
+                "anypointmq": {},
+                "nats": {},
+                "jms": {},
+                "sns": {},
+                "sqs": {},
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {},
+                "solace": {},
+                "googlepubsub": {},
+                "pulsar": {}
+            }
+        },
+        "http://asyncapi.com/definitions/2.6.0/tag.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/tag.json",
+            "type": "object",
+            "description": "Allows adding meta data to a single tag.",
+            "additionalProperties": false,
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the tag."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for the tag."
+                },
+                "externalDocs": {
+                    "description": "Additional external documentation for this tag.",
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/externalDocs.json"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "user",
+                    "description": "User-related messages"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/externalDocs.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/externalDocs.json",
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Allows referencing an external resource for extended documentation.",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A short description of the target documentation."
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL for the target documentation. This MUST be in the form of an absolute URL."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "description": "Find more info here",
+                    "url": "https://example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/channels.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/channels.json",
+            "type": "object",
+            "description": "Holds the relative paths to the individual channel and their operations. Channel paths are relative to servers.",
+            "propertyNames": {
+                "type": "string",
+                "format": "uri-template",
+                "minLength": 1
+            },
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.6.0/channelItem.json"
+            },
+            "examples": [
+                {
+                    "user/signedup": {
+                        "subscribe": {
+                            "message": {
+                                "$ref": "#/components/messages/userSignedUp"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/channelItem.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/channelItem.json",
+            "type": "object",
+            "description": "Describes the operations available on a single channel.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "$ref": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/ReferenceObject.json"
+                },
+                "parameters": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/parameters.json"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A description of the channel."
+                },
+                "servers": {
+                    "type": "array",
+                    "description": "The names of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "publish": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/operation.json"
+                },
+                "subscribe": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/operation.json"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                }
+            },
+            "examples": [
+                {
+                    "description": "This channel is used to exchange messages about users signing up",
+                    "subscribe": {
+                        "summary": "A user signed up.",
+                        "message": {
+                            "description": "A longer description of the message",
+                            "payload": {
+                                "type": "object",
+                                "properties": {
+                                    "user": {
+                                        "$ref": "#/components/schemas/user"
+                                    },
+                                    "signup": {
+                                        "$ref": "#/components/schemas/signup"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "bindings": {
+                        "amqp": {
+                            "is": "queue",
+                            "queue": {
+                                "exclusive": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "subscribe": {
+                        "message": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/messages/signup"
+                                },
+                                {
+                                    "$ref": "#/components/messages/login"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "description": "This application publishes WebUICommand messages to an AMQP queue on RabbitMQ brokers in the Staging and Production environments.",
+                    "servers": [
+                        "rabbitmqBrokerInProd",
+                        "rabbitmqBrokerInStaging"
+                    ],
+                    "subscribe": {
+                        "message": {
+                            "$ref": "#/components/messages/WebUICommand"
+                        }
+                    },
+                    "bindings": {
+                        "amqp": {
+                            "is": "queue"
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/parameters.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/parameters.json",
+            "type": "object",
+            "description": "JSON objects describing reusable channel parameters.",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/parameter.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "user/{userId}/signup": {
+                        "parameters": {
+                            "userId": {
+                                "description": "Id of the user.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "subscribe": {
+                            "message": {
+                                "$ref": "#/components/messages/userSignedUp"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/parameter.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/parameter.json",
+            "description": "Describes a parameter included in a channel name.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
+                },
+                "schema": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the parameter value",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "examples": [
+                {
+                    "user/{userId}/signup": {
+                        "parameters": {
+                            "userId": {
+                                "description": "Id of the user.",
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "location": "$message.payload#/user/id"
+                            }
+                        },
+                        "subscribe": {
+                            "message": {
+                                "$ref": "#/components/messages/userSignedUp"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/schema.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/schema.json",
+            "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays.",
+            "allOf": [
+                {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                },
+                {
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                                    }
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "allOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                            }
+                        },
+                        "oneOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                            }
+                        },
+                        "anyOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                            }
+                        },
+                        "not": {
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "patternProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "propertyNames": {
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                        },
+                        "contains": {
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                        },
+                        "discriminator": {
+                            "type": "string",
+                            "description": "Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. "
+                        },
+                        "externalDocs": {
+                            "description": "Additional external documentation for this schema.",
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/externalDocs.json"
+                        },
+                        "deprecated": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Specifies that a schema is deprecated and SHOULD be transitioned out of usage"
+                        }
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "type": "string",
+                    "format": "email"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "address": {
+                            "$ref": "#/components/schemas/Address"
+                        },
+                        "age": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": 0
+                        }
+                    }
+                }
+            ]
+        },
+        "http://json-schema.org/draft-07/schema": {
+            "$id": "http://json-schema.org/draft-07/schema",
+            "title": "Core schema meta-schema",
+            "definitions": {
+                "schemaArray": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#"
+                    }
+                },
+                "nonNegativeInteger": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "nonNegativeIntegerDefault0": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/nonNegativeInteger"
+                        },
+                        {
+                            "default": 0
+                        }
+                    ]
+                },
+                "simpleTypes": {
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "null",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "stringArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": []
+                }
+            },
+            "type": [
+                "object",
+                "boolean"
+            ],
+            "properties": {
+                "$id": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$schema": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "$ref": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$comment": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": true,
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "items": true
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "number"
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "number"
+                },
+                "maxLength": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minLength": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "additionalItems": {
+                    "$ref": "#"
+                },
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/schemaArray"
+                        }
+                    ],
+                    "default": true
+                },
+                "maxItems": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minItems": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "contains": {
+                    "$ref": "#"
+                },
+                "maxProperties": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minProperties": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "required": {
+                    "$ref": "#/definitions/stringArray"
+                },
+                "additionalProperties": {
+                    "$ref": "#"
+                },
+                "definitions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "patternProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "propertyNames": {
+                        "format": "regex"
+                    },
+                    "default": {}
+                },
+                "dependencies": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/stringArray"
+                            }
+                        ]
+                    }
+                },
+                "propertyNames": {
+                    "$ref": "#"
+                },
+                "const": true,
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/simpleTypes"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/simpleTypes"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    ]
+                },
+                "format": {
+                    "type": "string"
+                },
+                "contentMediaType": {
+                    "type": "string"
+                },
+                "contentEncoding": {
+                    "type": "string"
+                },
+                "if": {
+                    "$ref": "#"
+                },
+                "then": {
+                    "$ref": "#"
+                },
+                "else": {
+                    "$ref": "#"
+                },
+                "allOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "anyOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "oneOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "not": {
+                    "$ref": "#"
+                }
+            },
+            "default": true
+        },
+        "http://asyncapi.com/definitions/2.6.0/operation.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/operation.json",
+            "type": "object",
+            "description": "Describes a publish or a subscribe operation. This provides a place to document how and why messages are sent and received.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "traits": {
+                    "type": "array",
+                    "description": "A list of traits to apply to the operation object.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/2.6.0/operationTrait.json"
+                            }
+                        ]
+                    }
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A short summary of what the operation is about."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A verbose explanation of the operation."
+                },
+                "security": {
+                    "type": "array",
+                    "description": "A declaration of which security mechanisms are associated with this operation.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/SecurityRequirement.json"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/tag.json"
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/externalDocs.json"
+                },
+                "operationId": {
+                    "type": "string"
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                },
+                "message": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/message.json"
+                }
+            },
+            "examples": [
+                {
+                    "user/signedup": {
+                        "subscribe": {
+                            "message": {
+                                "$ref": "#/components/messages/userSignedUp"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/operationTrait.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/operationTrait.json",
+            "type": "object",
+            "description": "Describes a trait that MAY be applied to an Operation Object.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "A short summary of what the operation is about."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A verbose explanation of the operation."
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/tag.json"
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/externalDocs.json"
+                },
+                "operationId": {
+                    "type": "string",
+                    "description": "Unique string used to identify the operation. The id MUST be unique among all operations described in the API."
+                },
+                "security": {
+                    "type": "array",
+                    "description": "A declaration of which security mechanisms are associated with this operation. ",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/SecurityRequirement.json"
+                    }
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                }
+            },
+            "examples": [
+                {
+                    "bindings": {
+                        "amqp": {
+                            "ack": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/message.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/message.json",
+            "description": "Describes a message received on a given channel and operation.",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                },
+                {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "required": [
+                                "oneOf"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "oneOf": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/2.6.0/message.json"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^x-[\\w\\d\\.\\x2d_]+$": {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                                }
+                            },
+                            "properties": {
+                                "schemaFormat": {
+                                    "type": "string"
+                                },
+                                "contentType": {
+                                    "type": "string"
+                                },
+                                "headers": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                                        },
+                                        {
+                                            "properties": {
+                                                "type": {
+                                                    "const": "object"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "messageId": {
+                                    "type": "string"
+                                },
+                                "payload": {},
+                                "correlationId": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/2.6.0/correlationId.json"
+                                        }
+                                    ]
+                                },
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/2.6.0/tag.json"
+                                    },
+                                    "uniqueItems": true
+                                },
+                                "summary": {
+                                    "type": "string",
+                                    "description": "A brief summary of the message."
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the message."
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "description": "A human-friendly title for the message."
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "A longer description of the message. CommonMark is allowed."
+                                },
+                                "externalDocs": {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/externalDocs.json"
+                                },
+                                "deprecated": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "examples": {
+                                    "type": "array",
+                                    "description": "List of examples.",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "payload"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "headers"
+                                                ]
+                                            }
+                                        ],
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Machine readable name of the message example."
+                                            },
+                                            "summary": {
+                                                "type": "string",
+                                                "description": "A brief summary of the message example."
+                                            },
+                                            "headers": {
+                                                "type": "object",
+                                                "description": "Schema definition of the application headers."
+                                            },
+                                            "payload": {
+                                                "description": "Definition of the message payload. It can be of any type"
+                                            }
+                                        }
+                                    }
+                                },
+                                "bindings": {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                                },
+                                "traits": {
+                                    "type": "array",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                                            },
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/2.6.0/messageTrait.json"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "allOf": [
+                                {
+                                    "if": {
+                                        "not": {
+                                            "required": [
+                                                "schemaFormat"
+                                            ]
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "payload": {
+                                                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "required": [
+                                            "schemaFormat"
+                                        ],
+                                        "properties": {
+                                            "schemaFormat": {
+                                                "enum": [
+                                                    "application/vnd.aai.asyncapi;version=2.0.0",
+                                                    "application/vnd.aai.asyncapi+json;version=2.0.0",
+                                                    "application/vnd.aai.asyncapi+yaml;version=2.0.0",
+                                                    "application/vnd.aai.asyncapi;version=2.1.0",
+                                                    "application/vnd.aai.asyncapi+json;version=2.1.0",
+                                                    "application/vnd.aai.asyncapi+yaml;version=2.1.0",
+                                                    "application/vnd.aai.asyncapi;version=2.2.0",
+                                                    "application/vnd.aai.asyncapi+json;version=2.2.0",
+                                                    "application/vnd.aai.asyncapi+yaml;version=2.2.0",
+                                                    "application/vnd.aai.asyncapi;version=2.3.0",
+                                                    "application/vnd.aai.asyncapi+json;version=2.3.0",
+                                                    "application/vnd.aai.asyncapi+yaml;version=2.3.0",
+                                                    "application/vnd.aai.asyncapi;version=2.4.0",
+                                                    "application/vnd.aai.asyncapi+json;version=2.4.0",
+                                                    "application/vnd.aai.asyncapi+yaml;version=2.4.0",
+                                                    "application/vnd.aai.asyncapi;version=2.5.0",
+                                                    "application/vnd.aai.asyncapi+json;version=2.5.0",
+                                                    "application/vnd.aai.asyncapi+yaml;version=2.5.0",
+                                                    "application/vnd.aai.asyncapi;version=2.6.0",
+                                                    "application/vnd.aai.asyncapi+json;version=2.6.0",
+                                                    "application/vnd.aai.asyncapi+yaml;version=2.6.0"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "payload": {
+                                                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "required": [
+                                            "schemaFormat"
+                                        ],
+                                        "properties": {
+                                            "schemaFormat": {
+                                                "enum": [
+                                                    "application/schema+json;version=draft-07",
+                                                    "application/schema+yaml;version=draft-07"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "payload": {
+                                                "$ref": "http://json-schema.org/draft-07/schema"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "required": [
+                                            "schemaFormat"
+                                        ],
+                                        "properties": {
+                                            "schemaFormat": {
+                                                "enum": [
+                                                    "application/vnd.oai.openapi;version=3.0.0",
+                                                    "application/vnd.oai.openapi+json;version=3.0.0",
+                                                    "application/vnd.oai.openapi+yaml;version=3.0.0"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "payload": {
+                                                "$ref": "http://asyncapi.com/definitions/2.6.0/openapiSchema_3_0.json"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "required": [
+                                            "schemaFormat"
+                                        ],
+                                        "properties": {
+                                            "schemaFormat": {
+                                                "enum": [
+                                                    "application/vnd.apache.avro;version=1.9.0",
+                                                    "application/vnd.apache.avro+json;version=1.9.0",
+                                                    "application/vnd.apache.avro+yaml;version=1.9.0"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "payload": {
+                                                "$ref": "http://asyncapi.com/definitions/2.6.0/avroSchema_v1.json"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "examples": [
+                {
+                    "messageId": "userSignup",
+                    "name": "UserSignup",
+                    "title": "User signup",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "contentType": "application/json",
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "correlationId": {
+                                "description": "Correlation ID set by application",
+                                "type": "string"
+                            },
+                            "applicationInstanceId": {
+                                "description": "Unique identifier for a given instance of the publishing application",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "payload": {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "$ref": "#/components/schemas/userCreate"
+                            },
+                            "signup": {
+                                "$ref": "#/components/schemas/signup"
+                            }
+                        }
+                    },
+                    "correlationId": {
+                        "description": "Default Correlation ID",
+                        "location": "$message.header#/correlationId"
+                    },
+                    "traits": [
+                        {
+                            "$ref": "#/components/messageTraits/commonHeaders"
+                        }
+                    ],
+                    "examples": [
+                        {
+                            "name": "SimpleSignup",
+                            "summary": "A simple UserSignup example message",
+                            "headers": {
+                                "correlationId": "my-correlation-id",
+                                "applicationInstanceId": "myInstanceId"
+                            },
+                            "payload": {
+                                "user": {
+                                    "someUserKey": "someUserValue"
+                                },
+                                "signup": {
+                                    "someSignupKey": "someSignupValue"
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "messageId": "userSignup",
+                    "name": "UserSignup",
+                    "title": "User signup",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "schemaFormat": "application/vnd.apache.avro+json;version=1.9.0",
+                    "payload": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/correlationId.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/correlationId.json",
+            "type": "object",
+            "description": "An object that specifies an identifier at design time that can used for message tracing and correlation.",
+            "required": [
+                "location"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the correlation ID",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "examples": [
+                {
+                    "description": "Default Correlation ID",
+                    "location": "$message.header#/correlationId"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/messageTrait.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/messageTrait.json",
+            "type": "object",
+            "description": "Describes a trait that MAY be applied to a Message Object.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaFormat": {
+                    "type": "string",
+                    "description": "A string containing the name of the schema format/language used to define the message payload."
+                },
+                "contentType": {
+                    "type": "string",
+                    "description": "The content type to use when encoding/decoding a message's payload."
+                },
+                "headers": {
+                    "description": "Schema definition of the application headers.",
+                    "allOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "const": "object"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "messageId": {
+                    "type": "string",
+                    "description": "Unique string used to identify the message. The id MUST be unique among all messages described in the API."
+                },
+                "correlationId": {
+                    "description": "Definition of the correlation ID used for message tracing or matching.",
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/2.6.0/correlationId.json"
+                        }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping and categorization of messages.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/tag.json"
+                    },
+                    "uniqueItems": true
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the message."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the message."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the message. CommonMark is allowed."
+                },
+                "externalDocs": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/externalDocs.json"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "List of examples.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "anyOf": [
+                            {
+                                "required": [
+                                    "payload"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "headers"
+                                ]
+                            }
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Machine readable name of the message example."
+                            },
+                            "summary": {
+                                "type": "string",
+                                "description": "A brief summary of the message example."
+                            },
+                            "headers": {
+                                "type": "object",
+                                "description": "Schema definition of the application headers."
+                            },
+                            "payload": {
+                                "description": "Definition of the message payload. It can be of any type"
+                            }
+                        }
+                    }
+                },
+                "bindings": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                }
+            },
+            "examples": [
+                {
+                    "schemaFormat": "application/vnd.apache.avro+json;version=1.9.0",
+                    "contentType": "application/json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/openapiSchema_3_0.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/openapiSchema_3_0.json",
+            "type": "object",
+            "definitions": {
+                "ExternalDocumentation": {
+                    "type": "object",
+                    "required": [
+                        "url"
+                    ],
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                },
+                "Discriminator": {
+                    "type": "object",
+                    "required": [
+                        "propertyName"
+                    ],
+                    "properties": {
+                        "propertyName": {
+                            "type": "string"
+                        },
+                        "mapping": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "Reference": {
+                    "type": "object",
+                    "required": [
+                        "$ref"
+                    ],
+                    "patternProperties": {
+                        "^\\$ref$": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    }
+                },
+                "XML": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "attribute": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "wrapped": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxLength": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "maxItems": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": false
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "not": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "allOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "oneOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "items": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "default": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "default": true,
+                "nullable": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "discriminator": {
+                    "$ref": "#/definitions/Discriminator"
+                },
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "example": true,
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "xml": {
+                    "$ref": "#/definitions/XML"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.6.0/avroSchema_v1.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/avroSchema_v1.json",
+            "definitions": {
+                "avroSchema": {
+                    "title": "Avro Schema",
+                    "description": "Root Schema",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/types"
+                        }
+                    ]
+                },
+                "types": {
+                    "title": "Avro Types",
+                    "description": "Allowed Avro types",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/primitiveType"
+                        },
+                        {
+                            "$ref": "#/definitions/primitiveTypeWithMetadata"
+                        },
+                        {
+                            "$ref": "#/definitions/customTypeReference"
+                        },
+                        {
+                            "$ref": "#/definitions/avroRecord"
+                        },
+                        {
+                            "$ref": "#/definitions/avroEnum"
+                        },
+                        {
+                            "$ref": "#/definitions/avroArray"
+                        },
+                        {
+                            "$ref": "#/definitions/avroMap"
+                        },
+                        {
+                            "$ref": "#/definitions/avroFixed"
+                        },
+                        {
+                            "$ref": "#/definitions/avroUnion"
+                        }
+                    ]
+                },
+                "primitiveType": {
+                    "title": "Primitive Type",
+                    "description": "Basic type primitives.",
+                    "type": "string",
+                    "enum": [
+                        "null",
+                        "boolean",
+                        "int",
+                        "long",
+                        "float",
+                        "double",
+                        "bytes",
+                        "string"
+                    ]
+                },
+                "primitiveTypeWithMetadata": {
+                    "title": "Primitive Type With Metadata",
+                    "description": "A primitive type with metadata attached.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "$ref": "#/definitions/primitiveType"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "customTypeReference": {
+                    "title": "Custom Type",
+                    "description": "Reference to a ComplexType",
+                    "not": {
+                        "$ref": "#/definitions/primitiveType"
+                    },
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+                },
+                "avroUnion": {
+                    "title": "Union",
+                    "description": "A Union of types",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/avroSchema"
+                    },
+                    "minItems": 1
+                },
+                "avroField": {
+                    "title": "Field",
+                    "description": "A field within a Record",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/types"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "default": true,
+                        "order": {
+                            "enum": [
+                                "ascending",
+                                "descending",
+                                "ignore"
+                            ]
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "type"
+                    ]
+                },
+                "avroRecord": {
+                    "title": "Record",
+                    "description": "A Record",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "record"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "fields": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/avroField"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "fields"
+                    ]
+                },
+                "avroEnum": {
+                    "title": "Enum",
+                    "description": "An enumeration",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "enum"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "symbols": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "symbols"
+                    ]
+                },
+                "avroArray": {
+                    "title": "Array",
+                    "description": "An array",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "array"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "items": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "items"
+                    ]
+                },
+                "avroMap": {
+                    "title": "Map",
+                    "description": "A map of values",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "map"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "values": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "values"
+                    ]
+                },
+                "avroFixed": {
+                    "title": "Fixed",
+                    "description": "A fixed sized array of bytes",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "fixed"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "size": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "size"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                },
+                "namespace": {
+                    "type": "string",
+                    "pattern": "^([A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*)*$"
+                }
+            },
+            "description": "Json-Schema definition for Avro AVSC files.",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/avroSchema"
+                }
+            ],
+            "title": "Avro Schema Definition"
+        },
+        "http://asyncapi.com/definitions/2.6.0/components.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/components.json",
+            "type": "object",
+            "description": "Holds a set of reusable objects for different aspects of the AsyncAPI specification. All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemas": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/schemas.json"
+                },
+                "servers": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/servers.json"
+                },
+                "channels": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/channels.json"
+                },
+                "serverVariables": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/serverVariables.json"
+                },
+                "messages": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/messages.json"
+                },
+                "securitySchemes": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/SecurityScheme.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parameters": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/parameters.json"
+                },
+                "correlationIds": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/correlationId.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationTraits": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/operationTrait.json"
+                    }
+                },
+                "messageTraits": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/messageTrait.json"
+                    }
+                },
+                "serverBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                    }
+                },
+                "channelBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                    }
+                },
+                "operationBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                    }
+                },
+                "messageBindings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "http://asyncapi.com/definitions/2.6.0/bindingsObject.json"
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "components": {
+                        "schemas": {
+                            "Category": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "Tag": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "servers": {
+                            "development": {
+                                "url": "{stage}.gigantic-server.com:{port}",
+                                "description": "Development server",
+                                "protocol": "amqp",
+                                "protocolVersion": "0.9.1",
+                                "variables": {
+                                    "stage": {
+                                        "$ref": "#/components/serverVariables/stage"
+                                    },
+                                    "port": {
+                                        "$ref": "#/components/serverVariables/port"
+                                    }
+                                }
+                            }
+                        },
+                        "serverVariables": {
+                            "stage": {
+                                "default": "demo",
+                                "description": "This value is assigned by the service provider, in this example `gigantic-server.com`"
+                            },
+                            "port": {
+                                "enum": [
+                                    "8883",
+                                    "8884"
+                                ],
+                                "default": "8883"
+                            }
+                        },
+                        "channels": {
+                            "user/signedup": {
+                                "subscribe": {
+                                    "message": {
+                                        "$ref": "#/components/messages/userSignUp"
+                                    }
+                                }
+                            }
+                        },
+                        "messages": {
+                            "userSignUp": {
+                                "summary": "Action to sign a user up.",
+                                "description": "Multiline description of what this action does.\nHere you have another line.\n",
+                                "tags": [
+                                    {
+                                        "name": "user"
+                                    },
+                                    {
+                                        "name": "signup"
+                                    }
+                                ],
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "applicationInstanceId": {
+                                            "description": "Unique identifier for a given instance of the publishing application",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "properties": {
+                                        "user": {
+                                            "$ref": "#/components/schemas/userCreate"
+                                        },
+                                        "signup": {
+                                            "$ref": "#/components/schemas/signup"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "userId": {
+                                "description": "Id of the user.",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "correlationIds": {
+                            "default": {
+                                "description": "Default Correlation ID",
+                                "location": "$message.header#/correlationId"
+                            }
+                        },
+                        "messageTraits": {
+                            "commonHeaders": {
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "my-app-header": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 100
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/schemas.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/schemas.json",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.6.0/schema.json"
+            },
+            "description": "JSON objects describing schemas the API uses."
+        },
+        "http://asyncapi.com/definitions/2.6.0/messages.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/messages.json",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "http://asyncapi.com/definitions/2.6.0/message.json"
+            },
+            "description": "JSON objects describing the messages being consumed and produced by the API."
+        },
+        "http://asyncapi.com/definitions/2.6.0/SecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/SecurityScheme.json",
+            "description": "Defines a security scheme that can be used by the operations.",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/userPassword.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/apiKey.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/X509.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/symmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/asymmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/HTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/oauth2Flows.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/openIdConnect.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/SaslSecurityScheme.json"
+                }
+            ],
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/userPassword.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/userPassword.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme. ",
+                    "enum": [
+                        "userPassword"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/apiKey.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/apiKey.json",
+            "type": "object",
+            "required": [
+                "type",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "apiKey"
+                    ]
+                },
+                "in": {
+                    "type": "string",
+                    "description": "The location of the API key. ",
+                    "enum": [
+                        "user",
+                        "password"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "apiKey",
+                    "in": "user"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/X509.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/X509.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "X509"
+                    ],
+                    "description": "The type of the security scheme."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "X509"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/symmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/symmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "symmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "symmetricEncryption"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/asymmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/asymmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "asymmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.6.0/HTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/HTTPSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/NonBearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/BearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/APIKeyHTTPSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/NonBearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/NonBearerHTTPSecurityScheme.json",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "description": "A short description for security scheme.",
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "scheme",
+                "type"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme. ",
+                    "enum": [
+                        "http"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.6.0/BearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/BearerHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "scheme"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235.",
+                    "enum": [
+                        "bearer"
+                    ]
+                },
+                "bearerFormat": {
+                    "type": "string",
+                    "description": "A hint to the client to identify how the bearer token is formatted."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme. ",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.6.0/APIKeyHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/APIKeyHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "name",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme. ",
+                    "enum": [
+                        "httpApiKey"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the header, query or cookie parameter to be used."
+                },
+                "in": {
+                    "type": "string",
+                    "description": "The location of the API key. ",
+                    "enum": [
+                        "header",
+                        "query",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "httpApiKey",
+                    "name": "api_key",
+                    "in": "header"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/oauth2Flows.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/oauth2Flows.json",
+            "type": "object",
+            "description": "Allows configuration of the supported OAuth Flows.",
+            "required": [
+                "type",
+                "flows"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "A short description for security scheme.",
+                    "enum": [
+                        "oauth2"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                },
+                "flows": {
+                    "type": "object",
+                    "properties": {
+                        "implicit": {
+                            "description": "Configuration for the OAuth Implicit flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "scopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "tokenUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "password": {
+                            "description": "Configuration for the OAuth Resource Owner Protected Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "scopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "clientCredentials": {
+                            "description": "Configuration for the OAuth Client Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "scopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "authorizationCode": {
+                            "description": "Configuration for the OAuth Authorization Code flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/2.6.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "tokenUrl",
+                                        "scopes"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/2.6.0/oauth2Flow.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/oauth2Flow.json",
+            "type": "object",
+            "description": "Configuration details for a supported OAuth Flow",
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The authorization URL to be used for this flow. This MUST be in the form of an absolute URL."
+                },
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The token URL to be used for this flow. This MUST be in the form of an absolute URL."
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of an absolute URL."
+                },
+                "scopes": {
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.",
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/oauth2Scopes.json"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "oauth2",
+                    "flows": {
+                        "implicit": {
+                            "authorizationUrl": "https://example.com/api/oauth/dialog",
+                            "scopes": {
+                                "write:pets": "modify pets in your account",
+                                "read:pets": "read your pets"
+                            }
+                        },
+                        "authorizationCode": {
+                            "authorizationUrl": "https://example.com/api/oauth/dialog",
+                            "tokenUrl": "https://example.com/api/oauth/token",
+                            "scopes": {
+                                "write:pets": "modify pets in your account",
+                                "read:pets": "read your pets"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/oauth2Scopes.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/oauth2Scopes.json",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "http://asyncapi.com/definitions/2.6.0/openIdConnect.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/openIdConnect.json",
+            "type": "object",
+            "required": [
+                "type",
+                "openIdConnectUrl"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "openIdConnect"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "openIdConnectUrl": {
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/2.6.0/SaslSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/SaslSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/SaslPlainSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/SaslScramSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/SaslGssapiSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/SaslPlainSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/SaslPlainSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme. Valid values",
+                    "enum": [
+                        "plain"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/SaslScramSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/SaslScramSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "scramSha256",
+                        "scramSha512"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/2.6.0/SaslGssapiSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/2.6.0/SaslGssapiSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "gssapi"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/2.6.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        }
+    },
+    "description": "!!Auto generated!! \n Do not manually edit. "
+}

--- a/schemas/asyncapi/3.0.0/schema.json
+++ b/schemas/asyncapi/3.0.0/schema.json
@@ -1,0 +1,9077 @@
+{
+    "$id": "http://asyncapi.com/definitions/3.0.0/asyncapi.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "AsyncAPI 3.0.0 schema.",
+    "type": "object",
+    "required": [
+        "asyncapi",
+        "info"
+    ],
+    "additionalProperties": false,
+    "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+        }
+    },
+    "properties": {
+        "asyncapi": {
+            "type": "string",
+            "const": "3.0.0",
+            "description": "The AsyncAPI specification version of this document."
+        },
+        "id": {
+            "type": "string",
+            "description": "A unique id representing the application.",
+            "format": "uri"
+        },
+        "info": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/info.json"
+        },
+        "servers": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/servers.json"
+        },
+        "defaultContentType": {
+            "type": "string",
+            "description": "Default content type to use when encoding/decoding a message's payload."
+        },
+        "channels": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/channels.json"
+        },
+        "operations": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/operations.json"
+        },
+        "components": {
+            "$ref": "http://asyncapi.com/definitions/3.0.0/components.json"
+        }
+    },
+    "definitions": {
+        "http://asyncapi.com/definitions/3.0.0/specificationExtension.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json",
+            "description": "Any property starting with x- is valid.",
+            "additionalProperties": true,
+            "additionalItems": true
+        },
+        "http://asyncapi.com/definitions/3.0.0/info.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/info.json",
+            "description": "The object provides metadata about the API. The metadata can be used by the clients if needed.",
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "version",
+                        "title"
+                    ],
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "A unique and precise title of the API."
+                        },
+                        "version": {
+                            "type": "string",
+                            "description": "A semantic version number of the API."
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "A longer description of the API. Should be different from the title. CommonMark is allowed."
+                        },
+                        "termsOfService": {
+                            "type": "string",
+                            "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+                            "format": "uri"
+                        },
+                        "contact": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/contact.json"
+                        },
+                        "license": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/license.json"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "description": "A list of tags for application API documentation control. Tags can be used for logical grouping of applications.",
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                    },
+                                    {
+                                        "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "externalDocs": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/infoExtensions.json"
+                }
+            ],
+            "examples": [
+                {
+                    "title": "AsyncAPI Sample App",
+                    "version": "1.0.1",
+                    "description": "This is a sample app.",
+                    "termsOfService": "https://asyncapi.org/terms/",
+                    "contact": {
+                        "name": "API Support",
+                        "url": "https://www.asyncapi.org/support",
+                        "email": "support@asyncapi.org"
+                    },
+                    "license": {
+                        "name": "Apache 2.0",
+                        "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                    },
+                    "externalDocs": {
+                        "description": "Find more info here",
+                        "url": "https://www.asyncapi.org"
+                    },
+                    "tags": [
+                        {
+                            "name": "e-commerce"
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/contact.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/contact.json",
+            "type": "object",
+            "description": "Contact information for the exposed API.",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The identifying name of the contact person/organization."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the contact information.",
+                    "format": "uri"
+                },
+                "email": {
+                    "type": "string",
+                    "description": "The email address of the contact person/organization.",
+                    "format": "email"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "API Support",
+                    "url": "https://www.example.com/support",
+                    "email": "support@example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/license.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/license.json",
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL pointing to the license.",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "Apache 2.0",
+                    "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/Reference.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/Reference.json",
+            "type": "object",
+            "description": "A simple object to allow referencing other components in the specification, internally and externally.",
+            "required": [
+                "$ref"
+            ],
+            "properties": {
+                "$ref": {
+                    "description": "The reference string.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json"
+                }
+            },
+            "examples": [
+                {
+                    "$ref": "#/components/schemas/Pet"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json",
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "http://asyncapi.com/definitions/3.0.0/tag.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/tag.json",
+            "type": "object",
+            "description": "Allows adding metadata to a single tag.",
+            "additionalProperties": false,
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the tag."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for the tag. CommonMark syntax can be used for rich text representation."
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "name": "user",
+                    "description": "User-related messages"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/externalDocs.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/externalDocs.json",
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Allows referencing an external resource for extended documentation.",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A short description of the target documentation. CommonMark syntax can be used for rich text representation."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL for the target documentation. This MUST be in the form of an absolute URL.",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "description": "Find more info here",
+                    "url": "https://example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/infoExtensions.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/infoExtensions.json",
+            "type": "object",
+            "description": "The object that lists all the extensions of Info",
+            "properties": {
+                "x-x": {
+                    "$ref": "http://asyncapi.com/extensions/x/0.1.0/schema.json"
+                },
+                "x-linkedin": {
+                    "$ref": "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json"
+                }
+            }
+        },
+        "http://asyncapi.com/extensions/x/0.1.0/schema.json": {
+            "$id": "http://asyncapi.com/extensions/x/0.1.0/schema.json",
+            "type": "string",
+            "description": "This extension allows you to provide the Twitter username of the account representing the team/company of the API.",
+            "example": [
+                "sambhavgupta75",
+                "AsyncAPISpec"
+            ]
+        },
+        "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json": {
+            "$id": "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json",
+            "type": "string",
+            "pattern": "^http(s)?://(www\\.)?linkedin\\.com.*$",
+            "description": "This extension allows you to provide the Linkedin profile URL of the account representing the team/company of the API.",
+            "example": [
+                "https://www.linkedin.com/company/asyncapi/",
+                "https://www.linkedin.com/in/sambhavgupta0705/"
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/servers.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/servers.json",
+            "description": "An object representing multiple servers.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/server.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "development": {
+                        "host": "localhost:5672",
+                        "description": "Development AMQP broker.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:development",
+                                "description": "This environment is meant for developers to run their own tests."
+                            }
+                        ]
+                    },
+                    "staging": {
+                        "host": "rabbitmq-staging.in.mycompany.com:5672",
+                        "description": "RabbitMQ broker for the staging environment.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:staging",
+                                "description": "This environment is a replica of the production environment."
+                            }
+                        ]
+                    },
+                    "production": {
+                        "host": "rabbitmq.in.mycompany.com:5672",
+                        "description": "RabbitMQ broker for the production environment.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:production",
+                                "description": "This environment is the live environment available for final users."
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/server.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/server.json",
+            "type": "object",
+            "description": "An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data.",
+            "required": [
+                "host",
+                "protocol"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "The server host name. It MAY include the port. This field supports Server Variables. Variable substitutions will be made when a variable is named in {braces}."
+                },
+                "pathname": {
+                    "type": "string",
+                    "description": "The path to a resource in the host. This field supports Server Variables. Variable substitutions will be made when a variable is named in {braces}."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the server."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the server."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the server. CommonMark is allowed."
+                },
+                "protocol": {
+                    "type": "string",
+                    "description": "The protocol this server supports for connection."
+                },
+                "protocolVersion": {
+                    "type": "string",
+                    "description": "An optional string describing the server. CommonMark syntax MAY be used for rich text representation."
+                },
+                "variables": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/serverVariables.json"
+                },
+                "security": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/securityRequirements.json"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "host": "kafka.in.mycompany.com:9092",
+                    "description": "Production Kafka broker.",
+                    "protocol": "kafka",
+                    "protocolVersion": "3.2"
+                },
+                {
+                    "host": "rabbitmq.in.mycompany.com:5672",
+                    "pathname": "/production",
+                    "protocol": "amqp",
+                    "description": "Production RabbitMQ broker (uses the `production` vhost)."
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/serverVariables.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/serverVariables.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/serverVariable.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/serverVariable.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/serverVariable.json",
+            "type": "object",
+            "description": "An object representing a Server Variable for server URL template substitution.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "enum": {
+                    "type": "array",
+                    "description": "An enumeration of string values to be used if the substitution options are from a limited set.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "default": {
+                    "type": "string",
+                    "description": "The default value to use for substitution, and to send, if an alternate value is not supplied."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional description for the server variable. CommonMark syntax MAY be used for rich text representation."
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "An array of examples of the server variable.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "host": "rabbitmq.in.mycompany.com:5672",
+                    "pathname": "/{env}",
+                    "protocol": "amqp",
+                    "description": "RabbitMQ broker. Use the `env` variable to point to either `production` or `staging`.",
+                    "variables": {
+                        "env": {
+                            "description": "Environment to connect to. It can be either `production` or `staging`.",
+                            "enum": [
+                                "production",
+                                "staging"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/securityRequirements.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/securityRequirements.json",
+            "description": "An array representing security requirements.",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json",
+            "description": "Defines a security scheme that can be used by the operations.",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/userPassword.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/apiKey.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/X509.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/symmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/asymmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/HTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flows.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/openIdConnect.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslSecurityScheme.json"
+                }
+            ],
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/userPassword.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/userPassword.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "userPassword"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/apiKey.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/apiKey.json",
+            "type": "object",
+            "required": [
+                "type",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme",
+                    "enum": [
+                        "apiKey"
+                    ]
+                },
+                "in": {
+                    "type": "string",
+                    "description": " The location of the API key.",
+                    "enum": [
+                        "user",
+                        "password"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "apiKey",
+                    "in": "user"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/X509.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/X509.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "X509"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "X509"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/symmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/symmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "symmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "symmetricEncryption"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/asymmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/asymmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "asymmetricEncryption"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/HTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/HTTPSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/NonBearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/BearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/APIKeyHTTPSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/NonBearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/NonBearerHTTPSecurityScheme.json",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "description": "A short description for security scheme.",
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "scheme",
+                "type"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "http"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/BearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/BearerHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "scheme"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235.",
+                    "enum": [
+                        "bearer"
+                    ]
+                },
+                "bearerFormat": {
+                    "type": "string",
+                    "description": "A hint to the client to identify how the bearer token is formatted. Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/APIKeyHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/APIKeyHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "name",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "httpApiKey"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the header, query or cookie parameter to be used."
+                },
+                "in": {
+                    "type": "string",
+                    "description": "The location of the API key",
+                    "enum": [
+                        "header",
+                        "query",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "httpApiKey",
+                    "name": "api_key",
+                    "in": "header"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/oauth2Flows.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/oauth2Flows.json",
+            "type": "object",
+            "description": "Allows configuration of the supported OAuth Flows.",
+            "required": [
+                "type",
+                "flows"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "oauth2"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                },
+                "flows": {
+                    "type": "object",
+                    "properties": {
+                        "implicit": {
+                            "description": "Configuration for the OAuth Implicit flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "tokenUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "password": {
+                            "description": "Configuration for the OAuth Resource Owner Protected Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "clientCredentials": {
+                            "description": "Configuration for the OAuth Client Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "authorizationCode": {
+                            "description": "Configuration for the OAuth Authorization Code flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "scopes": {
+                    "type": "array",
+                    "description": "List of the needed scope names.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/oauth2Flow.json",
+            "type": "object",
+            "description": "Configuration details for a supported OAuth Flow",
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The authorization URL to be used for this flow. This MUST be in the form of an absolute URL."
+                },
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The token URL to be used for this flow. This MUST be in the form of an absolute URL."
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of an absolute URL."
+                },
+                "availableScopes": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/oauth2Scopes.json",
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "authorizationUrl": "https://example.com/api/oauth/dialog",
+                    "tokenUrl": "https://example.com/api/oauth/token",
+                    "availableScopes": {
+                        "write:pets": "modify pets in your account",
+                        "read:pets": "read your pets"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/oauth2Scopes.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/oauth2Scopes.json",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/openIdConnect.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/openIdConnect.json",
+            "type": "object",
+            "required": [
+                "type",
+                "openIdConnectUrl"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "openIdConnect"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation."
+                },
+                "openIdConnectUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of an absolute URL."
+                },
+                "scopes": {
+                    "type": "array",
+                    "description": "List of the needed scope names. An empty array means no scopes are needed.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslPlainSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslScramSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/SaslGssapiSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslPlainSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslPlainSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme. Valid values",
+                    "enum": [
+                        "plain"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslScramSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslScramSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "scramSha256",
+                        "scramSha512"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/SaslGssapiSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/SaslGssapiSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the security scheme.",
+                    "enum": [
+                        "gssapi"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A short description for security scheme."
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for a server.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {},
+                "ws": {},
+                "amqp": {},
+                "amqp1": {},
+                "mqtt": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {},
+                "nats": {},
+                "jms": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {},
+                "sqs": {},
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "solace": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.4.0",
+                                "0.3.0",
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.3.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.2.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "googlepubsub": {},
+                "pulsar": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains information about the server representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "clientId": {
+                    "type": "string",
+                    "description": "The client identifier."
+                },
+                "cleanSession": {
+                    "type": "boolean",
+                    "description": "Whether to create a persistent connection or not. When 'false', the connection will be persistent. This is called clean start in MQTTv5."
+                },
+                "lastWill": {
+                    "type": "object",
+                    "description": "Last Will and Testament configuration.",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "The topic where the Last Will and Testament message will be sent."
+                        },
+                        "qos": {
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2
+                            ],
+                            "description": "Defines how hard the broker/client will try to ensure that the Last Will and Testament message is received. Its value MUST be either 0, 1 or 2."
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Last Will message."
+                        },
+                        "retain": {
+                            "type": "boolean",
+                            "description": "Whether the broker should retain the Last Will and Testament message or not."
+                        }
+                    }
+                },
+                "keepAlive": {
+                    "type": "integer",
+                    "description": "Interval in seconds of the longest period of time the broker and the client can endure without sending a message."
+                },
+                "sessionExpiryInterval": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Interval time in seconds or a Schema Object containing the definition of the interval.  The broker maintains a session for a disconnected client until this interval expires."
+                },
+                "maximumPacketSize": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4294967295
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Number of bytes or a Schema Object representing the Maximum Packet Size the Client is willing to accept."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "clientId": "guest",
+                    "cleanSession": true,
+                    "lastWill": {
+                        "topic": "/last-wills",
+                        "qos": 2,
+                        "message": "Guest gone offline.",
+                        "retain": false
+                    },
+                    "keepAlive": 60,
+                    "sessionExpiryInterval": 120,
+                    "maximumPacketSize": 1024,
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/schema.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/schema.json",
+            "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is a superset of the JSON Schema Specification Draft 07. The empty schema (which allows any instance to validate) MAY be represented by the boolean value true and a schema which allows no instance to validate MAY be represented by the boolean value false.",
+            "allOf": [
+                {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                },
+                {
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                    }
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "allOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "oneOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "anyOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "not": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "patternProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "propertyNames": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "contains": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "discriminator": {
+                            "type": "string",
+                            "description": "Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. The property name used MUST be defined at this schema and it MUST be in the required property list. When used, the value MUST be the name of this schema or any schema that inherits it. See Composition and Inheritance for more details."
+                        },
+                        "externalDocs": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                                }
+                            ]
+                        },
+                        "deprecated": {
+                            "type": "boolean",
+                            "description": "Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is false.",
+                            "default": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://json-schema.org/draft-07/schema": {
+            "$id": "http://json-schema.org/draft-07/schema",
+            "title": "Core schema meta-schema",
+            "definitions": {
+                "schemaArray": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#"
+                    }
+                },
+                "nonNegativeInteger": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "nonNegativeIntegerDefault0": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/nonNegativeInteger"
+                        },
+                        {
+                            "default": 0
+                        }
+                    ]
+                },
+                "simpleTypes": {
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "null",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "stringArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": []
+                }
+            },
+            "type": [
+                "object",
+                "boolean"
+            ],
+            "properties": {
+                "$id": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$schema": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "$ref": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$comment": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": true,
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "items": true
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "number"
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "number"
+                },
+                "maxLength": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minLength": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "additionalItems": {
+                    "$ref": "#"
+                },
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/schemaArray"
+                        }
+                    ],
+                    "default": true
+                },
+                "maxItems": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minItems": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "contains": {
+                    "$ref": "#"
+                },
+                "maxProperties": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minProperties": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "required": {
+                    "$ref": "#/definitions/stringArray"
+                },
+                "additionalProperties": {
+                    "$ref": "#"
+                },
+                "definitions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "patternProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "propertyNames": {
+                        "format": "regex"
+                    },
+                    "default": {}
+                },
+                "dependencies": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/stringArray"
+                            }
+                        ]
+                    }
+                },
+                "propertyNames": {
+                    "$ref": "#"
+                },
+                "const": true,
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/simpleTypes"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/simpleTypes"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    ]
+                },
+                "format": {
+                    "type": "string"
+                },
+                "contentMediaType": {
+                    "type": "string"
+                },
+                "contentEncoding": {
+                    "type": "string"
+                },
+                "if": {
+                    "$ref": "#"
+                },
+                "then": {
+                    "$ref": "#"
+                },
+                "else": {
+                    "$ref": "#"
+                },
+                "allOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "anyOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "oneOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "not": {
+                    "$ref": "#"
+                }
+            },
+            "default": true
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/server.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/server.json",
+            "title": "Server Schema",
+            "description": "This object contains configuration for describing a JMS broker as an AsyncAPI server. This objects only contains configuration that can not be provided in the AsyncAPI standard server object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "jmsConnectionFactory"
+            ],
+            "properties": {
+                "jmsConnectionFactory": {
+                    "type": "string",
+                    "description": "The classname of the ConnectionFactory implementation for the JMS Provider."
+                },
+                "properties": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json#/definitions/property"
+                    },
+                    "description": "Additional properties to set on the JMS ConnectionFactory implementation for the JMS Provider."
+                },
+                "clientID": {
+                    "type": "string",
+                    "description": "A client identifier for applications that use this JMS connection factory. If the Client ID Policy is set to 'Restricted' (the default), then configuring a Client ID on the ConnectionFactory prevents more than one JMS client from using a connection from this factory."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "definitions": {
+                "property": {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of a property"
+                        },
+                        "value": {
+                            "type": [
+                                "string",
+                                "boolean",
+                                "number",
+                                "null"
+                            ],
+                            "description": "The name of a property"
+                        }
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "jmsConnectionFactory": "org.apache.activemq.ActiveMQConnectionFactory",
+                    "properties": [
+                        {
+                            "name": "disableTimeStampsByDefault",
+                            "value": false
+                        }
+                    ],
+                    "clientID": "my-application-1",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json",
+            "title": "IBM MQ server bindings object",
+            "description": "This object contains server connection information about the IBM MQ server, referred to as an IBM MQ queue manager. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "type": "string",
+                    "description": "Defines a logical group of IBM MQ server objects. This is necessary to specify multi-endpoint configurations used in high availability deployments. If omitted, the server object is not part of a group."
+                },
+                "ccdtQueueManagerName": {
+                    "type": "string",
+                    "default": "*",
+                    "description": "The name of the IBM MQ queue manager to bind to in the CCDT file."
+                },
+                "cipherSpec": {
+                    "type": "string",
+                    "description": "The recommended cipher specification used to establish a TLS connection between the client and the IBM MQ queue manager. More information on SSL/TLS cipher specifications supported by IBM MQ can be found on this page in the IBM MQ Knowledge Center."
+                },
+                "multiEndpointServer": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If 'multiEndpointServer' is 'true' then multiple connections can be workload balanced and applications should not make assumptions as to where messages are processed. Where message ordering, or affinity to specific message resources is necessary, a single endpoint ('multiEndpointServer' = 'false') may be required."
+                },
+                "heartBeatInterval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 999999,
+                    "default": 300,
+                    "description": "The recommended value (in seconds) for the heartbeat sent to the queue manager during periods of inactivity. A value of zero means that no heart beats are sent. A value of 1 means that the client will use the value defined by the queue manager. More information on heart beat interval can be found on this page in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": "PRODCLSTR1",
+                    "cipherSpec": "ANY_TLS12_OR_HIGHER",
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "groupId": "PRODCLSTR1",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.4.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.4.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msgVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "clientName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160,
+                    "description": "A unique client name to use to register to the appliance. If specified, it must be a valid Topic name, and a maximum of 160 bytes in length when encoded as UTF-8."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.3.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.3.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msgVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.2.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.2.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msvVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/pulsar/0.1.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server information of Pulsar broker, which covers cluster and tenant admin configuration. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "tenant": {
+                    "type": "string",
+                    "description": "The pulsar tenant. If omitted, 'public' MUST be assumed."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "tenant": "contoso",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channels.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channels.json",
+            "type": "object",
+            "description": "An object containing all the Channel Object definitions the Application MUST use during runtime.",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/channel.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "userSignedUp": {
+                        "address": "user.signedup",
+                        "messages": {
+                            "userSignedUp": {
+                                "$ref": "#/components/messages/userSignedUp"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channel.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channel.json",
+            "type": "object",
+            "description": "Describes a shared communication channel.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "address": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "An optional string representation of this channel's address. The address is typically the \"topic name\", \"routing key\", \"event type\", or \"path\". When `null` or absent, it MUST be interpreted as unknown. This is useful when the address is generated dynamically at runtime or can't be known upfront. It MAY contain Channel Address Expressions."
+                },
+                "messages": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/channelMessages.json"
+                },
+                "parameters": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/parameters.json"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the channel."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the channel."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the channel. CommonMark is allowed."
+                },
+                "servers": {
+                    "type": "array",
+                    "description": "The references of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    "uniqueItems": true
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping of channels.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "address": "users.{userId}",
+                    "title": "Users channel",
+                    "description": "This channel is used to exchange messages about user events.",
+                    "messages": {
+                        "userSignedUp": {
+                            "$ref": "#/components/messages/userSignedUp"
+                        },
+                        "userCompletedOrder": {
+                            "$ref": "#/components/messages/userCompletedOrder"
+                        }
+                    },
+                    "parameters": {
+                        "userId": {
+                            "$ref": "#/components/parameters/userId"
+                        }
+                    },
+                    "servers": [
+                        {
+                            "$ref": "#/servers/rabbitmqInProd"
+                        },
+                        {
+                            "$ref": "#/servers/rabbitmqInStaging"
+                        }
+                    ],
+                    "bindings": {
+                        "amqp": {
+                            "is": "queue",
+                            "queue": {
+                                "exclusive": true
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "name": "user",
+                            "description": "User-related messages"
+                        }
+                    ],
+                    "externalDocs": {
+                        "description": "Find more info here",
+                        "url": "https://example.com"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channelMessages.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channelMessages.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageObject.json"
+                    }
+                ]
+            },
+            "description": "A map of the messages that will be sent to this channel by any application at any time. **Every message sent to this channel MUST be valid against one, and only one, of the message objects defined in this map.**"
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageObject.json",
+            "type": "object",
+            "description": "Describes a message received on a given channel and operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "contentType": {
+                    "type": "string",
+                    "description": "The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. application/json). When omitted, the value MUST be the one specified on the defaultContentType field."
+                },
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                },
+                "payload": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                },
+                "correlationId": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/correlationId.json"
+                        }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the message."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the message."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the message. CommonMark is allowed."
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "List of examples.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
+                    }
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+                        }
+                    ]
+                },
+                "traits": {
+                    "type": "array",
+                    "description": "A list of traits to apply to the message object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Message Object.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/messageTrait.json"
+                            },
+                            {
+                                "type": "array",
+                                "items": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                            },
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/3.0.0/messageTrait.json"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "additionalItems": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "messageId": "userSignup",
+                    "name": "UserSignup",
+                    "title": "User signup",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "contentType": "application/json",
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "correlationId": {
+                                "description": "Correlation ID set by application",
+                                "type": "string"
+                            },
+                            "applicationInstanceId": {
+                                "description": "Unique identifier for a given instance of the publishing application",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "payload": {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "$ref": "#/components/schemas/userCreate"
+                            },
+                            "signup": {
+                                "$ref": "#/components/schemas/signup"
+                            }
+                        }
+                    },
+                    "correlationId": {
+                        "description": "Default Correlation ID",
+                        "location": "$message.header#/correlationId"
+                    },
+                    "traits": [
+                        {
+                            "$ref": "#/components/messageTraits/commonHeaders"
+                        }
+                    ],
+                    "examples": [
+                        {
+                            "name": "SimpleSignup",
+                            "summary": "A simple UserSignup example message",
+                            "headers": {
+                                "correlationId": "my-correlation-id",
+                                "applicationInstanceId": "myInstanceId"
+                            },
+                            "payload": {
+                                "user": {
+                                    "someUserKey": "someUserValue"
+                                },
+                                "signup": {
+                                    "someSignupKey": "someSignupValue"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/anySchema.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/anySchema.json",
+            "if": {
+                "required": [
+                    "schema"
+                ]
+            },
+            "then": {
+                "$ref": "http://asyncapi.com/definitions/3.0.0/multiFormatSchema.json"
+            },
+            "else": {
+                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+            },
+            "description": "An object representing either a schema or a multiFormatSchema based on the existence of the 'schema' property. If the property 'schema' is present, use the multi-format schema. Use the default AsyncAPI Schema otherwise."
+        },
+        "http://asyncapi.com/definitions/3.0.0/multiFormatSchema.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/multiFormatSchema.json",
+            "description": "The Multi Format Schema Object represents a schema definition. It differs from the Schema Object in that it supports multiple schema formats or languages (e.g., JSON Schema, Avro, etc.).",
+            "type": "object",
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "if": {
+                "not": {
+                    "type": "object"
+                }
+            },
+            "then": {
+                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+            },
+            "else": {
+                "properties": {
+                    "schemaFormat": {
+                        "description": "A string containing the name of the schema format that is used to define the information. If schemaFormat is missing, it MUST default to application/vnd.aai.asyncapi+json;version={{asyncapi}} where {{asyncapi}} matches the AsyncAPI Version String. In such a case, this would make the Multi Format Schema Object equivalent to the Schema Object. When using Reference Object within the schema, the schemaFormat of the resource being referenced MUST match the schemaFormat of the schema that contains the initial reference. For example, if you reference Avro schema, then schemaFormat of referencing resource and the resource being reference MUST match.",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "description": "All the schema formats tooling MUST support",
+                                "enum": [
+                                    "application/schema+json;version=draft-07",
+                                    "application/schema+yaml;version=draft-07",
+                                    "application/vnd.aai.asyncapi;version=3.0.0",
+                                    "application/vnd.aai.asyncapi+json;version=3.0.0",
+                                    "application/vnd.aai.asyncapi+yaml;version=3.0.0"
+                                ]
+                            },
+                            {
+                                "description": "All the schema formats tools are RECOMMENDED to support",
+                                "enum": [
+                                    "application/vnd.oai.openapi;version=3.0.0",
+                                    "application/vnd.oai.openapi+json;version=3.0.0",
+                                    "application/vnd.oai.openapi+yaml;version=3.0.0",
+                                    "application/vnd.apache.avro;version=1.9.0",
+                                    "application/vnd.apache.avro+json;version=1.9.0",
+                                    "application/vnd.apache.avro+yaml;version=1.9.0",
+                                    "application/raml+yaml;version=1.0"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "not": {
+                                "description": "If no schemaFormat has been defined, default to schema or reference",
+                                "required": [
+                                    "schemaFormat"
+                                ]
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "description": "If schemaFormat has been defined check if it's one of the AsyncAPI Schema Object formats",
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.aai.asyncapi;version=2.0.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.0.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.0.0",
+                                        "application/vnd.aai.asyncapi;version=2.1.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.1.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.1.0",
+                                        "application/vnd.aai.asyncapi;version=2.2.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.2.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.2.0",
+                                        "application/vnd.aai.asyncapi;version=2.3.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.3.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.3.0",
+                                        "application/vnd.aai.asyncapi;version=2.4.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.4.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.4.0",
+                                        "application/vnd.aai.asyncapi;version=2.5.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.5.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.5.0",
+                                        "application/vnd.aai.asyncapi;version=2.6.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.6.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.6.0",
+                                        "application/vnd.aai.asyncapi;version=3.0.0",
+                                        "application/vnd.aai.asyncapi+json;version=3.0.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=3.0.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/schema+json;version=draft-07",
+                                        "application/schema+yaml;version=draft-07"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://json-schema.org/draft-07/schema"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.oai.openapi;version=3.0.0",
+                                        "application/vnd.oai.openapi+json;version=3.0.0",
+                                        "application/vnd.oai.openapi+yaml;version=3.0.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.apache.avro;version=1.9.0",
+                                        "application/vnd.apache.avro+json;version=1.9.0",
+                                        "application/vnd.apache.avro+yaml;version=1.9.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json",
+            "type": "object",
+            "definitions": {
+                "ExternalDocumentation": {
+                    "type": "object",
+                    "required": [
+                        "url"
+                    ],
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                },
+                "Discriminator": {
+                    "type": "object",
+                    "required": [
+                        "propertyName"
+                    ],
+                    "properties": {
+                        "propertyName": {
+                            "type": "string"
+                        },
+                        "mapping": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "Reference": {
+                    "type": "object",
+                    "required": [
+                        "$ref"
+                    ],
+                    "patternProperties": {
+                        "^\\$ref$": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    }
+                },
+                "XML": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "attribute": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "wrapped": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxLength": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "maxItems": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": false
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "not": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "allOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "oneOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "items": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "default": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "default": true,
+                "nullable": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "discriminator": {
+                    "$ref": "#/definitions/Discriminator"
+                },
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "example": true,
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "xml": {
+                    "$ref": "#/definitions/XML"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json",
+            "definitions": {
+                "avroSchema": {
+                    "title": "Avro Schema",
+                    "description": "Root Schema",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/types"
+                        }
+                    ]
+                },
+                "types": {
+                    "title": "Avro Types",
+                    "description": "Allowed Avro types",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/primitiveType"
+                        },
+                        {
+                            "$ref": "#/definitions/primitiveTypeWithMetadata"
+                        },
+                        {
+                            "$ref": "#/definitions/customTypeReference"
+                        },
+                        {
+                            "$ref": "#/definitions/avroRecord"
+                        },
+                        {
+                            "$ref": "#/definitions/avroEnum"
+                        },
+                        {
+                            "$ref": "#/definitions/avroArray"
+                        },
+                        {
+                            "$ref": "#/definitions/avroMap"
+                        },
+                        {
+                            "$ref": "#/definitions/avroFixed"
+                        },
+                        {
+                            "$ref": "#/definitions/avroUnion"
+                        }
+                    ]
+                },
+                "primitiveType": {
+                    "title": "Primitive Type",
+                    "description": "Basic type primitives.",
+                    "type": "string",
+                    "enum": [
+                        "null",
+                        "boolean",
+                        "int",
+                        "long",
+                        "float",
+                        "double",
+                        "bytes",
+                        "string"
+                    ]
+                },
+                "primitiveTypeWithMetadata": {
+                    "title": "Primitive Type With Metadata",
+                    "description": "A primitive type with metadata attached.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "$ref": "#/definitions/primitiveType"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "customTypeReference": {
+                    "title": "Custom Type",
+                    "description": "Reference to a ComplexType",
+                    "not": {
+                        "$ref": "#/definitions/primitiveType"
+                    },
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+                },
+                "avroUnion": {
+                    "title": "Union",
+                    "description": "A Union of types",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/avroSchema"
+                    },
+                    "minItems": 1
+                },
+                "avroField": {
+                    "title": "Field",
+                    "description": "A field within a Record",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/types"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "default": true,
+                        "order": {
+                            "enum": [
+                                "ascending",
+                                "descending",
+                                "ignore"
+                            ]
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "type"
+                    ]
+                },
+                "avroRecord": {
+                    "title": "Record",
+                    "description": "A Record",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "record"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "fields": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/avroField"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "fields"
+                    ]
+                },
+                "avroEnum": {
+                    "title": "Enum",
+                    "description": "An enumeration",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "enum"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "symbols": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "symbols"
+                    ]
+                },
+                "avroArray": {
+                    "title": "Array",
+                    "description": "An array",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "array"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "items": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "items"
+                    ]
+                },
+                "avroMap": {
+                    "title": "Map",
+                    "description": "A map of values",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "map"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "values": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "values"
+                    ]
+                },
+                "avroFixed": {
+                    "title": "Fixed",
+                    "description": "A fixed sized array of bytes",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "fixed"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "size": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "size"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                },
+                "namespace": {
+                    "type": "string",
+                    "pattern": "^([A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*)*$"
+                }
+            },
+            "description": "Json-Schema definition for Avro AVSC files.",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/avroSchema"
+                }
+            ],
+            "title": "Avro Schema Definition"
+        },
+        "http://asyncapi.com/definitions/3.0.0/correlationId.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/correlationId.json",
+            "type": "object",
+            "description": "An object that specifies an identifier at design time that can used for message tracing and correlation.",
+            "required": [
+                "location"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed."
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the correlation ID",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "examples": [
+                {
+                    "description": "Default Correlation ID",
+                    "location": "$message.header#/correlationId"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json",
+            "type": "object",
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "payload"
+                    ]
+                },
+                {
+                    "required": [
+                        "headers"
+                    ]
+                }
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Machine readable name of the message example."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message example."
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Example of the application headers. It MUST be a map of key-value pairs."
+                },
+                "payload": {
+                    "type": [
+                        "number",
+                        "string",
+                        "boolean",
+                        "object",
+                        "array",
+                        "null"
+                    ],
+                    "description": "Example of the message payload. It can be of any type."
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for a message.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "ws": {},
+                "amqp": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp1": {},
+                "mqtt": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json"
+                            }
+                        }
+                    ]
+                },
+                "nats": {},
+                "jms": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/message.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {},
+                "sqs": {},
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json"
+                            }
+                        }
+                    ]
+                },
+                "solace": {},
+                "googlepubsub": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "http://asyncapi.com/bindings/http/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.3.0/message.json",
+            "title": "HTTP message bindings object",
+            "description": "This object contains information about the message representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "\tA Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "statusCode": {
+                    "type": "number",
+                    "description": "The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes). `statusCode` is only relevant for messages referenced by the [Operation Reply Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyObject), as it defines the status code for the response. In all other cases, this value can be safely ignored."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "Content-Type": {
+                                "type": "string",
+                                "enum": [
+                                    "application/json"
+                                ]
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.2.0/message.json",
+            "title": "HTTP message bindings object",
+            "description": "This object contains information about the message representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "\tA Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "Content-Type": {
+                                "type": "string",
+                                "enum": [
+                                    "application/json"
+                                ]
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/message.json",
+            "title": "AMQP message bindings object",
+            "description": "This object contains information about the message representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "contentEncoding": {
+                    "type": "string",
+                    "description": "A MIME encoding for the message content."
+                },
+                "messageType": {
+                    "type": "string",
+                    "description": "Application-specific message type."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "contentEncoding": "gzip",
+                    "messageType": "user.signup",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json",
+            "title": "MQTT message bindings object",
+            "description": "This object contains information about the message representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "payloadFormatIndicator": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1
+                    ],
+                    "description": "1 indicates that the payload is UTF-8 encoded character data.  0 indicates that the payload format is unspecified.",
+                    "default": 0
+                },
+                "correlationData": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Correlation Data is used by the sender of the request message to identify which request the response message is for when it is received."
+                },
+                "contentType": {
+                    "type": "string",
+                    "description": "String describing the content type of the message payload. This should not conflict with the contentType field of the associated AsyncAPI Message object."
+                },
+                "responseTopic": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "format": "uri-template",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "The topic (channel URI) to be used for a response message."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.2.0"
+                },
+                {
+                    "contentType": "application/json",
+                    "correlationData": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "responseTopic": "application/responses",
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.5.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.4.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json": {
+            "$id": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json",
+            "title": "Anypoint MQ message bindings object",
+            "description": "This object contains configuration for describing an Anypoint MQ message as an AsyncAPI message. This objects only contains configuration that can not be provided in the AsyncAPI standard message object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions for Anypoint MQ-specific headers (protocol headers). This schema MUST be of type 'object' and have a 'properties' key. Examples of Anypoint MQ protocol headers are 'messageId' and 'messageGroupId'."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "messageId": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/message.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/message.json",
+            "title": "Message Schema",
+            "description": "This object contains configuration for describing a JMS message as an AsyncAPI message. This objects only contains configuration that can not be provided in the AsyncAPI standard message object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for JMS headers (protocol headers). This schema MUST be of type 'object' and have a 'properties' key. Examples of JMS protocol headers are 'JMSMessageID', 'JMSTimestamp', and 'JMSCorrelationID'."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "required": [
+                            "JMSMessageID"
+                        ],
+                        "properties": {
+                            "JMSMessageID": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A unique message identifier. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSTimestamp": {
+                                "type": "integer",
+                                "description": "The time the message was sent. This may be set by your JMS Provider on your behalf. The time the message was sent. The value of the timestamp is the amount of time, measured in milliseconds, that has elapsed since midnight, January 1, 1970, UTC."
+                            },
+                            "JMSDeliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "PERSISTENT",
+                                    "NON_PERSISTENT"
+                                ],
+                                "default": "PERSISTENT",
+                                "description": "Denotes the delivery mode for the message. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSPriority": {
+                                "type": "integer",
+                                "default": 4,
+                                "description": "The priority of the message. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSExpires": {
+                                "type": "integer",
+                                "description": "The time at which the message expires. This may be set by your JMS Provider on your behalf. A value of zero means that the message does not expire. Any non-zero value is the amount of time, measured in milliseconds, that has elapsed since midnight, January 1, 1970, UTC, at which the message will expire."
+                            },
+                            "JMSType": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The type of message. Some JMS providers use a message repository that contains the definitions of messages sent by applications. The 'JMSType' header field may reference a message's definition in the provider's repository. The JMS API does not define a standard message definition repository, nor does it define a naming policy for the definitions it contains. Some messaging systems require that a message type definition for each application message be created and that each message specify its type. In order to work with such JMS providers, JMS clients should assign a value to 'JMSType', whether the application makes use of it or not. This ensures that the field is properly set for those providers that require it."
+                            },
+                            "JMSCorrelationID": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The correlation identifier of the message. A client can use the 'JMSCorrelationID' header field to link one message with another. A typical use is to link a response message with its request message. Since each message sent by a JMS provider is assigned a message ID value, it is convenient to link messages via message ID, such message ID values must start with the 'ID:' prefix. Conversely, application-specified values must not start with the 'ID:' prefix; this is reserved for provider-generated message ID values."
+                            },
+                            "JMSReplyTo": {
+                                "type": "string",
+                                "description": "The queue or topic that the message sender expects replies to."
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json",
+            "title": "IBM MQ message bindings object",
+            "description": "This object contains information about the message representation in IBM MQ.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "string",
+                        "jms",
+                        "binary"
+                    ],
+                    "default": "string",
+                    "description": "The type of the message."
+                },
+                "headers": {
+                    "type": "string",
+                    "description": "Defines the IBM MQ message headers to include with this message. More than one header can be specified as a comma separated list. Supporting information on IBM MQ message formats can be found on this [page](https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqmd-format-mqchar8) in the IBM MQ Knowledge Center."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Provides additional information for application developers: describes the message type or format."
+                },
+                "expiry": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "The recommended setting the client should use for the TTL (Time-To-Live) of the message. This is a period of time expressed in milliseconds and set by the application that puts the message. 'expiry' values are API dependant e.g., MQI and JMS use different units of time and default values for 'unlimited'. General information on IBM MQ message expiry can be found on this [page](https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqmd-expiry-mqlong) in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "const": "binary"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "const": "jms"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "headers"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "const": "string"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "headers"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "type": "string",
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "type": "jms",
+                    "description": "JMS stream message",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json",
+            "title": "Cloud Pub/Sub Channel Schema",
+            "description": "This object contains information about the message representation for Google Cloud Pub/Sub.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                },
+                "attributes": {
+                    "type": "object"
+                },
+                "orderingKey": {
+                    "type": "string"
+                },
+                "schema": {
+                    "type": "object",
+                    "additionalItems": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "schema": {
+                        "name": "projects/your-project-id/schemas/your-avro-schema-id"
+                    }
+                },
+                {
+                    "schema": {
+                        "name": "projects/your-project-id/schemas/your-protobuf-schema-id"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/messageTrait.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/messageTrait.json",
+            "type": "object",
+            "description": "Describes a trait that MAY be applied to a Message Object. This object MAY contain any property from the Message Object, except payload and traits.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "contentType": {
+                    "type": "string",
+                    "description": "The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. application/json). When omitted, the value MUST be the one specified on the defaultContentType field."
+                },
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                },
+                "correlationId": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/correlationId.json"
+                        }
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the message."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the message."
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the message."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the message. CommonMark is allowed."
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "description": "List of examples.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/messageExampleObject.json"
+                    }
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "contentType": "application/json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/parameters.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/parameters.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/parameter.json"
+                    }
+                ]
+            },
+            "description": "JSON objects describing re-usable channel parameters.",
+            "examples": [
+                {
+                    "address": "user/{userId}/signedup",
+                    "parameters": {
+                        "userId": {
+                            "description": "Id of the user."
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/parameter.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/parameter.json",
+            "description": "Describes a parameter included in a channel address.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed."
+                },
+                "enum": {
+                    "description": "An enumeration of string values to be used if the substitution options are from a limited set.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "description": "The default value to use for substitution, and to send, if an alternate value is not supplied.",
+                    "type": "string"
+                },
+                "examples": {
+                    "description": "An array of examples of the parameter value.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the parameter value",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "examples": [
+                {
+                    "address": "user/{userId}/signedup",
+                    "parameters": {
+                        "userId": {
+                            "description": "Id of the user.",
+                            "location": "$message.payload#/user/id"
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for a channel.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {},
+                "ws": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp1": {},
+                "mqtt": {},
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "nats": {},
+                "jms": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "sqs": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "solace": {},
+                "googlepubsub": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json"
+                            }
+                        }
+                    ]
+                },
+                "pulsar": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "http://asyncapi.com/bindings/websockets/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json",
+            "title": "WebSockets channel bindings object",
+            "description": "When using WebSockets, the channel represents the connection. Unlike other protocols that support multiple virtual channels (topics, routing keys, etc.) per connection, WebSockets doesn't support virtual channels or, put it another way, there's only one channel and its characteristics are strongly related to the protocol used for the handshake, i.e., HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "POST"
+                    ],
+                    "description": "The HTTP method to use when establishing the connection. Its value MUST be either 'GET' or 'POST'."
+                },
+                "query": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "headers": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "method": "POST",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json",
+            "title": "AMQP channel bindings object",
+            "description": "This object contains information about the channel representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "is": {
+                    "type": "string",
+                    "enum": [
+                        "queue",
+                        "routingKey"
+                    ],
+                    "description": "Defines what type of channel is it. Can be either 'queue' or 'routingKey' (default)."
+                },
+                "exchange": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "The name of the exchange. It MUST NOT exceed 255 characters long."
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "topic",
+                                "direct",
+                                "fanout",
+                                "default",
+                                "headers"
+                            ],
+                            "description": "The type of the exchange. Can be either 'topic', 'direct', 'fanout', 'default' or 'headers'."
+                        },
+                        "durable": {
+                            "type": "boolean",
+                            "description": "Whether the exchange should survive broker restarts or not."
+                        },
+                        "autoDelete": {
+                            "type": "boolean",
+                            "description": "Whether the exchange should be deleted when the last queue is unbound from it."
+                        },
+                        "vhost": {
+                            "type": "string",
+                            "default": "/",
+                            "description": "The virtual host of the exchange. Defaults to '/'."
+                        }
+                    },
+                    "description": "When is=routingKey, this object defines the exchange properties."
+                },
+                "queue": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "The name of the queue. It MUST NOT exceed 255 characters long."
+                        },
+                        "durable": {
+                            "type": "boolean",
+                            "description": "Whether the queue should survive broker restarts or not."
+                        },
+                        "exclusive": {
+                            "type": "boolean",
+                            "description": "Whether the queue should be used only by one connection or not."
+                        },
+                        "autoDelete": {
+                            "type": "boolean",
+                            "description": "Whether the queue should be deleted when the last consumer unsubscribes."
+                        },
+                        "vhost": {
+                            "type": "string",
+                            "default": "/",
+                            "description": "The virtual host of the queue. Defaults to '/'."
+                        }
+                    },
+                    "description": "When is=queue, this object defines the queue properties."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "is": {
+                            "const": "routingKey"
+                        }
+                    },
+                    "required": [
+                        "exchange"
+                    ],
+                    "not": {
+                        "required": [
+                            "queue"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "is": {
+                            "const": "queue"
+                        }
+                    },
+                    "required": [
+                        "queue"
+                    ],
+                    "not": {
+                        "required": [
+                            "exchange"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "is": "routingKey",
+                    "exchange": {
+                        "name": "myExchange",
+                        "type": "topic",
+                        "durable": true,
+                        "autoDelete": false,
+                        "vhost": "/"
+                    },
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "is": "queue",
+                    "queue": {
+                        "name": "my-queue-name",
+                        "durable": true,
+                        "exclusive": true,
+                        "autoDelete": false,
+                        "vhost": "/"
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "confluent.key.schema.validation": {
+                            "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.key.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+                            "type": "string"
+                        },
+                        "confluent.value.schema.validation": {
+                            "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.value.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json": {
+            "$id": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json",
+            "title": "Anypoint MQ channel bindings object",
+            "description": "This object contains configuration for describing an Anypoint MQ exchange, queue, or FIFO queue as an AsyncAPI channel. This objects only contains configuration that can not be provided in the AsyncAPI standard channel object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "The destination (queue or exchange) name for this channel. SHOULD only be specified if the channel name differs from the actual destination name, such as when the channel name is not a valid destination name in Anypoint MQ. Defaults to the channel name."
+                },
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "exchange",
+                        "queue",
+                        "fifo-queue"
+                    ],
+                    "default": "queue",
+                    "description": "The type of destination. SHOULD be specified to document the messaging model (publish/subscribe, point-to-point, strict message ordering) supported by this channel."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "destination": "user-signup-exchg",
+                    "destinationType": "exchange",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/channel.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains configuration for describing a JMS queue, or FIFO queue as an AsyncAPI channel. This objects only contains configuration that can not be provided in the AsyncAPI standard channel object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "The destination (queue) name for this channel. SHOULD only be specified if the channel name differs from the actual destination name, such as when the channel name is not a valid destination name according to the JMS Provider. Defaults to the channel name."
+                },
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "queue",
+                        "fifo-queue"
+                    ],
+                    "default": "queue",
+                    "description": "The type of destination. SHOULD be specified to document the messaging model (point-to-point, or strict message ordering) supported by this channel."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "destination": "user-signed-up",
+                    "destinationType": "fifo-queue",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sns/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/sns/0.1.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in SNS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the topic. Can be different from the channel name to allow flexibility around AWS resource naming limitations."
+                },
+                "ordering": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/ordering"
+                },
+                "policy": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/policy"
+                },
+                "tags": {
+                    "type": "object",
+                    "description": "Key-value pairs that represent AWS tags on the topic."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "description": "The version of this binding.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "definitions": {
+                "ordering": {
+                    "type": "object",
+                    "description": "By default, we assume an unordered SNS topic. This field allows configuration of a FIFO SNS Topic.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Defines the type of SNS Topic.",
+                            "enum": [
+                                "standard",
+                                "FIFO"
+                            ]
+                        },
+                        "contentBasedDeduplication": {
+                            "type": "boolean",
+                            "description": "True to turn on de-duplication of messages for a channel."
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SNS Topic.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this topic",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SNS permission being allowed or denied e.g. sns:Publish",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "name": "my-sns-topic",
+                    "policy": {
+                        "statements": [
+                            {
+                                "effect": "Allow",
+                                "principal": "*",
+                                "action": "SNS:Publish"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sqs/0.2.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in SQS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queue": {
+                    "description": "A definition of the queue that will be used as the channel.",
+                    "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/queue"
+                },
+                "deadLetterQueue": {
+                    "description": "A definition of the queue that will be used for un-processable messages.",
+                    "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/queue"
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0",
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "queue"
+            ],
+            "definitions": {
+                "queue": {
+                    "type": "object",
+                    "description": "A definition of a queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the queue. When an SNS Operation Binding Object references an SQS queue by name, the identifier should be the one in this field."
+                        },
+                        "fifoQueue": {
+                            "type": "boolean",
+                            "description": "Is this a FIFO queue?",
+                            "default": false
+                        },
+                        "deduplicationScope": {
+                            "type": "string",
+                            "enum": [
+                                "queue",
+                                "messageGroup"
+                            ],
+                            "description": "Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue (default).",
+                            "default": "queue"
+                        },
+                        "fifoThroughputLimit": {
+                            "type": "string",
+                            "enum": [
+                                "perQueue",
+                                "perMessageGroupId"
+                            ],
+                            "description": "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue (default) and perMessageGroupId.",
+                            "default": "perQueue"
+                        },
+                        "deliveryDelay": {
+                            "type": "integer",
+                            "description": "The number of seconds to delay before a message sent to the queue can be received. used to create a delay queue.",
+                            "minimum": 0,
+                            "maximum": 900,
+                            "default": 0
+                        },
+                        "visibilityTimeout": {
+                            "type": "integer",
+                            "description": "The length of time, in seconds, that a consumer locks a message - hiding it from reads - before it is unlocked and can be read again.",
+                            "minimum": 0,
+                            "maximum": 43200,
+                            "default": 30
+                        },
+                        "receiveMessageWaitTime": {
+                            "type": "integer",
+                            "description": "Determines if the queue uses short polling or long polling. Set to zero the queue reads available messages and returns immediately. Set to a non-zero integer, long polling waits the specified number of seconds for messages to arrive before returning.",
+                            "default": 0
+                        },
+                        "messageRetentionPeriod": {
+                            "type": "integer",
+                            "description": "How long to retain a message on the queue in seconds, unless deleted.",
+                            "minimum": 60,
+                            "maximum": 1209600,
+                            "default": 345600
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/redrivePolicy"
+                        },
+                        "policy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/policy"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "description": "Key-value pairs that represent AWS tags on the queue."
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "fifoQueue"
+                    ]
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/identifier"
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                },
+                "identifier": {
+                    "type": "object",
+                    "description": "The SQS queue to use as a dead letter queue (DLQ).",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding."
+                        }
+                    }
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SQS Queue",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this queue.",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SQS permission being allowed or denied e.g. sqs:ReceiveMessage",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "queue": {
+                        "name": "myQueue",
+                        "fifoQueue": true,
+                        "deduplicationScope": "messageGroup",
+                        "fifoThroughputLimit": "perMessageGroupId",
+                        "deliveryDelay": 15,
+                        "visibilityTimeout": 60,
+                        "receiveMessageWaitTime": 0,
+                        "messageRetentionPeriod": 86400,
+                        "redrivePolicy": {
+                            "deadLetterQueue": {
+                                "arn": "arn:aws:SQS:eu-west-1:0000000:123456789"
+                            },
+                            "maxReceiveCount": 15
+                        },
+                        "policy": {
+                            "statements": [
+                                {
+                                    "effect": "Deny",
+                                    "principal": "arn:aws:iam::123456789012:user/dec.kolakowski",
+                                    "action": [
+                                        "sqs:SendMessage",
+                                        "sqs:ReceiveMessage"
+                                    ]
+                                }
+                            ]
+                        },
+                        "tags": {
+                            "owner": "AsyncAPI.NET",
+                            "platform": "AsyncAPIOrg"
+                        }
+                    },
+                    "deadLetterQueue": {
+                        "name": "myQueue_error",
+                        "deliveryDelay": 0,
+                        "visibilityTimeout": 0,
+                        "receiveMessageWaitTime": 0,
+                        "messageRetentionPeriod": 604800
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json",
+            "title": "IBM MQ channel bindings object",
+            "description": "This object contains information about the channel representation in IBM MQ. Each channel corresponds to a Queue or Topic within IBM MQ.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "topic",
+                        "queue"
+                    ],
+                    "default": "topic",
+                    "description": "Defines the type of AsyncAPI channel."
+                },
+                "queue": {
+                    "type": "object",
+                    "description": "Defines the properties of a queue.",
+                    "properties": {
+                        "objectName": {
+                            "type": "string",
+                            "maxLength": 48,
+                            "description": "Defines the name of the IBM MQ queue associated with the channel."
+                        },
+                        "isPartitioned": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Defines if the queue is a cluster queue and therefore partitioned. If 'true', a binding option MAY be specified when accessing the queue. More information on binding options can be found on this page in the IBM MQ Knowledge Center."
+                        },
+                        "exclusive": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Specifies if it is recommended to open the queue exclusively."
+                        }
+                    },
+                    "required": [
+                        "objectName"
+                    ]
+                },
+                "topic": {
+                    "type": "object",
+                    "description": "Defines the properties of a topic.",
+                    "properties": {
+                        "string": {
+                            "type": "string",
+                            "maxLength": 10240,
+                            "description": "The value of the IBM MQ topic string to be used."
+                        },
+                        "objectName": {
+                            "type": "string",
+                            "maxLength": 48,
+                            "description": "The name of the IBM MQ topic object."
+                        },
+                        "durablePermitted": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Defines if the subscription may be durable."
+                        },
+                        "lastMsgRetained": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Defines if the last message published will be made available to new subscriptions."
+                        }
+                    }
+                },
+                "maxMsgLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 104857600,
+                    "description": "The maximum length of the physical message (in bytes) accepted by the Topic or Queue. Messages produced that are greater in size than this value may fail to be delivered. More information on the maximum message length can be found on this [page](https://www.ibm.com/support/knowledgecenter/SSFKSJ_latest/com.ibm.mq.ref.dev.doc/q097520_.html) in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "destinationType": {
+                            "const": "topic"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "queue"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "destinationType": {
+                            "const": "queue"
+                        }
+                    },
+                    "required": [
+                        "queue"
+                    ],
+                    "not": {
+                        "required": [
+                            "topic"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "destinationType": "topic",
+                    "topic": {
+                        "objectName": "myTopicName"
+                    },
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "destinationType": "queue",
+                    "queue": {
+                        "objectName": "myQueueName",
+                        "exclusive": true
+                    },
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json",
+            "title": "Cloud Pub/Sub Channel Schema",
+            "description": "This object contains information about the channel representation for Google Cloud Pub/Sub.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "messageRetentionDuration": {
+                    "type": "string"
+                },
+                "messageStoragePolicy": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "allowedPersistenceRegions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "schemaSettings": {
+                    "type": "object",
+                    "additionalItems": false,
+                    "properties": {
+                        "encoding": {
+                            "type": "string"
+                        },
+                        "firstRevisionId": {
+                            "type": "string"
+                        },
+                        "lastRevisionId": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoding",
+                        "name"
+                    ]
+                }
+            },
+            "required": [
+                "schemaSettings"
+            ],
+            "examples": [
+                {
+                    "labels": {
+                        "label1": "value1",
+                        "label2": "value2"
+                    },
+                    "messageRetentionDuration": "86400s",
+                    "messageStoragePolicy": {
+                        "allowedPersistenceRegions": [
+                            "us-central1",
+                            "us-east1"
+                        ]
+                    },
+                    "schemaSettings": {
+                        "encoding": "json",
+                        "name": "projects/your-project-id/schemas/your-schema"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Pulsar, which covers namespace and topic level admin configuration. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "namespace",
+                "persistence"
+            ],
+            "properties": {
+                "namespace": {
+                    "type": "string",
+                    "description": "The namespace, the channel is associated with."
+                },
+                "persistence": {
+                    "type": "string",
+                    "enum": [
+                        "persistent",
+                        "non-persistent"
+                    ],
+                    "description": "persistence of the topic in Pulsar."
+                },
+                "compaction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Topic compaction threshold given in MB"
+                },
+                "geo-replication": {
+                    "type": "array",
+                    "description": "A list of clusters the topic is replicated to.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "retention": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "time": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Time given in Minutes. `0` = Disable message retention."
+                        },
+                        "size": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Size given in MegaBytes. `0` = Disable message retention."
+                        }
+                    }
+                },
+                "ttl": {
+                    "type": "integer",
+                    "description": "TTL in seconds for the specified topic"
+                },
+                "deduplication": {
+                    "type": "boolean",
+                    "description": "Whether deduplication of events is enabled or not."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "namespace": "ns1",
+                    "persistence": "persistent",
+                    "compaction": 1000,
+                    "retention": {
+                        "time": 15,
+                        "size": 1000
+                    },
+                    "ttl": 360,
+                    "geo-replication": [
+                        "us-west",
+                        "us-east"
+                    ],
+                    "deduplication": true,
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operations.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operations.json",
+            "type": "object",
+            "description": "Holds a dictionary with all the operations this application MUST implement.",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "onUserSignUp": {
+                        "title": "User sign up",
+                        "summary": "Action to sign a user up.",
+                        "description": "A longer description",
+                        "channel": {
+                            "$ref": "#/channels/userSignup"
+                        },
+                        "action": "send",
+                        "tags": [
+                            {
+                                "name": "user"
+                            },
+                            {
+                                "name": "signup"
+                            },
+                            {
+                                "name": "register"
+                            }
+                        ],
+                        "bindings": {
+                            "amqp": {
+                                "ack": false
+                            }
+                        },
+                        "traits": [
+                            {
+                                "$ref": "#/components/operationTraits/kafka"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operation.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operation.json",
+            "type": "object",
+            "description": "Describes a specific operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "action",
+                "channel"
+            ],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Allowed values are send and receive. Use send when it's expected that the application will send a message to the given channel, and receive when the application should expect receiving messages from the given channel.",
+                    "enum": [
+                        "send",
+                        "receive"
+                    ]
+                },
+                "channel": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "A list of $ref pointers pointing to the supported Message Objects that can be processed by this operation. It MUST contain a subset of the messages defined in the channel referenced in this operation. Every message processed by this operation MUST be valid against one, and only one, of the message objects referenced in this list. Please note the messages property value MUST be a list of Reference Objects and, therefore, MUST NOT contain Message Objects. However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    }
+                },
+                "reply": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationReply.json"
+                        }
+                    ]
+                },
+                "traits": {
+                    "type": "array",
+                    "description": "A list of traits to apply to the operation object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Operation Object.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/operationTrait.json"
+                            }
+                        ]
+                    }
+                },
+                "title": {
+                    "type": "string",
+                    "description": "A human-friendly title for the operation."
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "A brief summary of the operation."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A longer description of the operation. CommonMark is allowed."
+                },
+                "security": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/securityRequirements.json"
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "title": "User sign up",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "channel": {
+                        "$ref": "#/channels/userSignup"
+                    },
+                    "action": "send",
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "bindings": {
+                        "amqp": {
+                            "ack": false
+                        }
+                    },
+                    "traits": [
+                        {
+                            "$ref": "#/components/operationTraits/kafka"
+                        }
+                    ],
+                    "messages": [
+                        {
+                            "$ref": "#/components/messages/userSignedUp"
+                        }
+                    ],
+                    "reply": {
+                        "address": {
+                            "location": "$message.header#/replyTo"
+                        },
+                        "channel": {
+                            "$ref": "#/channels/userSignupReply"
+                        },
+                        "messages": [
+                            {
+                                "$ref": "#/components/messages/userSignedUpReply"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationReply.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationReply.json",
+            "type": "object",
+            "description": "Describes the reply part that MAY be applied to an Operation Object. If an operation implements the request/reply pattern, the reply object represents the response message.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "address": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json"
+                        }
+                    ]
+                },
+                "channel": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                },
+                "messages": {
+                    "type": "array",
+                    "description": "A list of $ref pointers pointing to the supported Message Objects that can be processed by this operation as reply. It MUST contain a subset of the messages defined in the channel referenced in this operation reply. Every message processed by this operation MUST be valid against one, and only one, of the message objects referenced in this list. Please note the messages property value MUST be a list of Reference Objects and, therefore, MUST NOT contain Message Objects. However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                    }
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json",
+            "type": "object",
+            "description": "An object that specifies where an operation has to send the reply",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "location"
+            ],
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "A runtime expression that specifies the location of the reply address.",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional description of the address. CommonMark is allowed."
+                }
+            },
+            "examples": [
+                {
+                    "description": "Consumer inbox",
+                    "location": "$message.header#/replyTo"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationTrait.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationTrait.json",
+            "type": "object",
+            "description": "Describes a trait that MAY be applied to an Operation Object. This object MAY contain any property from the Operation Object, except the action, channel and traits ones.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the operation.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/title"
+                },
+                "summary": {
+                    "description": "A short summary of what the operation is about.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/summary"
+                },
+                "description": {
+                    "description": "A verbose explanation of the operation. CommonMark syntax can be used for rich text representation.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/description"
+                },
+                "security": {
+                    "description": "A declaration of which security schemes are associated with this operation. Only one of the security scheme objects MUST be satisfied to authorize an operation. In cases where Server Security also applies, it MUST also be satisfied.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/security"
+                },
+                "tags": {
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/tags"
+                },
+                "externalDocs": {
+                    "description": "Additional external documentation for this operation.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json#/properties/externalDocs"
+                },
+                "bindings": {
+                    "description": "A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.",
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+                        }
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "bindings": {
+                        "amqp": {
+                            "ack": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json",
+            "type": "object",
+            "description": "Map describing protocol-specific definitions for an operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "http": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "ws": {},
+                "amqp": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "amqp1": {},
+                "mqtt": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "kafka": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "anypointmq": {},
+                "nats": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/nats/0.1.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/nats/0.1.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "jms": {},
+                "sns": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "sqs": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "stomp": {},
+                "redis": {},
+                "ibmmq": {},
+                "solace": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.4.0",
+                                "0.3.0",
+                                "0.2.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.2.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "googlepubsub": {}
+            }
+        },
+        "http://asyncapi.com/bindings/http/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.3.0/operation.json",
+            "title": "HTTP operation bindings object",
+            "description": "This object contains information about the operation representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "PUT",
+                        "POST",
+                        "PATCH",
+                        "DELETE",
+                        "HEAD",
+                        "OPTIONS",
+                        "CONNECT",
+                        "TRACE"
+                    ],
+                    "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
+                },
+                "query": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "method": "GET",
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.2.0/operation.json",
+            "title": "HTTP operation bindings object",
+            "description": "This object contains information about the operation representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "PUT",
+                        "POST",
+                        "PATCH",
+                        "DELETE",
+                        "HEAD",
+                        "OPTIONS",
+                        "CONNECT",
+                        "TRACE"
+                    ],
+                    "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
+                },
+                "query": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.2.0"
+                },
+                {
+                    "method": "GET",
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json",
+            "title": "AMQP operation bindings object",
+            "description": "This object contains information about the operation representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "expiration": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "TTL (Time-To-Live) for the message. It MUST be greater than or equal to zero."
+                },
+                "userId": {
+                    "type": "string",
+                    "description": "Identifies the user who has sent the message."
+                },
+                "cc": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The routing keys the message should be routed to at the time of publishing."
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "A priority for the message."
+                },
+                "deliveryMode": {
+                    "type": "integer",
+                    "enum": [
+                        1,
+                        2
+                    ],
+                    "description": "Delivery mode of the message. Its value MUST be either 1 (transient) or 2 (persistent)."
+                },
+                "mandatory": {
+                    "type": "boolean",
+                    "description": "Whether the message is mandatory or not."
+                },
+                "bcc": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Like cc but consumers will not receive this information."
+                },
+                "timestamp": {
+                    "type": "boolean",
+                    "description": "Whether the message should include a timestamp or not."
+                },
+                "ack": {
+                    "type": "boolean",
+                    "description": "Whether the consumer should ack the message or not."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "expiration": 100000,
+                    "userId": "guest",
+                    "cc": [
+                        "user.logs"
+                    ],
+                    "priority": 10,
+                    "deliveryMode": 2,
+                    "mandatory": false,
+                    "bcc": [
+                        "external.audit"
+                    ],
+                    "timestamp": true,
+                    "ack": false,
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json",
+            "title": "MQTT operation bindings object",
+            "description": "This object contains information about the operation representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "qos": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "description": "Defines the Quality of Service (QoS) levels for the message flow between client and server. Its value MUST be either 0 (At most once delivery), 1 (At least once delivery), or 2 (Exactly once delivery)."
+                },
+                "retain": {
+                    "type": "boolean",
+                    "description": "Whether the broker should retain the message or not."
+                },
+                "messageExpiryInterval": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 4294967295
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Lifetime of the message in seconds"
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "qos": 2,
+                    "retain": true,
+                    "messageExpiryInterval": 60,
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/nats/0.1.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/nats/0.1.0/operation.json",
+            "title": "NATS operation bindings object",
+            "description": "This object contains information about the operation representation in NATS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queue": {
+                    "type": "string",
+                    "description": "Defines the name of the queue to use. It MUST NOT exceed 255 characters.",
+                    "maxLength": 255
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "queue": "MyCustomQueue",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sns/0.1.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/sns/0.1.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in SNS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier",
+                    "description": "Often we can assume that the SNS Topic is the channel name-we provide this field in case the you need to supply the ARN, or the Topic name is not the channel name in the AsyncAPI document."
+                },
+                "consumers": {
+                    "type": "array",
+                    "description": "The protocols that listen to this topic and their endpoints.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/consumer"
+                    },
+                    "minItems": 1
+                },
+                "deliveryPolicy": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/deliveryPolicy",
+                    "description": "Policy for retries to HTTP. The field is the default for HTTP receivers of the SNS Topic which may be overridden by a specific consumer."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "description": "The version of this binding.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "consumers"
+            ],
+            "definitions": {
+                "identifier": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "The endpoint is a URL."
+                        },
+                        "email": {
+                            "type": "string",
+                            "description": "The endpoint is an email address."
+                        },
+                        "phone": {
+                            "type": "string",
+                            "description": "The endpoint is a phone number."
+                        },
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding. We don't use $ref because we are referring, not including."
+                        }
+                    }
+                },
+                "consumer": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "protocol": {
+                            "description": "The protocol that this endpoint receives messages by.",
+                            "type": "string",
+                            "enum": [
+                                "http",
+                                "https",
+                                "email",
+                                "email-json",
+                                "sms",
+                                "sqs",
+                                "application",
+                                "lambda",
+                                "firehose"
+                            ]
+                        },
+                        "endpoint": {
+                            "description": "The endpoint messages are delivered to.",
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier"
+                        },
+                        "filterPolicy": {
+                            "type": "object",
+                            "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
+                            "patternProperties": {
+                                "^x-[\\w\\d\\.\\x2d_]+$": {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                                }
+                            },
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "filterPolicyScope": {
+                            "type": "string",
+                            "description": "Determines whether the FilterPolicy applies to MessageAttributes or MessageBody.",
+                            "enum": [
+                                "MessageAttributes",
+                                "MessageBody"
+                            ],
+                            "default": "MessageAttributes"
+                        },
+                        "rawMessageDelivery": {
+                            "type": "boolean",
+                            "description": "If true AWS SNS attributes are removed from the body, and for SQS, SNS message attributes are copied to SQS message attributes. If false the SNS attributes are included in the body."
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/redrivePolicy"
+                        },
+                        "deliveryPolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/deliveryPolicy",
+                            "description": "Policy for retries to HTTP. The parameter is for that SNS Subscription and overrides any policy on the SNS Topic."
+                        },
+                        "displayName": {
+                            "type": "string",
+                            "description": "The display name to use with an SNS subscription"
+                        }
+                    },
+                    "required": [
+                        "protocol",
+                        "endpoint",
+                        "rawMessageDelivery"
+                    ]
+                },
+                "deliveryPolicy": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "minDelayTarget": {
+                            "type": "integer",
+                            "description": "The minimum delay for a retry in seconds."
+                        },
+                        "maxDelayTarget": {
+                            "type": "integer",
+                            "description": "The maximum delay for a retry in seconds."
+                        },
+                        "numRetries": {
+                            "type": "integer",
+                            "description": "The total number of retries, including immediate, pre-backoff, backoff, and post-backoff retries."
+                        },
+                        "numNoDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of immediate retries (with no delay)."
+                        },
+                        "numMinDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of immediate retries (with delay)."
+                        },
+                        "numMaxDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of post-backoff phase retries, with the maximum delay between retries."
+                        },
+                        "backoffFunction": {
+                            "type": "string",
+                            "description": "The algorithm for backoff between retries.",
+                            "enum": [
+                                "arithmetic",
+                                "exponential",
+                                "geometric",
+                                "linear"
+                            ]
+                        },
+                        "maxReceivesPerSecond": {
+                            "type": "integer",
+                            "description": "The maximum number of deliveries per second, per subscription."
+                        }
+                    }
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier",
+                            "description": "The SQS queue to use as a dead letter queue (DLQ)."
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "topic": {
+                        "name": "someTopic"
+                    },
+                    "consumers": [
+                        {
+                            "protocol": "sqs",
+                            "endpoint": {
+                                "name": "someQueue"
+                            },
+                            "filterPolicy": {
+                                "store": [
+                                    "asyncapi_corp"
+                                ],
+                                "event": [
+                                    {
+                                        "anything-but": "order_cancelled"
+                                    }
+                                ],
+                                "customer_interests": [
+                                    "rugby",
+                                    "football",
+                                    "baseball"
+                                ]
+                            },
+                            "filterPolicyScope": "MessageAttributes",
+                            "rawMessageDelivery": false,
+                            "redrivePolicy": {
+                                "deadLetterQueue": {
+                                    "arn": "arn:aws:SQS:eu-west-1:0000000:123456789"
+                                },
+                                "maxReceiveCount": 25
+                            },
+                            "deliveryPolicy": {
+                                "minDelayTarget": 10,
+                                "maxDelayTarget": 100,
+                                "numRetries": 5,
+                                "numNoDelayRetries": 2,
+                                "numMinDelayRetries": 3,
+                                "numMaxDelayRetries": 5,
+                                "backoffFunction": "linear",
+                                "maxReceivesPerSecond": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sqs/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in SQS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queues": {
+                    "type": "array",
+                    "description": "Queue objects that are either the endpoint for an SNS Operation Binding Object, or the deadLetterQueue of the SQS Operation Binding Object.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/queue"
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0",
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "queues"
+            ],
+            "definitions": {
+                "queue": {
+                    "type": "object",
+                    "description": "A definition of a queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "$ref": {
+                            "type": "string",
+                            "description": "Allows for an external definition of a queue. The referenced structure MUST be in the format of a Queue. If there are conflicts between the referenced definition and this Queue's definition, the behavior is undefined."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the queue. When an SNS Operation Binding Object references an SQS queue by name, the identifier should be the one in this field."
+                        },
+                        "fifoQueue": {
+                            "type": "boolean",
+                            "description": "Is this a FIFO queue?",
+                            "default": false
+                        },
+                        "deduplicationScope": {
+                            "type": "string",
+                            "enum": [
+                                "queue",
+                                "messageGroup"
+                            ],
+                            "description": "Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue (default).",
+                            "default": "queue"
+                        },
+                        "fifoThroughputLimit": {
+                            "type": "string",
+                            "enum": [
+                                "perQueue",
+                                "perMessageGroupId"
+                            ],
+                            "description": "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue (default) and perMessageGroupId.",
+                            "default": "perQueue"
+                        },
+                        "deliveryDelay": {
+                            "type": "integer",
+                            "description": "The number of seconds to delay before a message sent to the queue can be received. Used to create a delay queue.",
+                            "minimum": 0,
+                            "maximum": 900,
+                            "default": 0
+                        },
+                        "visibilityTimeout": {
+                            "type": "integer",
+                            "description": "The length of time, in seconds, that a consumer locks a message - hiding it from reads - before it is unlocked and can be read again.",
+                            "minimum": 0,
+                            "maximum": 43200,
+                            "default": 30
+                        },
+                        "receiveMessageWaitTime": {
+                            "type": "integer",
+                            "description": "Determines if the queue uses short polling or long polling. Set to zero the queue reads available messages and returns immediately. Set to a non-zero integer, long polling waits the specified number of seconds for messages to arrive before returning.",
+                            "default": 0
+                        },
+                        "messageRetentionPeriod": {
+                            "type": "integer",
+                            "description": "How long to retain a message on the queue in seconds, unless deleted.",
+                            "minimum": 60,
+                            "maximum": 1209600,
+                            "default": 345600
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/redrivePolicy"
+                        },
+                        "policy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/policy"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "description": "Key-value pairs that represent AWS tags on the queue."
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/identifier"
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                },
+                "identifier": {
+                    "type": "object",
+                    "description": "The SQS queue to use as a dead letter queue (DLQ).",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding."
+                        }
+                    }
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SQS Queue",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this queue.",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SQS permission being allowed or denied e.g. sqs:ReceiveMessage",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "queues": [
+                        {
+                            "name": "myQueue",
+                            "fifoQueue": true,
+                            "deduplicationScope": "messageGroup",
+                            "fifoThroughputLimit": "perMessageGroupId",
+                            "deliveryDelay": 10,
+                            "redrivePolicy": {
+                                "deadLetterQueue": {
+                                    "name": "myQueue_error"
+                                },
+                                "maxReceiveCount": 15
+                            },
+                            "policy": {
+                                "statements": [
+                                    {
+                                        "effect": "Deny",
+                                        "principal": "arn:aws:iam::123456789012:user/dec.kolakowski",
+                                        "action": [
+                                            "sqs:SendMessage",
+                                            "sqs:ReceiveMessage"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "myQueue_error",
+                            "deliveryDelay": 10
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.4.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.4.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                },
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            },
+                                            "maxTtl": {
+                                                "type": "string",
+                                                "description": "The maximum TTL to apply to messages to be spooled."
+                                            },
+                                            "maxMsgSpoolUsage": {
+                                                "type": "string",
+                                                "description": "The maximum amount of message spool that the given queue may use"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "timeToLive": {
+                    "type": "integer",
+                    "description": "Interval in milliseconds or a Schema Object containing the definition of the lifetime of the message."
+                },
+                "priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255,
+                    "description": "The valid priority value range is 0-255 with 0 as the lowest priority and 255 as the highest or a Schema Object containing the definition of the priority."
+                },
+                "dmqEligible": {
+                    "type": "boolean",
+                    "description": "Set the message to be eligible to be moved to a Dead Message Queue. The default value is false."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.4.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.3.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            },
+                                            "maxTtl": {
+                                                "type": "string",
+                                                "description": "The maximum TTL to apply to messages to be spooled."
+                                            },
+                                            "maxMsgSpoolUsage": {
+                                                "type": "string",
+                                                "description": "The maximum amount of message spool that the given queue may use"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.3.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.2.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.2.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/components.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/components.json",
+            "type": "object",
+            "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI specification. All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemas": {
+                    "type": "object",
+                    "description": "An object to hold reusable Schema Object. If this is a Schema Object, then the schemaFormat will be assumed to be 'application/vnd.aai.asyncapi+json;version=asyncapi' where the version is equal to the AsyncAPI Version String.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/anySchema.json"
+                        }
+                    }
+                },
+                "servers": {
+                    "type": "object",
+                    "description": "An object to hold reusable Server Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/server.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "channels": {
+                    "type": "object",
+                    "description": "An object to hold reusable Channel Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/channel.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "serverVariables": {
+                    "type": "object",
+                    "description": "An object to hold reusable Server Variable Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/serverVariable.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operations": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operation.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messages": {
+                    "type": "object",
+                    "description": "An object to hold reusable Message Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/messageObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "securitySchemes": {
+                    "type": "object",
+                    "description": "An object to hold reusable Security Scheme Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/SecurityScheme.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "An object to hold reusable Parameter Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/parameter.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "correlationIds": {
+                    "type": "object",
+                    "description": "An object to hold reusable Correlation ID Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/correlationId.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationTraits": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Trait Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationTrait.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messageTraits": {
+                    "type": "object",
+                    "description": "An object to hold reusable Message Trait Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/messageTrait.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "replies": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Reply Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationReply.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "replyAddresses": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Reply Address Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationReplyAddress.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "serverBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Server Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/serverBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "channelBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Channel Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/channelBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Operation Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/operationBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messageBindings": {
+                    "type": "object",
+                    "description": "An object to hold reusable Message Bindings Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/messageBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "tags": {
+                    "type": "object",
+                    "description": "An object to hold reusable Tag Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/tag.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "type": "object",
+                    "description": "An object to hold reusable External Documentation Objects.",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "components": {
+                        "schemas": {
+                            "Category": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "Tag": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "AvroExample": {
+                                "schemaFormat": "application/vnd.apache.avro+json;version=1.9.0",
+                                "schema": {
+                                    "$ref": "path/to/user-create.avsc#/UserCreate"
+                                }
+                            }
+                        },
+                        "servers": {
+                            "development": {
+                                "host": "{stage}.in.mycompany.com:{port}",
+                                "description": "RabbitMQ broker",
+                                "protocol": "amqp",
+                                "protocolVersion": "0-9-1",
+                                "variables": {
+                                    "stage": {
+                                        "$ref": "#/components/serverVariables/stage"
+                                    },
+                                    "port": {
+                                        "$ref": "#/components/serverVariables/port"
+                                    }
+                                }
+                            }
+                        },
+                        "serverVariables": {
+                            "stage": {
+                                "default": "demo",
+                                "description": "This value is assigned by the service provider, in this example `mycompany.com`"
+                            },
+                            "port": {
+                                "enum": [
+                                    "5671",
+                                    "5672"
+                                ],
+                                "default": "5672"
+                            }
+                        },
+                        "channels": {
+                            "user/signedup": {
+                                "subscribe": {
+                                    "message": {
+                                        "$ref": "#/components/messages/userSignUp"
+                                    }
+                                }
+                            }
+                        },
+                        "messages": {
+                            "userSignUp": {
+                                "summary": "Action to sign a user up.",
+                                "description": "Multiline description of what this action does.\nHere you have another line.\n",
+                                "tags": [
+                                    {
+                                        "name": "user"
+                                    },
+                                    {
+                                        "name": "signup"
+                                    }
+                                ],
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "applicationInstanceId": {
+                                            "description": "Unique identifier for a given instance of the publishing application",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "properties": {
+                                        "user": {
+                                            "$ref": "#/components/schemas/userCreate"
+                                        },
+                                        "signup": {
+                                            "$ref": "#/components/schemas/signup"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "userId": {
+                                "description": "Id of the user."
+                            }
+                        },
+                        "correlationIds": {
+                            "default": {
+                                "description": "Default Correlation ID",
+                                "location": "$message.header#/correlationId"
+                            }
+                        },
+                        "messageTraits": {
+                            "commonHeaders": {
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "my-app-header": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 100
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "description": "!!Auto generated!! \n Do not manually edit. "
+}

--- a/schemas/asyncapi/3.1.0/schema.json
+++ b/schemas/asyncapi/3.1.0/schema.json
@@ -1,0 +1,9461 @@
+{
+    "$id": "http://asyncapi.com/definitions/3.1.0/asyncapi.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "AsyncAPI 3.1.0 schema.",
+    "type": "object",
+    "required": [
+        "asyncapi",
+        "info"
+    ],
+    "properties": {
+        "id": {
+            "description": "A unique id representing the application.",
+            "type": "string",
+            "format": "uri"
+        },
+        "asyncapi": {
+            "description": "The AsyncAPI specification version of this document.",
+            "type": "string",
+            "const": "3.1.0"
+        },
+        "channels": {
+            "$ref": "http://asyncapi.com/definitions/3.1.0/channels.json"
+        },
+        "components": {
+            "$ref": "http://asyncapi.com/definitions/3.1.0/components.json"
+        },
+        "defaultContentType": {
+            "description": "Default content type to use when encoding/decoding a message's payload.",
+            "type": "string"
+        },
+        "info": {
+            "$ref": "http://asyncapi.com/definitions/3.1.0/info.json"
+        },
+        "operations": {
+            "$ref": "http://asyncapi.com/definitions/3.1.0/operations.json"
+        },
+        "servers": {
+            "$ref": "http://asyncapi.com/definitions/3.1.0/servers.json"
+        }
+    },
+    "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+            "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+        }
+    },
+    "additionalProperties": false,
+    "definitions": {
+        "http://asyncapi.com/definitions/3.1.0/channels.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/channels.json",
+            "description": "An object containing all the Channel Object definitions the Application MUST use during runtime.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/channel.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "userSignedUp": {
+                        "address": "user.signedup",
+                        "messages": {
+                            "userSignedUp": {
+                                "$ref": "#/components/messages/userSignedUp"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/Reference.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/Reference.json",
+            "description": "A simple object to allow referencing other components in the specification, internally and externally.",
+            "type": "object",
+            "required": [
+                "$ref"
+            ],
+            "properties": {
+                "$ref": {
+                    "description": "The reference string.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/ReferenceObject.json"
+                }
+            },
+            "examples": [
+                {
+                    "$ref": "#/components/schemas/Pet"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/ReferenceObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/ReferenceObject.json",
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "http://asyncapi.com/definitions/3.1.0/channel.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/channel.json",
+            "description": "Describes a shared communication channel.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the channel.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A longer description of the channel. CommonMark is allowed.",
+                    "type": "string"
+                },
+                "address": {
+                    "description": "An optional string representation of this channel's address. The address is typically the \"topic name\", \"routing key\", \"event type\", or \"path\". When `null` or absent, it MUST be interpreted as unknown. This is useful when the address is generated dynamically at runtime or can't be known upfront. It MAY contain Channel Address Expressions.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/channelBindingsObject.json"
+                        }
+                    ]
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "messages": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/channelMessages.json"
+                },
+                "parameters": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/parameters.json"
+                },
+                "servers": {
+                    "description": "The references of the servers on which this channel is available. If absent or empty then this channel must be available on all servers.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    }
+                },
+                "summary": {
+                    "description": "A brief summary of the channel.",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "A list of tags for logical grouping of channels.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/tag.json"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "address": "users.{userId}",
+                    "title": "Users channel",
+                    "description": "This channel is used to exchange messages about user events.",
+                    "messages": {
+                        "userSignedUp": {
+                            "$ref": "#/components/messages/userSignedUp"
+                        },
+                        "userCompletedOrder": {
+                            "$ref": "#/components/messages/userCompletedOrder"
+                        }
+                    },
+                    "parameters": {
+                        "userId": {
+                            "$ref": "#/components/parameters/userId"
+                        }
+                    },
+                    "servers": [
+                        {
+                            "$ref": "#/servers/rabbitmqInProd"
+                        },
+                        {
+                            "$ref": "#/servers/rabbitmqInStaging"
+                        }
+                    ],
+                    "bindings": {
+                        "amqp": {
+                            "is": "queue",
+                            "queue": {
+                                "exclusive": true
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "name": "user",
+                            "description": "User-related messages"
+                        }
+                    ],
+                    "externalDocs": {
+                        "description": "Find more info here",
+                        "url": "https://example.com"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/channelBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/channelBindingsObject.json",
+            "description": "Map describing protocol-specific definitions for a channel.",
+            "type": "object",
+            "properties": {
+                "amqp": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "amqp1": {},
+                "anypointmq": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    }
+                },
+                "googlepubsub": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "http": {},
+                "ibmmq": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "jms": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    }
+                },
+                "kafka": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "mqtt": {},
+                "nats": {},
+                "pulsar": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "redis": {},
+                "sns": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "solace": {},
+                "sqs": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "stomp": {},
+                "ws": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/channel.json",
+            "title": "AMQP channel bindings object",
+            "description": "This object contains information about the channel representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "is": {
+                    "type": "string",
+                    "enum": [
+                        "queue",
+                        "routingKey"
+                    ],
+                    "description": "Defines what type of channel is it. Can be either 'queue' or 'routingKey' (default)."
+                },
+                "exchange": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "The name of the exchange. It MUST NOT exceed 255 characters long."
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "topic",
+                                "direct",
+                                "fanout",
+                                "default",
+                                "headers"
+                            ],
+                            "description": "The type of the exchange. Can be either 'topic', 'direct', 'fanout', 'default' or 'headers'."
+                        },
+                        "durable": {
+                            "type": "boolean",
+                            "description": "Whether the exchange should survive broker restarts or not."
+                        },
+                        "autoDelete": {
+                            "type": "boolean",
+                            "description": "Whether the exchange should be deleted when the last queue is unbound from it."
+                        },
+                        "vhost": {
+                            "type": "string",
+                            "default": "/",
+                            "description": "The virtual host of the exchange. Defaults to '/'."
+                        }
+                    },
+                    "description": "When is=routingKey, this object defines the exchange properties."
+                },
+                "queue": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "The name of the queue. It MUST NOT exceed 255 characters long."
+                        },
+                        "durable": {
+                            "type": "boolean",
+                            "description": "Whether the queue should survive broker restarts or not."
+                        },
+                        "exclusive": {
+                            "type": "boolean",
+                            "description": "Whether the queue should be used only by one connection or not."
+                        },
+                        "autoDelete": {
+                            "type": "boolean",
+                            "description": "Whether the queue should be deleted when the last consumer unsubscribes."
+                        },
+                        "vhost": {
+                            "type": "string",
+                            "default": "/",
+                            "description": "The virtual host of the queue. Defaults to '/'."
+                        }
+                    },
+                    "description": "When is=queue, this object defines the queue properties."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "is": {
+                            "const": "routingKey"
+                        }
+                    },
+                    "required": [
+                        "exchange"
+                    ],
+                    "not": {
+                        "required": [
+                            "queue"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "is": {
+                            "const": "queue"
+                        }
+                    },
+                    "required": [
+                        "queue"
+                    ],
+                    "not": {
+                        "required": [
+                            "exchange"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "is": "routingKey",
+                    "exchange": {
+                        "name": "myExchange",
+                        "type": "topic",
+                        "durable": true,
+                        "autoDelete": false,
+                        "vhost": "/"
+                    },
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "is": "queue",
+                    "queue": {
+                        "name": "my-queue-name",
+                        "durable": true,
+                        "exclusive": true,
+                        "autoDelete": false,
+                        "vhost": "/"
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/specificationExtension.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json",
+            "description": "Any property starting with x- is valid.",
+            "additionalProperties": true,
+            "additionalItems": true
+        },
+        "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json": {
+            "$id": "http://asyncapi.com/bindings/anypointmq/0.0.1/channel.json",
+            "title": "Anypoint MQ channel bindings object",
+            "description": "This object contains configuration for describing an Anypoint MQ exchange, queue, or FIFO queue as an AsyncAPI channel. This objects only contains configuration that can not be provided in the AsyncAPI standard channel object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "The destination (queue or exchange) name for this channel. SHOULD only be specified if the channel name differs from the actual destination name, such as when the channel name is not a valid destination name in Anypoint MQ. Defaults to the channel name."
+                },
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "exchange",
+                        "queue",
+                        "fifo-queue"
+                    ],
+                    "default": "queue",
+                    "description": "The type of destination. SHOULD be specified to document the messaging model (publish/subscribe, point-to-point, strict message ordering) supported by this channel."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "destination": "user-signup-exchg",
+                    "destinationType": "exchange",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/googlepubsub/0.2.0/channel.json",
+            "title": "Cloud Pub/Sub Channel Schema",
+            "description": "This object contains information about the channel representation for Google Cloud Pub/Sub.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "messageRetentionDuration": {
+                    "type": "string"
+                },
+                "messageStoragePolicy": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "allowedPersistenceRegions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "schemaSettings": {
+                    "type": "object",
+                    "additionalItems": false,
+                    "properties": {
+                        "encoding": {
+                            "type": "string"
+                        },
+                        "firstRevisionId": {
+                            "type": "string"
+                        },
+                        "lastRevisionId": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoding",
+                        "name"
+                    ]
+                }
+            },
+            "required": [
+                "schemaSettings"
+            ],
+            "examples": [
+                {
+                    "labels": {
+                        "label1": "value1",
+                        "label2": "value2"
+                    },
+                    "messageRetentionDuration": "86400s",
+                    "messageStoragePolicy": {
+                        "allowedPersistenceRegions": [
+                            "us-central1",
+                            "us-east1"
+                        ]
+                    },
+                    "schemaSettings": {
+                        "encoding": "json",
+                        "name": "projects/your-project-id/schemas/your-schema"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/channel.json",
+            "title": "IBM MQ channel bindings object",
+            "description": "This object contains information about the channel representation in IBM MQ. Each channel corresponds to a Queue or Topic within IBM MQ.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "topic",
+                        "queue"
+                    ],
+                    "default": "topic",
+                    "description": "Defines the type of AsyncAPI channel."
+                },
+                "queue": {
+                    "type": "object",
+                    "description": "Defines the properties of a queue.",
+                    "properties": {
+                        "objectName": {
+                            "type": "string",
+                            "maxLength": 48,
+                            "description": "Defines the name of the IBM MQ queue associated with the channel."
+                        },
+                        "isPartitioned": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Defines if the queue is a cluster queue and therefore partitioned. If 'true', a binding option MAY be specified when accessing the queue. More information on binding options can be found on this page in the IBM MQ Knowledge Center."
+                        },
+                        "exclusive": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Specifies if it is recommended to open the queue exclusively."
+                        }
+                    },
+                    "required": [
+                        "objectName"
+                    ]
+                },
+                "topic": {
+                    "type": "object",
+                    "description": "Defines the properties of a topic.",
+                    "properties": {
+                        "string": {
+                            "type": "string",
+                            "maxLength": 10240,
+                            "description": "The value of the IBM MQ topic string to be used."
+                        },
+                        "objectName": {
+                            "type": "string",
+                            "maxLength": 48,
+                            "description": "The name of the IBM MQ topic object."
+                        },
+                        "durablePermitted": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Defines if the subscription may be durable."
+                        },
+                        "lastMsgRetained": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Defines if the last message published will be made available to new subscriptions."
+                        }
+                    }
+                },
+                "maxMsgLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 104857600,
+                    "description": "The maximum length of the physical message (in bytes) accepted by the Topic or Queue. Messages produced that are greater in size than this value may fail to be delivered. More information on the maximum message length can be found on this [page](https://www.ibm.com/support/knowledgecenter/SSFKSJ_latest/com.ibm.mq.ref.dev.doc/q097520_.html) in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "destinationType": {
+                            "const": "topic"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "queue"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "destinationType": {
+                            "const": "queue"
+                        }
+                    },
+                    "required": [
+                        "queue"
+                    ],
+                    "not": {
+                        "required": [
+                            "topic"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "destinationType": "topic",
+                    "topic": {
+                        "objectName": "myTopicName"
+                    },
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "destinationType": "queue",
+                    "queue": {
+                        "objectName": "myQueueName",
+                        "exclusive": true
+                    },
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/channel.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains configuration for describing a JMS queue, or FIFO queue as an AsyncAPI channel. This objects only contains configuration that can not be provided in the AsyncAPI standard channel object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "The destination (queue) name for this channel. SHOULD only be specified if the channel name differs from the actual destination name, such as when the channel name is not a valid destination name according to the JMS Provider. Defaults to the channel name."
+                },
+                "destinationType": {
+                    "type": "string",
+                    "enum": [
+                        "queue",
+                        "fifo-queue"
+                    ],
+                    "default": "queue",
+                    "description": "The type of destination. SHOULD be specified to document the messaging model (point-to-point, or strict message ordering) supported by this channel."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "destination": "user-signed-up",
+                    "destinationType": "fifo-queue",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "confluent.key.schema.validation": {
+                            "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.key.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message key. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-key-subject-name-strategy)",
+                            "type": "string"
+                        },
+                        "confluent.value.schema.validation": {
+                            "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-schema-validation)",
+                            "type": "boolean"
+                        },
+                        "confluent.value.subject.name.strategy": {
+                            "description": "The name of the schema lookup strategy for the message value. Vendor specific config. For more details: (https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#confluent-value-subject-name-strategy)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "topicConfiguration": {
+                    "description": "Topic configuration properties that are relevant for the API.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "cleanup.policy": {
+                            "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "compact",
+                                    "delete"
+                                ]
+                            }
+                        },
+                        "retention.ms": {
+                            "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "retention.bytes": {
+                            "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": -1
+                        },
+                        "delete.retention.ms": {
+                            "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "max.message.bytes": {
+                            "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "Kafka topic name if different from channel name."
+                },
+                "partitions": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of partitions configured on this topic."
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of replicas configured on this topic."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "topic": "my-specific-topic",
+                    "partitions": 20,
+                    "replicas": 3,
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/pulsar/0.1.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in Pulsar, which covers namespace and topic level admin configuration. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "namespace",
+                "persistence"
+            ],
+            "properties": {
+                "namespace": {
+                    "type": "string",
+                    "description": "The namespace, the channel is associated with."
+                },
+                "persistence": {
+                    "type": "string",
+                    "enum": [
+                        "persistent",
+                        "non-persistent"
+                    ],
+                    "description": "persistence of the topic in Pulsar."
+                },
+                "compaction": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Topic compaction threshold given in MB"
+                },
+                "geo-replication": {
+                    "type": "array",
+                    "description": "A list of clusters the topic is replicated to.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "retention": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "time": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Time given in Minutes. `0` = Disable message retention."
+                        },
+                        "size": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Size given in MegaBytes. `0` = Disable message retention."
+                        }
+                    }
+                },
+                "ttl": {
+                    "type": "integer",
+                    "description": "TTL in seconds for the specified topic"
+                },
+                "deduplication": {
+                    "type": "boolean",
+                    "description": "Whether deduplication of events is enabled or not."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "namespace": "ns1",
+                    "persistence": "persistent",
+                    "compaction": 1000,
+                    "retention": {
+                        "time": 15,
+                        "size": 1000
+                    },
+                    "ttl": 360,
+                    "geo-replication": [
+                        "us-west",
+                        "us-east"
+                    ],
+                    "deduplication": true,
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sns/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/sns/0.1.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in SNS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the topic. Can be different from the channel name to allow flexibility around AWS resource naming limitations."
+                },
+                "ordering": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/ordering"
+                },
+                "policy": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/policy"
+                },
+                "tags": {
+                    "type": "object",
+                    "description": "Key-value pairs that represent AWS tags on the topic."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "description": "The version of this binding.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "definitions": {
+                "ordering": {
+                    "type": "object",
+                    "description": "By default, we assume an unordered SNS topic. This field allows configuration of a FIFO SNS Topic.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Defines the type of SNS Topic.",
+                            "enum": [
+                                "standard",
+                                "FIFO"
+                            ]
+                        },
+                        "contentBasedDeduplication": {
+                            "type": "boolean",
+                            "description": "True to turn on de-duplication of messages for a channel."
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SNS Topic.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this topic",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/channel.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SNS permission being allowed or denied e.g. sns:Publish",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "name": "my-sns-topic",
+                    "policy": {
+                        "statements": [
+                            {
+                                "effect": "Allow",
+                                "principal": "*",
+                                "action": "SNS:Publish"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sqs/0.2.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json",
+            "title": "Channel Schema",
+            "description": "This object contains information about the channel representation in SQS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queue": {
+                    "description": "A definition of the queue that will be used as the channel.",
+                    "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/queue"
+                },
+                "deadLetterQueue": {
+                    "description": "A definition of the queue that will be used for un-processable messages.",
+                    "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/queue"
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0",
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "queue"
+            ],
+            "definitions": {
+                "queue": {
+                    "type": "object",
+                    "description": "A definition of a queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the queue. When an SNS Operation Binding Object references an SQS queue by name, the identifier should be the one in this field."
+                        },
+                        "fifoQueue": {
+                            "type": "boolean",
+                            "description": "Is this a FIFO queue?",
+                            "default": false
+                        },
+                        "deduplicationScope": {
+                            "type": "string",
+                            "enum": [
+                                "queue",
+                                "messageGroup"
+                            ],
+                            "description": "Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue (default).",
+                            "default": "queue"
+                        },
+                        "fifoThroughputLimit": {
+                            "type": "string",
+                            "enum": [
+                                "perQueue",
+                                "perMessageGroupId"
+                            ],
+                            "description": "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue (default) and perMessageGroupId.",
+                            "default": "perQueue"
+                        },
+                        "deliveryDelay": {
+                            "type": "integer",
+                            "description": "The number of seconds to delay before a message sent to the queue can be received. used to create a delay queue.",
+                            "minimum": 0,
+                            "maximum": 900,
+                            "default": 0
+                        },
+                        "visibilityTimeout": {
+                            "type": "integer",
+                            "description": "The length of time, in seconds, that a consumer locks a message - hiding it from reads - before it is unlocked and can be read again.",
+                            "minimum": 0,
+                            "maximum": 43200,
+                            "default": 30
+                        },
+                        "receiveMessageWaitTime": {
+                            "type": "integer",
+                            "description": "Determines if the queue uses short polling or long polling. Set to zero the queue reads available messages and returns immediately. Set to a non-zero integer, long polling waits the specified number of seconds for messages to arrive before returning.",
+                            "default": 0
+                        },
+                        "messageRetentionPeriod": {
+                            "type": "integer",
+                            "description": "How long to retain a message on the queue in seconds, unless deleted.",
+                            "minimum": 60,
+                            "maximum": 1209600,
+                            "default": 345600
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/redrivePolicy"
+                        },
+                        "policy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/policy"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "description": "Key-value pairs that represent AWS tags on the queue."
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "fifoQueue"
+                    ]
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/identifier"
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                },
+                "identifier": {
+                    "type": "object",
+                    "description": "The SQS queue to use as a dead letter queue (DLQ).",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding."
+                        }
+                    }
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SQS Queue",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this queue.",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/channel.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SQS permission being allowed or denied e.g. sqs:ReceiveMessage",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "queue": {
+                        "name": "myQueue",
+                        "fifoQueue": true,
+                        "deduplicationScope": "messageGroup",
+                        "fifoThroughputLimit": "perMessageGroupId",
+                        "deliveryDelay": 15,
+                        "visibilityTimeout": 60,
+                        "receiveMessageWaitTime": 0,
+                        "messageRetentionPeriod": 86400,
+                        "redrivePolicy": {
+                            "deadLetterQueue": {
+                                "arn": "arn:aws:SQS:eu-west-1:0000000:123456789"
+                            },
+                            "maxReceiveCount": 15
+                        },
+                        "policy": {
+                            "statements": [
+                                {
+                                    "effect": "Deny",
+                                    "principal": "arn:aws:iam::123456789012:user/dec.kolakowski",
+                                    "action": [
+                                        "sqs:SendMessage",
+                                        "sqs:ReceiveMessage"
+                                    ]
+                                }
+                            ]
+                        },
+                        "tags": {
+                            "owner": "AsyncAPI.NET",
+                            "platform": "AsyncAPIOrg"
+                        }
+                    },
+                    "deadLetterQueue": {
+                        "name": "myQueue_error",
+                        "deliveryDelay": 0,
+                        "visibilityTimeout": 0,
+                        "receiveMessageWaitTime": 0,
+                        "messageRetentionPeriod": 604800
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/websockets/0.1.0/channel.json": {
+            "$id": "http://asyncapi.com/bindings/websockets/0.1.0/channel.json",
+            "title": "WebSockets channel bindings object",
+            "description": "When using WebSockets, the channel represents the connection. Unlike other protocols that support multiple virtual channels (topics, routing keys, etc.) per connection, WebSockets doesn't support virtual channels or, put it another way, there's only one channel and its characteristics are strongly related to the protocol used for the handshake, i.e., HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "POST"
+                    ],
+                    "description": "The HTTP method to use when establishing the connection. Its value MUST be either 'GET' or 'POST'."
+                },
+                "query": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "headers": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "method": "POST",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/schema.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/schema.json",
+            "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is a superset of the JSON Schema Specification Draft 07. The empty schema (which allows any instance to validate) MAY be represented by the boolean value true and a schema which allows no instance to validate MAY be represented by the boolean value false.",
+            "allOf": [
+                {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                },
+                {
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                                    }
+                                }
+                            ],
+                            "default": {}
+                        },
+                        "allOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "oneOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "anyOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            }
+                        },
+                        "not": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "patternProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                            },
+                            "default": {}
+                        },
+                        "propertyNames": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "contains": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        "discriminator": {
+                            "type": "string",
+                            "description": "Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. The property name used MUST be defined at this schema and it MUST be in the required property list. When used, the value MUST be the name of this schema or any schema that inherits it. See Composition and Inheritance for more details."
+                        },
+                        "externalDocs": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/externalDocs.json"
+                                }
+                            ]
+                        },
+                        "deprecated": {
+                            "type": "boolean",
+                            "description": "Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is false.",
+                            "default": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://json-schema.org/draft-07/schema": {
+            "$id": "http://json-schema.org/draft-07/schema",
+            "title": "Core schema meta-schema",
+            "definitions": {
+                "schemaArray": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#"
+                    }
+                },
+                "nonNegativeInteger": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "nonNegativeIntegerDefault0": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/nonNegativeInteger"
+                        },
+                        {
+                            "default": 0
+                        }
+                    ]
+                },
+                "simpleTypes": {
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "null",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "stringArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": []
+                }
+            },
+            "type": [
+                "object",
+                "boolean"
+            ],
+            "properties": {
+                "$id": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$schema": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "$ref": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "$comment": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": true,
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "examples": {
+                    "type": "array",
+                    "items": true
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "number"
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "number"
+                },
+                "maxLength": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minLength": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "additionalItems": {
+                    "$ref": "#"
+                },
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/schemaArray"
+                        }
+                    ],
+                    "default": true
+                },
+                "maxItems": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minItems": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "contains": {
+                    "$ref": "#"
+                },
+                "maxProperties": {
+                    "$ref": "#/definitions/nonNegativeInteger"
+                },
+                "minProperties": {
+                    "$ref": "#/definitions/nonNegativeIntegerDefault0"
+                },
+                "required": {
+                    "$ref": "#/definitions/stringArray"
+                },
+                "additionalProperties": {
+                    "$ref": "#"
+                },
+                "definitions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "default": {}
+                },
+                "patternProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#"
+                    },
+                    "propertyNames": {
+                        "format": "regex"
+                    },
+                    "default": {}
+                },
+                "dependencies": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/stringArray"
+                            }
+                        ]
+                    }
+                },
+                "propertyNames": {
+                    "$ref": "#"
+                },
+                "const": true,
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "type": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/simpleTypes"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/simpleTypes"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    ]
+                },
+                "format": {
+                    "type": "string"
+                },
+                "contentMediaType": {
+                    "type": "string"
+                },
+                "contentEncoding": {
+                    "type": "string"
+                },
+                "if": {
+                    "$ref": "#"
+                },
+                "then": {
+                    "$ref": "#"
+                },
+                "else": {
+                    "$ref": "#"
+                },
+                "allOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "anyOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "oneOf": {
+                    "$ref": "#/definitions/schemaArray"
+                },
+                "not": {
+                    "$ref": "#"
+                }
+            },
+            "default": true
+        },
+        "http://asyncapi.com/definitions/3.0.0/Reference.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/Reference.json",
+            "type": "object",
+            "description": "A simple object to allow referencing other components in the specification, internally and externally.",
+            "required": [
+                "$ref"
+            ],
+            "properties": {
+                "$ref": {
+                    "description": "The reference string.",
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json"
+                }
+            },
+            "examples": [
+                {
+                    "$ref": "#/components/schemas/Pet"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/ReferenceObject.json",
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "http://asyncapi.com/definitions/3.0.0/externalDocs.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/externalDocs.json",
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Allows referencing an external resource for extended documentation.",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A short description of the target documentation. CommonMark syntax can be used for rich text representation."
+                },
+                "url": {
+                    "type": "string",
+                    "description": "The URL for the target documentation. This MUST be in the form of an absolute URL.",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "examples": [
+                {
+                    "description": "Find more info here",
+                    "url": "https://example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/specificationExtension.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json",
+            "description": "Any property starting with x- is valid.",
+            "additionalItems": true,
+            "additionalProperties": true
+        },
+        "http://asyncapi.com/definitions/3.1.0/externalDocs.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/externalDocs.json",
+            "description": "Allows referencing an external resource for extended documentation.",
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description of the target documentation. CommonMark syntax can be used for rich text representation.",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "The URL for the target documentation. This MUST be in the form of an absolute URL.",
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "description": "Find more info here",
+                    "url": "https://example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/channelMessages.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/channelMessages.json",
+            "description": "A map of the messages that will be sent to this channel by any application at any time. **Every message sent to this channel MUST be valid against one, and only one, of the message objects defined in this map.**",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/messageObject.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.1.0/messageObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/messageObject.json",
+            "description": "Describes a message received on a given channel and operation.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the message.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A longer description of the message. CommonMark is allowed.",
+                    "type": "string"
+                },
+                "examples": {
+                    "description": "List of examples.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/messageExampleObject.json"
+                    }
+                },
+                "deprecated": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/messageBindingsObject.json"
+                        }
+                    ]
+                },
+                "contentType": {
+                    "description": "The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. application/json). When omitted, the value MUST be the one specified on the defaultContentType field.",
+                    "type": "string"
+                },
+                "correlationId": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/correlationId.json"
+                        }
+                    ]
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/anySchema.json"
+                },
+                "name": {
+                    "description": "Name of the message.",
+                    "type": "string"
+                },
+                "payload": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/anySchema.json"
+                },
+                "summary": {
+                    "description": "A brief summary of the message.",
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/tag.json"
+                            }
+                        ]
+                    }
+                },
+                "traits": {
+                    "description": "A list of traits to apply to the message object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Message Object.",
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/messageTrait.json"
+                            },
+                            {
+                                "type": "array",
+                                "items": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                            },
+                                            {
+                                                "$ref": "http://asyncapi.com/definitions/3.1.0/messageTrait.json"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "additionalItems": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "messageId": "userSignup",
+                    "name": "UserSignup",
+                    "title": "User signup",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "contentType": "application/json",
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "correlationId": {
+                                "description": "Correlation ID set by application",
+                                "type": "string"
+                            },
+                            "applicationInstanceId": {
+                                "description": "Unique identifier for a given instance of the publishing application",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "payload": {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "$ref": "#/components/schemas/userCreate"
+                            },
+                            "signup": {
+                                "$ref": "#/components/schemas/signup"
+                            }
+                        }
+                    },
+                    "correlationId": {
+                        "description": "Default Correlation ID",
+                        "location": "$message.header#/correlationId"
+                    },
+                    "traits": [
+                        {
+                            "$ref": "#/components/messageTraits/commonHeaders"
+                        }
+                    ],
+                    "examples": [
+                        {
+                            "name": "SimpleSignup",
+                            "summary": "A simple UserSignup example message",
+                            "headers": {
+                                "correlationId": "my-correlation-id",
+                                "applicationInstanceId": "myInstanceId"
+                            },
+                            "payload": {
+                                "user": {
+                                    "someUserKey": "someUserValue"
+                                },
+                                "signup": {
+                                    "someSignupKey": "someSignupValue"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/messageExampleObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/messageExampleObject.json",
+            "type": "object",
+            "anyOf": [
+                {
+                    "required": [
+                        "payload"
+                    ]
+                },
+                {
+                    "required": [
+                        "headers"
+                    ]
+                }
+            ],
+            "properties": {
+                "headers": {
+                    "description": "Example of the application headers. It can be of any type.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "Machine readable name of the message example.",
+                    "type": "string"
+                },
+                "payload": {
+                    "description": "Example of the message payload. It can be of any type."
+                },
+                "summary": {
+                    "description": "A brief summary of the message example.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.1.0/messageBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/messageBindingsObject.json",
+            "description": "Map describing protocol-specific definitions for a message.",
+            "type": "object",
+            "properties": {
+                "amqp": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "amqp1": {},
+                "anypointmq": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    }
+                },
+                "googlepubsub": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "http": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0",
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "ibmmq": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "jms": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    }
+                },
+                "kafka": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "mqtt": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "nats": {},
+                "redis": {},
+                "sns": {},
+                "solace": {},
+                "sqs": {},
+                "stomp": {},
+                "ws": {}
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/message.json",
+            "title": "AMQP message bindings object",
+            "description": "This object contains information about the message representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "contentEncoding": {
+                    "type": "string",
+                    "description": "A MIME encoding for the message content."
+                },
+                "messageType": {
+                    "type": "string",
+                    "description": "Application-specific message type."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "contentEncoding": "gzip",
+                    "messageType": "user.signup",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json": {
+            "$id": "http://asyncapi.com/bindings/anypointmq/0.0.1/message.json",
+            "title": "Anypoint MQ message bindings object",
+            "description": "This object contains configuration for describing an Anypoint MQ message as an AsyncAPI message. This objects only contains configuration that can not be provided in the AsyncAPI standard message object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "A Schema object containing the definitions for Anypoint MQ-specific headers (protocol headers). This schema MUST be of type 'object' and have a 'properties' key. Examples of Anypoint MQ protocol headers are 'messageId' and 'messageGroupId'."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "messageId": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/googlepubsub/0.2.0/message.json",
+            "title": "Cloud Pub/Sub Channel Schema",
+            "description": "This object contains information about the message representation for Google Cloud Pub/Sub.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                },
+                "attributes": {
+                    "type": "object"
+                },
+                "orderingKey": {
+                    "type": "string"
+                },
+                "schema": {
+                    "type": "object",
+                    "additionalItems": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "schema": {
+                        "name": "projects/your-project-id/schemas/your-avro-schema-id"
+                    }
+                },
+                {
+                    "schema": {
+                        "name": "projects/your-project-id/schemas/your-protobuf-schema-id"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.3.0/message.json",
+            "title": "HTTP message bindings object",
+            "description": "This object contains information about the message representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "\tA Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "statusCode": {
+                    "type": "number",
+                    "description": "The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes). `statusCode` is only relevant for messages referenced by the [Operation Reply Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyObject), as it defines the status code for the response. In all other cases, this value can be safely ignored."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "Content-Type": {
+                                "type": "string",
+                                "enum": [
+                                    "application/json"
+                                ]
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.2.0/message.json",
+            "title": "HTTP message bindings object",
+            "description": "This object contains information about the message representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "\tA Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type 'object' and have a 'properties' key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "properties": {
+                            "Content-Type": {
+                                "type": "string",
+                                "enum": [
+                                    "application/json"
+                                ]
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/message.json",
+            "title": "IBM MQ message bindings object",
+            "description": "This object contains information about the message representation in IBM MQ.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "string",
+                        "jms",
+                        "binary"
+                    ],
+                    "default": "string",
+                    "description": "The type of the message."
+                },
+                "headers": {
+                    "type": "string",
+                    "description": "Defines the IBM MQ message headers to include with this message. More than one header can be specified as a comma separated list. Supporting information on IBM MQ message formats can be found on this [page](https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqmd-format-mqchar8) in the IBM MQ Knowledge Center."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Provides additional information for application developers: describes the message type or format."
+                },
+                "expiry": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "The recommended setting the client should use for the TTL (Time-To-Live) of the message. This is a period of time expressed in milliseconds and set by the application that puts the message. 'expiry' values are API dependant e.g., MQI and JMS use different units of time and default values for 'unlimited'. General information on IBM MQ message expiry can be found on this [page](https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqmd-expiry-mqlong) in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "const": "binary"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "const": "jms"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "headers"
+                        ]
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "const": "string"
+                        }
+                    },
+                    "not": {
+                        "required": [
+                            "headers"
+                        ]
+                    }
+                }
+            ],
+            "examples": [
+                {
+                    "type": "string",
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "type": "jms",
+                    "description": "JMS stream message",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/message.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/message.json",
+            "title": "Message Schema",
+            "description": "This object contains configuration for describing a JMS message as an AsyncAPI message. This objects only contains configuration that can not be provided in the AsyncAPI standard message object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for JMS headers (protocol headers). This schema MUST be of type 'object' and have a 'properties' key. Examples of JMS protocol headers are 'JMSMessageID', 'JMSTimestamp', and 'JMSCorrelationID'."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "headers": {
+                        "type": "object",
+                        "required": [
+                            "JMSMessageID"
+                        ],
+                        "properties": {
+                            "JMSMessageID": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A unique message identifier. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSTimestamp": {
+                                "type": "integer",
+                                "description": "The time the message was sent. This may be set by your JMS Provider on your behalf. The time the message was sent. The value of the timestamp is the amount of time, measured in milliseconds, that has elapsed since midnight, January 1, 1970, UTC."
+                            },
+                            "JMSDeliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "PERSISTENT",
+                                    "NON_PERSISTENT"
+                                ],
+                                "default": "PERSISTENT",
+                                "description": "Denotes the delivery mode for the message. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSPriority": {
+                                "type": "integer",
+                                "default": 4,
+                                "description": "The priority of the message. This may be set by your JMS Provider on your behalf."
+                            },
+                            "JMSExpires": {
+                                "type": "integer",
+                                "description": "The time at which the message expires. This may be set by your JMS Provider on your behalf. A value of zero means that the message does not expire. Any non-zero value is the amount of time, measured in milliseconds, that has elapsed since midnight, January 1, 1970, UTC, at which the message will expire."
+                            },
+                            "JMSType": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The type of message. Some JMS providers use a message repository that contains the definitions of messages sent by applications. The 'JMSType' header field may reference a message's definition in the provider's repository. The JMS API does not define a standard message definition repository, nor does it define a naming policy for the definitions it contains. Some messaging systems require that a message type definition for each application message be created and that each message specify its type. In order to work with such JMS providers, JMS clients should assign a value to 'JMSType', whether the application makes use of it or not. This ensures that the field is properly set for those providers that require it."
+                            },
+                            "JMSCorrelationID": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The correlation identifier of the message. A client can use the 'JMSCorrelationID' header field to link one message with another. A typical use is to link a response message with its request message. Since each message sent by a JMS provider is assigned a message ID value, it is convenient to link messages via message ID, such message ID values must start with the 'ID:' prefix. Conversely, application-specified values must not start with the 'ID:' prefix; this is reserved for provider-generated message ID values."
+                            },
+                            "JMSReplyTo": {
+                                "type": "string",
+                                "description": "The queue or topic that the message sender expects replies to."
+                            }
+                        }
+                    },
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.5.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                        }
+                    ],
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.4.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json",
+            "definitions": {
+                "avroSchema": {
+                    "title": "Avro Schema",
+                    "description": "Root Schema",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/types"
+                        }
+                    ]
+                },
+                "types": {
+                    "title": "Avro Types",
+                    "description": "Allowed Avro types",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/primitiveType"
+                        },
+                        {
+                            "$ref": "#/definitions/primitiveTypeWithMetadata"
+                        },
+                        {
+                            "$ref": "#/definitions/customTypeReference"
+                        },
+                        {
+                            "$ref": "#/definitions/avroRecord"
+                        },
+                        {
+                            "$ref": "#/definitions/avroEnum"
+                        },
+                        {
+                            "$ref": "#/definitions/avroArray"
+                        },
+                        {
+                            "$ref": "#/definitions/avroMap"
+                        },
+                        {
+                            "$ref": "#/definitions/avroFixed"
+                        },
+                        {
+                            "$ref": "#/definitions/avroUnion"
+                        }
+                    ]
+                },
+                "primitiveType": {
+                    "title": "Primitive Type",
+                    "description": "Basic type primitives.",
+                    "type": "string",
+                    "enum": [
+                        "null",
+                        "boolean",
+                        "int",
+                        "long",
+                        "float",
+                        "double",
+                        "bytes",
+                        "string"
+                    ]
+                },
+                "primitiveTypeWithMetadata": {
+                    "title": "Primitive Type With Metadata",
+                    "description": "A primitive type with metadata attached.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "$ref": "#/definitions/primitiveType"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "customTypeReference": {
+                    "title": "Custom Type",
+                    "description": "Reference to a ComplexType",
+                    "not": {
+                        "$ref": "#/definitions/primitiveType"
+                    },
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+                },
+                "avroUnion": {
+                    "title": "Union",
+                    "description": "A Union of types",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/avroSchema"
+                    },
+                    "minItems": 1
+                },
+                "avroField": {
+                    "title": "Field",
+                    "description": "A field within a Record",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/types"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "default": true,
+                        "order": {
+                            "enum": [
+                                "ascending",
+                                "descending",
+                                "ignore"
+                            ]
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "type"
+                    ]
+                },
+                "avroRecord": {
+                    "title": "Record",
+                    "description": "A Record",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "record"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "fields": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/avroField"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "fields"
+                    ]
+                },
+                "avroEnum": {
+                    "title": "Enum",
+                    "description": "An enumeration",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "enum"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "symbols": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "symbols"
+                    ]
+                },
+                "avroArray": {
+                    "title": "Array",
+                    "description": "An array",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "array"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "items": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "items"
+                    ]
+                },
+                "avroMap": {
+                    "title": "Map",
+                    "description": "A map of values",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "map"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "values": {
+                            "$ref": "#/definitions/types"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "values"
+                    ]
+                },
+                "avroFixed": {
+                    "title": "Fixed",
+                    "description": "A fixed sized array of bytes",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "fixed"
+                        },
+                        "name": {
+                            "$ref": "#/definitions/name"
+                        },
+                        "namespace": {
+                            "$ref": "#/definitions/namespace"
+                        },
+                        "doc": {
+                            "type": "string"
+                        },
+                        "aliases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            }
+                        },
+                        "size": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "name",
+                        "size"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                },
+                "namespace": {
+                    "type": "string",
+                    "pattern": "^([A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*)*$"
+                }
+            },
+            "description": "Json-Schema definition for Avro AVSC files.",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/avroSchema"
+                }
+            ],
+            "title": "Avro Schema Definition"
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/message.json",
+            "title": "Message Schema",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "key": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "The message key."
+                },
+                "schemaIdLocation": {
+                    "type": "string",
+                    "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+                    "enum": [
+                        "header",
+                        "payload"
+                    ]
+                },
+                "schemaIdPayloadEncoding": {
+                    "type": "string",
+                    "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+                },
+                "schemaLookupStrategy": {
+                    "type": "string",
+                    "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "key": {
+                        "type": "string",
+                        "enum": [
+                            "myKey"
+                        ]
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "apicurio-new",
+                    "schemaLookupStrategy": "TopicIdStrategy",
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "key": {
+                        "$ref": "path/to/user-create.avsc#/UserCreate"
+                    },
+                    "schemaIdLocation": "payload",
+                    "schemaIdPayloadEncoding": "4",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/message.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/message.json",
+            "title": "MQTT message bindings object",
+            "description": "This object contains information about the message representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "payloadFormatIndicator": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1
+                    ],
+                    "description": "1 indicates that the payload is UTF-8 encoded character data.  0 indicates that the payload format is unspecified.",
+                    "default": 0
+                },
+                "correlationData": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Correlation Data is used by the sender of the request message to identify which request the response message is for when it is received."
+                },
+                "contentType": {
+                    "type": "string",
+                    "description": "String describing the content type of the message payload. This should not conflict with the contentType field of the associated AsyncAPI Message object."
+                },
+                "responseTopic": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "format": "uri-template",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "The topic (channel URI) to be used for a response message."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.2.0"
+                },
+                {
+                    "contentType": "application/json",
+                    "correlationData": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "responseTopic": "application/responses",
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/correlationId.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/correlationId.json",
+            "description": "An object that specifies an identifier at design time that can used for message tracing and correlation.",
+            "type": "object",
+            "required": [
+                "location"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A optional description of the correlation ID. GitHub Flavored Markdown is allowed.",
+                    "type": "string"
+                },
+                "location": {
+                    "description": "A runtime expression that specifies the location of the correlation ID",
+                    "type": "string",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "description": "Default Correlation ID",
+                    "location": "$message.header#/correlationId"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/anySchema.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/anySchema.json",
+            "description": "An object representing either a schema or a multiFormatSchema based on the existence of the 'schema' property. If the property 'schema' is present, use the multi-format schema. Use the default AsyncAPI Schema otherwise.",
+            "if": {
+                "required": [
+                    "schema"
+                ]
+            },
+            "then": {
+                "$ref": "http://asyncapi.com/definitions/3.1.0/multiFormatSchema.json"
+            },
+            "else": {
+                "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+            }
+        },
+        "http://asyncapi.com/definitions/3.1.0/multiFormatSchema.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/multiFormatSchema.json",
+            "description": "The Multi Format Schema Object represents a schema definition. It differs from the Schema Object in that it supports multiple schema formats or languages (e.g., JSON Schema, Avro, etc.).",
+            "type": "object",
+            "if": {
+                "not": {
+                    "type": "object"
+                }
+            },
+            "then": {
+                "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+            },
+            "else": {
+                "allOf": [
+                    {
+                        "if": {
+                            "not": {
+                                "description": "If no schemaFormat has been defined, default to schema or reference",
+                                "required": [
+                                    "schemaFormat"
+                                ]
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "description": "If schemaFormat has been defined check if it's one of the AsyncAPI Schema Object formats",
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.aai.asyncapi;version=2.0.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.0.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.0.0",
+                                        "application/vnd.aai.asyncapi;version=2.1.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.1.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.1.0",
+                                        "application/vnd.aai.asyncapi;version=2.2.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.2.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.2.0",
+                                        "application/vnd.aai.asyncapi;version=2.3.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.3.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.3.0",
+                                        "application/vnd.aai.asyncapi;version=2.4.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.4.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.4.0",
+                                        "application/vnd.aai.asyncapi;version=2.5.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.5.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.5.0",
+                                        "application/vnd.aai.asyncapi;version=2.6.0",
+                                        "application/vnd.aai.asyncapi+json;version=2.6.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=2.6.0",
+                                        "application/vnd.aai.asyncapi;version=3.0.0",
+                                        "application/vnd.aai.asyncapi+json;version=3.0.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=3.0.0",
+                                        "application/vnd.aai.asyncapi;version=3.1.0",
+                                        "application/vnd.aai.asyncapi+json;version=3.1.0",
+                                        "application/vnd.aai.asyncapi+yaml;version=3.1.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/schema+json;version=draft-07",
+                                        "application/schema+yaml;version=draft-07"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "$ref": "http://json-schema.org/draft-07/schema"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.oai.openapi;version=3.0.0",
+                                        "application/vnd.oai.openapi+json;version=3.0.0",
+                                        "application/vnd.oai.openapi+yaml;version=3.0.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "required": [
+                                "schemaFormat"
+                            ],
+                            "properties": {
+                                "schemaFormat": {
+                                    "enum": [
+                                        "application/vnd.apache.avro;version=1.9.0",
+                                        "application/vnd.apache.avro+json;version=1.9.0",
+                                        "application/vnd.apache.avro+yaml;version=1.9.0"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                        },
+                                        {
+                                            "$ref": "http://asyncapi.com/definitions/3.0.0/avroSchema_v1.json"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ],
+                "properties": {
+                    "schemaFormat": {
+                        "description": "A string containing the name of the schema format that is used to define the information. If schemaFormat is missing, it MUST default to application/vnd.aai.asyncapi+json;version={{asyncapi}} where {{asyncapi}} matches the AsyncAPI Version String. In such a case, this would make the Multi Format Schema Object equivalent to the Schema Object. When using Reference Object within the schema, the schemaFormat of the resource being referenced MUST match the schemaFormat of the schema that contains the initial reference. For example, if you reference Avro schema, then schemaFormat of referencing resource and the resource being reference MUST match.",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "description": "All the schema formats tooling MUST support",
+                                "enum": [
+                                    "application/schema+json;version=draft-07",
+                                    "application/schema+yaml;version=draft-07",
+                                    "application/vnd.aai.asyncapi;version=3.0.0",
+                                    "application/vnd.aai.asyncapi+json;version=3.0.0",
+                                    "application/vnd.aai.asyncapi+yaml;version=3.0.0",
+                                    "application/vnd.aai.asyncapi;version=3.1.0",
+                                    "application/vnd.aai.asyncapi+json;version=3.1.0",
+                                    "application/vnd.aai.asyncapi+yaml;version=3.1.0"
+                                ]
+                            },
+                            {
+                                "description": "All the schema formats tools are RECOMMENDED to support",
+                                "enum": [
+                                    "application/vnd.oai.openapi;version=3.0.0",
+                                    "application/vnd.oai.openapi+json;version=3.0.0",
+                                    "application/vnd.oai.openapi+yaml;version=3.0.0",
+                                    "application/vnd.apache.avro;version=1.9.0",
+                                    "application/vnd.apache.avro+json;version=1.9.0",
+                                    "application/vnd.apache.avro+yaml;version=1.9.0",
+                                    "application/raml+yaml;version=1.0"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.1.0/schema.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/schema.json",
+            "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is a superset of the JSON Schema Specification Draft 07. The empty schema (which allows any instance to validate) MAY be represented by the boolean value true and a schema which allows no instance to validate MAY be represented by the boolean value false.",
+            "allOf": [
+                {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                },
+                {
+                    "properties": {
+                        "deprecated": {
+                            "description": "Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is false.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "allOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                            }
+                        },
+                        "anyOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                            }
+                        },
+                        "oneOf": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                            }
+                        },
+                        "not": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                        },
+                        "contains": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                        },
+                        "items": {
+                            "default": {},
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                                },
+                                {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                                    }
+                                }
+                            ]
+                        },
+                        "propertyNames": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                        },
+                        "properties": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                            }
+                        },
+                        "patternProperties": {
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                            }
+                        },
+                        "additionalProperties": {
+                            "default": {},
+                            "anyOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/schema.json"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "discriminator": {
+                            "description": "Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. The property name used MUST be defined at this schema and it MUST be in the required property list. When used, the value MUST be the name of this schema or any schema that inherits it. See Composition and Inheritance for more details.",
+                            "type": "string"
+                        },
+                        "externalDocs": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                                }
+                            ]
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json": {
+            "$id": "http://asyncapi.com/definitions/3.0.0/openapiSchema_3_0.json",
+            "type": "object",
+            "definitions": {
+                "ExternalDocumentation": {
+                    "type": "object",
+                    "required": [
+                        "url"
+                    ],
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                },
+                "Discriminator": {
+                    "type": "object",
+                    "required": [
+                        "propertyName"
+                    ],
+                    "properties": {
+                        "propertyName": {
+                            "type": "string"
+                        },
+                        "mapping": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "Reference": {
+                    "type": "object",
+                    "required": [
+                        "$ref"
+                    ],
+                    "patternProperties": {
+                        "^\\$ref$": {
+                            "type": "string",
+                            "format": "uri-reference"
+                        }
+                    }
+                },
+                "XML": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "attribute": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "wrapped": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": {}
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxLength": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "maxItems": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "enum": {
+                    "type": "array",
+                    "items": true,
+                    "minItems": 1,
+                    "uniqueItems": false
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "not": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "allOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "oneOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "items": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "default": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "default": true,
+                "nullable": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "discriminator": {
+                    "$ref": "#/definitions/Discriminator"
+                },
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "example": true,
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "xml": {
+                    "$ref": "#/definitions/XML"
+                }
+            },
+            "patternProperties": {
+                "^x-": true
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.1.0/tag.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/tag.json",
+            "description": "Allows adding metadata to a single tag.",
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for the tag. CommonMark syntax can be used for rich text representation.",
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "name": {
+                    "description": "The name of the tag.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "name": "user",
+                    "description": "User-related messages"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/messageTrait.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/messageTrait.json",
+            "description": "Describes a trait that MAY be applied to a Message Object. This object MAY contain any property from the Message Object, except payload and traits.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the message.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A longer description of the message. CommonMark is allowed.",
+                    "type": "string"
+                },
+                "examples": {
+                    "description": "List of examples.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/messageExampleObject.json"
+                    }
+                },
+                "deprecated": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/messageBindingsObject.json"
+                        }
+                    ]
+                },
+                "contentType": {
+                    "description": "The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. application/json). When omitted, the value MUST be the one specified on the defaultContentType field.",
+                    "type": "string"
+                },
+                "correlationId": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/correlationId.json"
+                        }
+                    ]
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "headers": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/anySchema.json"
+                },
+                "name": {
+                    "description": "Name of the message.",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "A brief summary of the message.",
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/tag.json"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "contentType": "application/json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/parameters.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/parameters.json",
+            "description": "JSON objects describing re-usable channel parameters.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/parameter.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "address": "user/{userId}/signedup",
+                    "parameters": {
+                        "userId": {
+                            "description": "Id of the user."
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/parameter.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/parameter.json",
+            "description": "Describes a parameter included in a channel address.",
+            "properties": {
+                "description": {
+                    "description": "A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed.",
+                    "type": "string"
+                },
+                "examples": {
+                    "description": "An array of examples of the parameter value.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "description": "The default value to use for substitution, and to send, if an alternate value is not supplied.",
+                    "type": "string"
+                },
+                "enum": {
+                    "description": "An enumeration of string values to be used if the substitution options are from a limited set.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "location": {
+                    "description": "A runtime expression that specifies the location of the parameter value",
+                    "type": "string",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "address": "user/{userId}/signedup",
+                    "parameters": {
+                        "userId": {
+                            "description": "Id of the user.",
+                            "location": "$message.payload#/user/id"
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/components.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/components.json",
+            "description": "An object to hold a set of reusable objects for different aspects of the AsyncAPI specification. All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.",
+            "type": "object",
+            "properties": {
+                "channelBindings": {
+                    "description": "An object to hold reusable Channel Bindings Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/channelBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "channels": {
+                    "description": "An object to hold reusable Channel Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/channel.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "correlationIds": {
+                    "description": "An object to hold reusable Correlation ID Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/correlationId.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "An object to hold reusable External Documentation Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messageBindings": {
+                    "description": "An object to hold reusable Message Bindings Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/messageBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messageTraits": {
+                    "description": "An object to hold reusable Message Trait Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/messageTrait.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "messages": {
+                    "description": "An object to hold reusable Message Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/messageObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationBindings": {
+                    "description": "An object to hold reusable Operation Bindings Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/operationBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operationTraits": {
+                    "description": "An object to hold reusable Operation Trait Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/operationTrait.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "operations": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parameters": {
+                    "description": "An object to hold reusable Parameter Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/parameter.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "replies": {
+                    "description": "An object to hold reusable Operation Reply Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/operationReply.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "replyAddresses": {
+                    "description": "An object to hold reusable Operation Reply Address Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/operationReplyAddress.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "schemas": {
+                    "description": "An object to hold reusable Schema Object. If this is a Schema Object, then the schemaFormat will be assumed to be 'application/vnd.aai.asyncapi+json;version=asyncapi' where the version is equal to the AsyncAPI Version String.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/anySchema.json"
+                        }
+                    }
+                },
+                "securitySchemes": {
+                    "description": "An object to hold reusable Security Scheme Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/SecurityScheme.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "serverBindings": {
+                    "description": "An object to hold reusable Server Bindings Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/serverBindingsObject.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "serverVariables": {
+                    "description": "An object to hold reusable Server Variable Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/serverVariable.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "servers": {
+                    "description": "An object to hold reusable Server Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/server.json"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "tags": {
+                    "description": "An object to hold reusable Tag Objects.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^[\\w\\d\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/tag.json"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "components": {
+                        "schemas": {
+                            "Category": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "Tag": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "AvroExample": {
+                                "schemaFormat": "application/vnd.apache.avro+json;version=1.9.0",
+                                "schema": {
+                                    "$ref": "path/to/user-create.avsc#/UserCreate"
+                                }
+                            }
+                        },
+                        "servers": {
+                            "development": {
+                                "host": "{stage}.in.mycompany.com:{port}",
+                                "description": "RabbitMQ broker",
+                                "protocol": "amqp",
+                                "protocolVersion": "0-9-1",
+                                "variables": {
+                                    "stage": {
+                                        "$ref": "#/components/serverVariables/stage"
+                                    },
+                                    "port": {
+                                        "$ref": "#/components/serverVariables/port"
+                                    }
+                                }
+                            }
+                        },
+                        "serverVariables": {
+                            "stage": {
+                                "default": "demo",
+                                "description": "This value is assigned by the service provider, in this example `mycompany.com`"
+                            },
+                            "port": {
+                                "enum": [
+                                    "5671",
+                                    "5672"
+                                ],
+                                "default": "5672"
+                            }
+                        },
+                        "channels": {
+                            "user/signedup": {
+                                "subscribe": {
+                                    "message": {
+                                        "$ref": "#/components/messages/userSignUp"
+                                    }
+                                }
+                            }
+                        },
+                        "messages": {
+                            "userSignUp": {
+                                "summary": "Action to sign a user up.",
+                                "description": "Multiline description of what this action does.\nHere you have another line.\n",
+                                "tags": [
+                                    {
+                                        "name": "user"
+                                    },
+                                    {
+                                        "name": "signup"
+                                    }
+                                ],
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "applicationInstanceId": {
+                                            "description": "Unique identifier for a given instance of the publishing application",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "properties": {
+                                        "user": {
+                                            "$ref": "#/components/schemas/userCreate"
+                                        },
+                                        "signup": {
+                                            "$ref": "#/components/schemas/signup"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "userId": {
+                                "description": "Id of the user."
+                            }
+                        },
+                        "correlationIds": {
+                            "default": {
+                                "description": "Default Correlation ID",
+                                "location": "$message.header#/correlationId"
+                            }
+                        },
+                        "messageTraits": {
+                            "commonHeaders": {
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "my-app-header": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 100
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/operationBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/operationBindingsObject.json",
+            "description": "Map describing protocol-specific definitions for an operation.",
+            "type": "object",
+            "properties": {
+                "amqp": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "amqp1": {},
+                "anypointmq": {},
+                "googlepubsub": {},
+                "http": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/http/0.3.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0",
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "ibmmq": {},
+                "jms": {},
+                "kafka": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "mqtt": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "nats": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/nats/0.1.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/nats/0.1.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "redis": {},
+                "ros2": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ros2/0.1.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ros2/0.1.0/operation.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "solace": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.3.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.2.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.4.0",
+                                "0.3.0",
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "sqs": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "stomp": {},
+                "ws": {}
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/bindings/amqp/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/amqp/0.3.0/operation.json",
+            "title": "AMQP operation bindings object",
+            "description": "This object contains information about the operation representation in AMQP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "expiration": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "TTL (Time-To-Live) for the message. It MUST be greater than or equal to zero."
+                },
+                "userId": {
+                    "type": "string",
+                    "description": "Identifies the user who has sent the message."
+                },
+                "cc": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The routing keys the message should be routed to at the time of publishing."
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "A priority for the message."
+                },
+                "deliveryMode": {
+                    "type": "integer",
+                    "enum": [
+                        1,
+                        2
+                    ],
+                    "description": "Delivery mode of the message. Its value MUST be either 1 (transient) or 2 (persistent)."
+                },
+                "mandatory": {
+                    "type": "boolean",
+                    "description": "Whether the message is mandatory or not."
+                },
+                "bcc": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Like cc but consumers will not receive this information."
+                },
+                "timestamp": {
+                    "type": "boolean",
+                    "description": "Whether the message should include a timestamp or not."
+                },
+                "ack": {
+                    "type": "boolean",
+                    "description": "Whether the consumer should ack the message or not."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "expiration": 100000,
+                    "userId": "guest",
+                    "cc": [
+                        "user.logs"
+                    ],
+                    "priority": 10,
+                    "deliveryMode": 2,
+                    "mandatory": false,
+                    "bcc": [
+                        "external.audit"
+                    ],
+                    "timestamp": true,
+                    "ack": false,
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.3.0/operation.json",
+            "title": "HTTP operation bindings object",
+            "description": "This object contains information about the operation representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "PUT",
+                        "POST",
+                        "PATCH",
+                        "DELETE",
+                        "HEAD",
+                        "OPTIONS",
+                        "CONNECT",
+                        "TRACE"
+                    ],
+                    "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
+                },
+                "query": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.3.0"
+                },
+                {
+                    "method": "GET",
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/http/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/http/0.2.0/operation.json",
+            "title": "HTTP operation bindings object",
+            "description": "This object contains information about the operation representation in HTTP.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "GET",
+                        "PUT",
+                        "POST",
+                        "PATCH",
+                        "DELETE",
+                        "HEAD",
+                        "OPTIONS",
+                        "CONNECT",
+                        "TRACE"
+                    ],
+                    "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
+                },
+                "query": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.2.0"
+                },
+                {
+                    "method": "GET",
+                    "query": {
+                        "type": "object",
+                        "required": [
+                            "companyId"
+                        ],
+                        "properties": {
+                            "companyId": {
+                                "type": "number",
+                                "minimum": 1,
+                                "description": "The Id of the company."
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in Kafka.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer group."
+                },
+                "clientId": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+                    "description": "Id of the consumer inside a consumer group."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": {
+                        "type": "string",
+                        "enum": [
+                            "myGroupId"
+                        ]
+                    },
+                    "clientId": {
+                        "type": "string",
+                        "enum": [
+                            "myClientId"
+                        ]
+                    },
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/operation.json",
+            "title": "MQTT operation bindings object",
+            "description": "This object contains information about the operation representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "qos": {
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "description": "Defines the Quality of Service (QoS) levels for the message flow between client and server. Its value MUST be either 0 (At most once delivery), 1 (At least once delivery), or 2 (Exactly once delivery)."
+                },
+                "retain": {
+                    "type": "boolean",
+                    "description": "Whether the broker should retain the message or not."
+                },
+                "messageExpiryInterval": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 4294967295
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Lifetime of the message in seconds"
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "qos": 2,
+                    "retain": true,
+                    "messageExpiryInterval": 60,
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/nats/0.1.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/nats/0.1.0/operation.json",
+            "title": "NATS operation bindings object",
+            "description": "This object contains information about the operation representation in NATS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queue": {
+                    "type": "string",
+                    "description": "Defines the name of the queue to use. It MUST NOT exceed 255 characters.",
+                    "maxLength": 255
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "queue": "MyCustomQueue",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ros2/0.1.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/ros2/0.1.0/operation.json",
+            "description": "This object contains information about the operation representation in ROS 2.",
+            "examples": [
+                {
+                    "node": "/turtlesim",
+                    "qosPolicies": {
+                        "deadline": "-1",
+                        "durability": "volatile",
+                        "history": "unknown",
+                        "leaseDuration": "-1",
+                        "lifespan": "-1",
+                        "liveliness": "automatic",
+                        "reliability": "reliable"
+                    },
+                    "role": "subscriber"
+                }
+            ],
+            "type": "object",
+            "required": [
+                "role",
+                "node"
+            ],
+            "properties": {
+                "bindingVersion": {
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ]
+                },
+                "node": {
+                    "description": "The name of the ROS 2 node that implements this operation.",
+                    "type": "string"
+                },
+                "qosPolicies": {
+                    "type": "object",
+                    "properties": {
+                        "deadline": {
+                            "description": "The expected maximum amount of time between subsequent messages being published to a topic. -1 means infinite.",
+                            "type": "integer"
+                        },
+                        "durability": {
+                            "description": "Persistence specification that determines message availability for late-joining subscribers",
+                            "type": "string",
+                            "enum": [
+                                "transient_local",
+                                "volatile"
+                            ]
+                        },
+                        "history": {
+                            "description": "Policy parameter that defines the maximum number of samples maintained in the middleware queue",
+                            "type": "string",
+                            "enum": [
+                                "keep_last",
+                                "keep_all",
+                                "unknown"
+                            ]
+                        },
+                        "leaseDuration": {
+                            "description": "The maximum period of time a publisher has to indicate that it is alive before the system considers it to have lost liveliness. -1 means infinite.",
+                            "type": "integer"
+                        },
+                        "lifespan": {
+                            "description": "The maximum amount of time between the publishing and the reception of a message without the message being considered stale or expired. -1 means infinite.",
+                            "type": "integer"
+                        },
+                        "liveliness": {
+                            "description": "Defines the mechanism by which the system monitors and determines the operational status of communication entities within the network.",
+                            "type": "string",
+                            "enum": [
+                                "automatic",
+                                "manual"
+                            ]
+                        },
+                        "reliability": {
+                            "description": "Specifies the communication guarantee model that determines whether message delivery confirmation between publisher and subscriber is required.",
+                            "type": "string",
+                            "enum": [
+                                "best_effort",
+                                "realiable"
+                            ]
+                        }
+                    }
+                },
+                "role": {
+                    "description": "Specifies the ROS 2 type of the node for this operation.",
+                    "type": "string",
+                    "enum": [
+                        "publisher",
+                        "action_client",
+                        "service_client",
+                        "subscriber",
+                        "action_server",
+                        "service_server"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/bindings/sns/0.1.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/sns/0.1.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in SNS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "topic": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier",
+                    "description": "Often we can assume that the SNS Topic is the channel name-we provide this field in case the you need to supply the ARN, or the Topic name is not the channel name in the AsyncAPI document."
+                },
+                "consumers": {
+                    "type": "array",
+                    "description": "The protocols that listen to this topic and their endpoints.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/consumer"
+                    },
+                    "minItems": 1
+                },
+                "deliveryPolicy": {
+                    "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/deliveryPolicy",
+                    "description": "Policy for retries to HTTP. The field is the default for HTTP receivers of the SNS Topic which may be overridden by a specific consumer."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "description": "The version of this binding.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "consumers"
+            ],
+            "definitions": {
+                "identifier": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "The endpoint is a URL."
+                        },
+                        "email": {
+                            "type": "string",
+                            "description": "The endpoint is an email address."
+                        },
+                        "phone": {
+                            "type": "string",
+                            "description": "The endpoint is a phone number."
+                        },
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding. We don't use $ref because we are referring, not including."
+                        }
+                    }
+                },
+                "consumer": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "protocol": {
+                            "description": "The protocol that this endpoint receives messages by.",
+                            "type": "string",
+                            "enum": [
+                                "http",
+                                "https",
+                                "email",
+                                "email-json",
+                                "sms",
+                                "sqs",
+                                "application",
+                                "lambda",
+                                "firehose"
+                            ]
+                        },
+                        "endpoint": {
+                            "description": "The endpoint messages are delivered to.",
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier"
+                        },
+                        "filterPolicy": {
+                            "type": "object",
+                            "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
+                            "patternProperties": {
+                                "^x-[\\w\\d\\.\\x2d_]+$": {
+                                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                                }
+                            },
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "filterPolicyScope": {
+                            "type": "string",
+                            "description": "Determines whether the FilterPolicy applies to MessageAttributes or MessageBody.",
+                            "enum": [
+                                "MessageAttributes",
+                                "MessageBody"
+                            ],
+                            "default": "MessageAttributes"
+                        },
+                        "rawMessageDelivery": {
+                            "type": "boolean",
+                            "description": "If true AWS SNS attributes are removed from the body, and for SQS, SNS message attributes are copied to SQS message attributes. If false the SNS attributes are included in the body."
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/redrivePolicy"
+                        },
+                        "deliveryPolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/deliveryPolicy",
+                            "description": "Policy for retries to HTTP. The parameter is for that SNS Subscription and overrides any policy on the SNS Topic."
+                        },
+                        "displayName": {
+                            "type": "string",
+                            "description": "The display name to use with an SNS subscription"
+                        }
+                    },
+                    "required": [
+                        "protocol",
+                        "endpoint",
+                        "rawMessageDelivery"
+                    ]
+                },
+                "deliveryPolicy": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "minDelayTarget": {
+                            "type": "integer",
+                            "description": "The minimum delay for a retry in seconds."
+                        },
+                        "maxDelayTarget": {
+                            "type": "integer",
+                            "description": "The maximum delay for a retry in seconds."
+                        },
+                        "numRetries": {
+                            "type": "integer",
+                            "description": "The total number of retries, including immediate, pre-backoff, backoff, and post-backoff retries."
+                        },
+                        "numNoDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of immediate retries (with no delay)."
+                        },
+                        "numMinDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of immediate retries (with delay)."
+                        },
+                        "numMaxDelayRetries": {
+                            "type": "integer",
+                            "description": "The number of post-backoff phase retries, with the maximum delay between retries."
+                        },
+                        "backoffFunction": {
+                            "type": "string",
+                            "description": "The algorithm for backoff between retries.",
+                            "enum": [
+                                "arithmetic",
+                                "exponential",
+                                "geometric",
+                                "linear"
+                            ]
+                        },
+                        "maxReceivesPerSecond": {
+                            "type": "integer",
+                            "description": "The maximum number of deliveries per second, per subscription."
+                        }
+                    }
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sns/0.1.0/operation.json#/definitions/identifier",
+                            "description": "The SQS queue to use as a dead letter queue (DLQ)."
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "topic": {
+                        "name": "someTopic"
+                    },
+                    "consumers": [
+                        {
+                            "protocol": "sqs",
+                            "endpoint": {
+                                "name": "someQueue"
+                            },
+                            "filterPolicy": {
+                                "store": [
+                                    "asyncapi_corp"
+                                ],
+                                "event": [
+                                    {
+                                        "anything-but": "order_cancelled"
+                                    }
+                                ],
+                                "customer_interests": [
+                                    "rugby",
+                                    "football",
+                                    "baseball"
+                                ]
+                            },
+                            "filterPolicyScope": "MessageAttributes",
+                            "rawMessageDelivery": false,
+                            "redrivePolicy": {
+                                "deadLetterQueue": {
+                                    "arn": "arn:aws:SQS:eu-west-1:0000000:123456789"
+                                },
+                                "maxReceiveCount": 25
+                            },
+                            "deliveryPolicy": {
+                                "minDelayTarget": 10,
+                                "maxDelayTarget": 100,
+                                "numRetries": 5,
+                                "numNoDelayRetries": 2,
+                                "numMinDelayRetries": 3,
+                                "numMaxDelayRetries": 5,
+                                "backoffFunction": "linear",
+                                "maxReceivesPerSecond": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.4.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.4.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                },
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            },
+                                            "maxTtl": {
+                                                "type": "string",
+                                                "description": "The maximum TTL to apply to messages to be spooled."
+                                            },
+                                            "maxMsgSpoolUsage": {
+                                                "type": "string",
+                                                "description": "The maximum amount of message spool that the given queue may use"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "timeToLive": {
+                    "type": "integer",
+                    "description": "Interval in milliseconds or a Schema Object containing the definition of the lifetime of the message."
+                },
+                "priority": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255,
+                    "description": "The valid priority value range is 0-255 with 0 as the lowest priority and 255 as the highest or a Schema Object containing the definition of the priority."
+                },
+                "dmqEligible": {
+                    "type": "boolean",
+                    "description": "Set the message to be eligible to be moved to a Dead Message Queue. The default value is false."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.4.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.3.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.3.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            },
+                                            "maxTtl": {
+                                                "type": "string",
+                                                "description": "The maximum TTL to apply to messages to be spooled."
+                                            },
+                                            "maxMsgSpoolUsage": {
+                                                "type": "string",
+                                                "description": "The maximum amount of message spool that the given queue may use"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.3.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.2.0/operation.json",
+            "title": "Solace operation bindings object",
+            "description": "This object contains information about the operation representation in Solace.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "destinations": {
+                    "description": "The list of Solace destinations referenced in the operation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "deliveryMode": {
+                                "type": "string",
+                                "enum": [
+                                    "direct",
+                                    "persistent"
+                                ]
+                            }
+                        },
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "queue",
+                                        "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "queue": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the queue"
+                                            },
+                                            "topicSubscriptions": {
+                                                "type": "array",
+                                                "description": "The list of topics that the queue subscribes to.",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "accessType": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "exclusive",
+                                                    "nonexclusive"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "destinationType": {
+                                        "type": "string",
+                                        "const": "topic",
+                                        "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+                                    },
+                                    "topicSubscriptions": {
+                                        "type": "array",
+                                        "description": "The list of topics that the client subscribes to.",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "bindingVersion": "0.2.0",
+                    "destinations": [
+                        {
+                            "destinationType": "queue",
+                            "queue": {
+                                "name": "sampleQueue",
+                                "topicSubscriptions": [
+                                    "samples/*"
+                                ],
+                                "accessType": "nonexclusive"
+                            }
+                        },
+                        {
+                            "destinationType": "topic",
+                            "topicSubscriptions": [
+                                "samples/*"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/sqs/0.2.0/operation.json": {
+            "$id": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json",
+            "title": "Operation Schema",
+            "description": "This object contains information about the operation representation in SQS.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "queues": {
+                    "type": "array",
+                    "description": "Queue objects that are either the endpoint for an SNS Operation Binding Object, or the deadLetterQueue of the SQS Operation Binding Object.",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/queue"
+                    }
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0",
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "default": "latest"
+                }
+            },
+            "required": [
+                "queues"
+            ],
+            "definitions": {
+                "queue": {
+                    "type": "object",
+                    "description": "A definition of a queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "$ref": {
+                            "type": "string",
+                            "description": "Allows for an external definition of a queue. The referenced structure MUST be in the format of a Queue. If there are conflicts between the referenced definition and this Queue's definition, the behavior is undefined."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the queue. When an SNS Operation Binding Object references an SQS queue by name, the identifier should be the one in this field."
+                        },
+                        "fifoQueue": {
+                            "type": "boolean",
+                            "description": "Is this a FIFO queue?",
+                            "default": false
+                        },
+                        "deduplicationScope": {
+                            "type": "string",
+                            "enum": [
+                                "queue",
+                                "messageGroup"
+                            ],
+                            "description": "Specifies whether message deduplication occurs at the message group or queue level. Valid values are messageGroup and queue (default).",
+                            "default": "queue"
+                        },
+                        "fifoThroughputLimit": {
+                            "type": "string",
+                            "enum": [
+                                "perQueue",
+                                "perMessageGroupId"
+                            ],
+                            "description": "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are perQueue (default) and perMessageGroupId.",
+                            "default": "perQueue"
+                        },
+                        "deliveryDelay": {
+                            "type": "integer",
+                            "description": "The number of seconds to delay before a message sent to the queue can be received. Used to create a delay queue.",
+                            "minimum": 0,
+                            "maximum": 900,
+                            "default": 0
+                        },
+                        "visibilityTimeout": {
+                            "type": "integer",
+                            "description": "The length of time, in seconds, that a consumer locks a message - hiding it from reads - before it is unlocked and can be read again.",
+                            "minimum": 0,
+                            "maximum": 43200,
+                            "default": 30
+                        },
+                        "receiveMessageWaitTime": {
+                            "type": "integer",
+                            "description": "Determines if the queue uses short polling or long polling. Set to zero the queue reads available messages and returns immediately. Set to a non-zero integer, long polling waits the specified number of seconds for messages to arrive before returning.",
+                            "default": 0
+                        },
+                        "messageRetentionPeriod": {
+                            "type": "integer",
+                            "description": "How long to retain a message on the queue in seconds, unless deleted.",
+                            "minimum": 60,
+                            "maximum": 1209600,
+                            "default": 345600
+                        },
+                        "redrivePolicy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/redrivePolicy"
+                        },
+                        "policy": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/policy"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "description": "Key-value pairs that represent AWS tags on the queue."
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                "redrivePolicy": {
+                    "type": "object",
+                    "description": "Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue.",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "deadLetterQueue": {
+                            "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/identifier"
+                        },
+                        "maxReceiveCount": {
+                            "type": "integer",
+                            "description": "The number of times a message is delivered to the source queue before being moved to the dead-letter queue.",
+                            "default": 10
+                        }
+                    },
+                    "required": [
+                        "deadLetterQueue"
+                    ]
+                },
+                "identifier": {
+                    "type": "object",
+                    "description": "The SQS queue to use as a dead letter queue (DLQ).",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "arn": {
+                            "type": "string",
+                            "description": "The target is an ARN. For example, for SQS, the identifier may be an ARN, which will be of the form: arn:aws:sqs:{region}:{account-id}:{queueName}"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The endpoint is identified by a name, which corresponds to an identifying field called 'name' of a binding for that protocol on this publish Operation Object. For example, if the protocol is 'sqs' then the name refers to the name field sqs binding."
+                        }
+                    }
+                },
+                "policy": {
+                    "type": "object",
+                    "description": "The security policy for the SQS Queue",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "statements": {
+                            "type": "array",
+                            "description": "An array of statement objects, each of which controls a permission for this queue.",
+                            "items": {
+                                "$ref": "http://asyncapi.com/bindings/sqs/0.2.0/operation.json#/definitions/statement"
+                            }
+                        }
+                    },
+                    "required": [
+                        "statements"
+                    ]
+                },
+                "statement": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                        }
+                    },
+                    "properties": {
+                        "effect": {
+                            "type": "string",
+                            "enum": [
+                                "Allow",
+                                "Deny"
+                            ]
+                        },
+                        "principal": {
+                            "description": "The AWS account or resource ARN that this statement applies to.",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        },
+                        "action": {
+                            "description": "The SQS permission being allowed or denied e.g. sqs:ReceiveMessage",
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "effect",
+                        "principal",
+                        "action"
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "queues": [
+                        {
+                            "name": "myQueue",
+                            "fifoQueue": true,
+                            "deduplicationScope": "messageGroup",
+                            "fifoThroughputLimit": "perMessageGroupId",
+                            "deliveryDelay": 10,
+                            "redrivePolicy": {
+                                "deadLetterQueue": {
+                                    "name": "myQueue_error"
+                                },
+                                "maxReceiveCount": 15
+                            },
+                            "policy": {
+                                "statements": [
+                                    {
+                                        "effect": "Deny",
+                                        "principal": "arn:aws:iam::123456789012:user/dec.kolakowski",
+                                        "action": [
+                                            "sqs:SendMessage",
+                                            "sqs:ReceiveMessage"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "myQueue_error",
+                            "deliveryDelay": 10
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/operationTrait.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/operationTrait.json",
+            "description": "Describes a trait that MAY be applied to an Operation Object. This object MAY contain any property from the Operation Object, except the action, channel and traits ones.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the operation.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json#/properties/title"
+                },
+                "description": {
+                    "description": "A verbose explanation of the operation. CommonMark syntax can be used for rich text representation.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json#/properties/description"
+                },
+                "bindings": {
+                    "description": "A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.",
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/operationBindingsObject.json"
+                        }
+                    ]
+                },
+                "externalDocs": {
+                    "description": "Additional external documentation for this operation.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json#/properties/externalDocs"
+                },
+                "security": {
+                    "description": "A declaration of which security schemes are associated with this operation. Only one of the security scheme objects MUST be satisfied to authorize an operation. In cases where Server Security also applies, it MUST also be satisfied.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json#/properties/security"
+                },
+                "summary": {
+                    "description": "A short summary of what the operation is about.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json#/properties/summary"
+                },
+                "tags": {
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json#/properties/tags"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "bindings": {
+                        "amqp": {
+                            "ack": false
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/operation.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/operation.json",
+            "description": "Describes a specific operation.",
+            "type": "object",
+            "required": [
+                "action",
+                "channel"
+            ],
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the operation.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A longer description of the operation. CommonMark is allowed.",
+                    "type": "string"
+                },
+                "action": {
+                    "description": "Allowed values are send and receive. Use send when it's expected that the application will send a message to the given channel, and receive when the application should expect receiving messages from the given channel.",
+                    "type": "string",
+                    "enum": [
+                        "send",
+                        "receive"
+                    ]
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/operationBindingsObject.json"
+                        }
+                    ]
+                },
+                "channel": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "messages": {
+                    "description": "A list of $ref pointers pointing to the supported Message Objects that can be processed by this operation. It MUST contain a subset of the messages defined in the channel referenced in this operation. Every message processed by this operation MUST be valid against one, and only one, of the message objects referenced in this list. Please note the messages property value MUST be a list of Reference Objects and, therefore, MUST NOT contain Message Objects. However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    }
+                },
+                "reply": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/operationReply.json"
+                        }
+                    ]
+                },
+                "security": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/securityRequirements.json"
+                },
+                "summary": {
+                    "description": "A brief summary of the operation.",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "A list of tags for logical grouping and categorization of operations.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/tag.json"
+                            }
+                        ]
+                    }
+                },
+                "traits": {
+                    "description": "A list of traits to apply to the operation object. Traits MUST be merged using traits merge mechanism. The resulting object MUST be a valid Operation Object.",
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/operationTrait.json"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "title": "User sign up",
+                    "summary": "Action to sign a user up.",
+                    "description": "A longer description",
+                    "channel": {
+                        "$ref": "#/channels/userSignup"
+                    },
+                    "action": "send",
+                    "security": [
+                        {
+                            "petstore_auth": [
+                                "write:pets",
+                                "read:pets"
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "signup"
+                        },
+                        {
+                            "name": "register"
+                        }
+                    ],
+                    "bindings": {
+                        "amqp": {
+                            "ack": false
+                        }
+                    },
+                    "traits": [
+                        {
+                            "$ref": "#/components/operationTraits/kafka"
+                        }
+                    ],
+                    "messages": [
+                        {
+                            "$ref": "#/components/messages/userSignedUp"
+                        }
+                    ],
+                    "reply": {
+                        "address": {
+                            "location": "$message.header#/replyTo"
+                        },
+                        "channel": {
+                            "$ref": "#/channels/userSignupReply"
+                        },
+                        "messages": [
+                            {
+                                "$ref": "#/components/messages/userSignedUpReply"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/securityRequirements.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/securityRequirements.json",
+            "description": "An array representing security requirements.",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/SecurityScheme.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.1.0/SecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/SecurityScheme.json",
+            "description": "Defines a security scheme that can be used by the operations.",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/userPassword.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/apiKey.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/X509.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/symmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/asymmetricEncryption.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/HTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/oauth2Flows.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/openIdConnect.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/SaslSecurityScheme.json"
+                }
+            ],
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/userPassword.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/userPassword.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "userPassword"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "userPassword"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/apiKey.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/apiKey.json",
+            "type": "object",
+            "required": [
+                "type",
+                "in"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme",
+                    "type": "string",
+                    "enum": [
+                        "apiKey"
+                    ]
+                },
+                "in": {
+                    "description": " The location of the API key.",
+                    "type": "string",
+                    "enum": [
+                        "user",
+                        "password"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "apiKey",
+                    "in": "user"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/X509.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/X509.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "X509"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "X509"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/symmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/symmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "symmetricEncryption"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "symmetricEncryption"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/asymmetricEncryption.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/asymmetricEncryption.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "asymmetricEncryption"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.1.0/HTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/HTTPSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/NonBearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/BearerHTTPSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/APIKeyHTTPSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/NonBearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/NonBearerHTTPSecurityScheme.json",
+            "type": "object",
+            "not": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "description": "A short description for security scheme.",
+                        "type": "string",
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "scheme",
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "scheme": {
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.1.0/BearerHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/BearerHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "scheme"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "bearerFormat": {
+                    "description": "A hint to the client to identify how the bearer token is formatted. Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.",
+                    "type": "string"
+                },
+                "scheme": {
+                    "description": "The name of the HTTP Authorization scheme to be used in the Authorization header as defined in RFC7235.",
+                    "type": "string",
+                    "enum": [
+                        "bearer"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.1.0/APIKeyHTTPSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/APIKeyHTTPSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type",
+                "name",
+                "in"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "httpApiKey"
+                    ]
+                },
+                "in": {
+                    "description": "The location of the API key",
+                    "type": "string",
+                    "enum": [
+                        "header",
+                        "query",
+                        "cookie"
+                    ]
+                },
+                "name": {
+                    "description": "The name of the header, query or cookie parameter to be used.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "httpApiKey",
+                    "name": "api_key",
+                    "in": "header"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/oauth2Flows.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/oauth2Flows.json",
+            "description": "Allows configuration of the supported OAuth Flows.",
+            "type": "object",
+            "required": [
+                "type",
+                "flows"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "oauth2"
+                    ]
+                },
+                "flows": {
+                    "type": "object",
+                    "properties": {
+                        "authorizationCode": {
+                            "description": "Configuration for the OAuth Authorization Code flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                }
+                            ]
+                        },
+                        "clientCredentials": {
+                            "description": "Configuration for the OAuth Client Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "implicit": {
+                            "description": "Configuration for the OAuth Implicit flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "authorizationUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "tokenUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "password": {
+                            "description": "Configuration for the OAuth Resource Owner Protected Credentials flow.",
+                            "allOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/oauth2Flow.json"
+                                },
+                                {
+                                    "required": [
+                                        "tokenUrl",
+                                        "availableScopes"
+                                    ]
+                                },
+                                {
+                                    "not": {
+                                        "required": [
+                                            "authorizationUrl"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "scopes": {
+                    "description": "List of the needed scope names.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/definitions/3.1.0/oauth2Flow.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/oauth2Flow.json",
+            "description": "Configuration details for a supported OAuth Flow",
+            "type": "object",
+            "properties": {
+                "authorizationUrl": {
+                    "description": "The authorization URL to be used for this flow. This MUST be in the form of an absolute URL.",
+                    "type": "string",
+                    "format": "uri"
+                },
+                "availableScopes": {
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.",
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/oauth2Scopes.json"
+                },
+                "refreshUrl": {
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of an absolute URL.",
+                    "type": "string",
+                    "format": "uri"
+                },
+                "tokenUrl": {
+                    "description": "The token URL to be used for this flow. This MUST be in the form of an absolute URL.",
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "authorizationUrl": "https://example.com/api/oauth/dialog",
+                    "tokenUrl": "https://example.com/api/oauth/token",
+                    "availableScopes": {
+                        "write:pets": "modify pets in your account",
+                        "read:pets": "read your pets"
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/oauth2Scopes.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/oauth2Scopes.json",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "http://asyncapi.com/definitions/3.1.0/openIdConnect.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/openIdConnect.json",
+            "type": "object",
+            "required": [
+                "type",
+                "openIdConnectUrl"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme. CommonMark syntax MAY be used for rich text representation.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "openIdConnect"
+                    ]
+                },
+                "openIdConnectUrl": {
+                    "description": "OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of an absolute URL.",
+                    "type": "string",
+                    "format": "uri"
+                },
+                "scopes": {
+                    "description": "List of the needed scope names. An empty array means no scopes are needed.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.1.0/SaslSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/SaslSecurityScheme.json",
+            "oneOf": [
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/SaslPlainSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/SaslScramSecurityScheme.json"
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/SaslGssapiSecurityScheme.json"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/SaslPlainSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/SaslPlainSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme. Valid values",
+                    "type": "string",
+                    "enum": [
+                        "plain"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/SaslScramSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/SaslScramSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "scramSha256",
+                        "scramSha512"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/SaslGssapiSecurityScheme.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/SaslGssapiSecurityScheme.json",
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "description": "A short description for security scheme.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the security scheme.",
+                    "type": "string",
+                    "enum": [
+                        "gssapi"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "type": "scramSha512"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/operationReply.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/operationReply.json",
+            "description": "Describes the reply part that MAY be applied to an Operation Object. If an operation implements the request/reply pattern, the reply object represents the response message.",
+            "type": "object",
+            "properties": {
+                "address": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/operationReplyAddress.json"
+                        }
+                    ]
+                },
+                "channel": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                },
+                "messages": {
+                    "description": "A list of $ref pointers pointing to the supported Message Objects that can be processed by this operation as reply. It MUST contain a subset of the messages defined in the channel referenced in this operation reply. Every message processed by this operation MUST be valid against one, and only one, of the message objects referenced in this list. Please note the messages property value MUST be a list of Reference Objects and, therefore, MUST NOT contain Message Objects. However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/definitions/3.1.0/operationReplyAddress.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/operationReplyAddress.json",
+            "description": "An object that specifies where an operation has to send the reply",
+            "type": "object",
+            "required": [
+                "location"
+            ],
+            "properties": {
+                "description": {
+                    "description": "An optional description of the address. CommonMark is allowed.",
+                    "type": "string"
+                },
+                "location": {
+                    "description": "A runtime expression that specifies the location of the reply address.",
+                    "type": "string",
+                    "pattern": "^\\$message\\.(header|payload)#(\\/(([^\\/~])|(~[01]))*)*"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "description": "Consumer inbox",
+                    "location": "$message.header#/replyTo"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/serverBindingsObject.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/serverBindingsObject.json",
+            "description": "Map describing protocol-specific definitions for a server.",
+            "type": "object",
+            "properties": {
+                "amqp": {},
+                "amqp1": {},
+                "anypointmq": {},
+                "googlepubsub": {},
+                "http": {},
+                "ibmmq": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "jms": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.0.1"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.0.1"
+                            ]
+                        }
+                    }
+                },
+                "kafka": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.5.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/kafka/0.3.0/server.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.5.0",
+                                "0.4.0",
+                                "0.3.0"
+                            ]
+                        }
+                    }
+                },
+                "mqtt": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "nats": {},
+                "pulsar": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    }
+                },
+                "redis": {},
+                "ros2": {
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.1.0"
+                            ]
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ros2/0.1.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.1.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/ros2/0.1.0/server.json"
+                            }
+                        }
+                    ]
+                },
+                "sns": {},
+                "solace": {
+                    "allOf": [
+                        {
+                            "description": "If no bindingVersion specified, use the latest binding",
+                            "if": {
+                                "not": {
+                                    "required": [
+                                        "bindingVersion"
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.4.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.4.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.3.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.3.0/server.json"
+                            }
+                        },
+                        {
+                            "if": {
+                                "required": [
+                                    "bindingVersion"
+                                ],
+                                "properties": {
+                                    "bindingVersion": {
+                                        "const": "0.2.0"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "$ref": "http://asyncapi.com/bindings/solace/0.2.0/server.json"
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "bindingVersion": {
+                            "enum": [
+                                "0.4.0",
+                                "0.3.0",
+                                "0.2.0"
+                            ]
+                        }
+                    }
+                },
+                "sqs": {},
+                "stomp": {},
+                "ws": {}
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/ibmmq/0.1.0/server.json",
+            "title": "IBM MQ server bindings object",
+            "description": "This object contains server connection information about the IBM MQ server, referred to as an IBM MQ queue manager. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "groupId": {
+                    "type": "string",
+                    "description": "Defines a logical group of IBM MQ server objects. This is necessary to specify multi-endpoint configurations used in high availability deployments. If omitted, the server object is not part of a group."
+                },
+                "ccdtQueueManagerName": {
+                    "type": "string",
+                    "default": "*",
+                    "description": "The name of the IBM MQ queue manager to bind to in the CCDT file."
+                },
+                "cipherSpec": {
+                    "type": "string",
+                    "description": "The recommended cipher specification used to establish a TLS connection between the client and the IBM MQ queue manager. More information on SSL/TLS cipher specifications supported by IBM MQ can be found on this page in the IBM MQ Knowledge Center."
+                },
+                "multiEndpointServer": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If 'multiEndpointServer' is 'true' then multiple connections can be workload balanced and applications should not make assumptions as to where messages are processed. Where message ordering, or affinity to specific message resources is necessary, a single endpoint ('multiEndpointServer' = 'false') may be required."
+                },
+                "heartBeatInterval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 999999,
+                    "default": 300,
+                    "description": "The recommended value (in seconds) for the heartbeat sent to the queue manager during periods of inactivity. A value of zero means that no heart beats are sent. A value of 1 means that the client will use the value defined by the queue manager. More information on heart beat interval can be found on this page in the IBM MQ Knowledge Center."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "groupId": "PRODCLSTR1",
+                    "cipherSpec": "ANY_TLS12_OR_HIGHER",
+                    "bindingVersion": "0.1.0"
+                },
+                {
+                    "groupId": "PRODCLSTR1",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/jms/0.0.1/server.json": {
+            "$id": "http://asyncapi.com/bindings/jms/0.0.1/server.json",
+            "title": "Server Schema",
+            "description": "This object contains configuration for describing a JMS broker as an AsyncAPI server. This objects only contains configuration that can not be provided in the AsyncAPI standard server object.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "required": [
+                "jmsConnectionFactory"
+            ],
+            "properties": {
+                "jmsConnectionFactory": {
+                    "type": "string",
+                    "description": "The classname of the ConnectionFactory implementation for the JMS Provider."
+                },
+                "properties": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "http://asyncapi.com/bindings/jms/0.0.1/server.json#/definitions/property"
+                    },
+                    "description": "Additional properties to set on the JMS ConnectionFactory implementation for the JMS Provider."
+                },
+                "clientID": {
+                    "type": "string",
+                    "description": "A client identifier for applications that use this JMS connection factory. If the Client ID Policy is set to 'Restricted' (the default), then configuring a Client ID on the ConnectionFactory prevents more than one JMS client from using a connection from this factory."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.0.1"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "definitions": {
+                "property": {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "value"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of a property"
+                        },
+                        "value": {
+                            "type": [
+                                "string",
+                                "boolean",
+                                "number",
+                                "null"
+                            ],
+                            "description": "The name of a property"
+                        }
+                    }
+                }
+            },
+            "examples": [
+                {
+                    "jmsConnectionFactory": "org.apache.activemq.ActiveMQConnectionFactory",
+                    "properties": [
+                        {
+                            "name": "disableTimeStampsByDefault",
+                            "value": false
+                        }
+                    ],
+                    "clientID": "my-application-1",
+                    "bindingVersion": "0.0.1"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.5.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.5.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.5.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.5.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.4.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.4.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/kafka/0.3.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/kafka/0.3.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "schemaRegistryUrl": {
+                    "type": "string",
+                    "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+                },
+                "schemaRegistryVendor": {
+                    "type": "string",
+                    "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "schemaRegistryUrl": "https://my-schema-registry.com",
+                    "schemaRegistryVendor": "confluent",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/mqtt/0.2.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/mqtt/0.2.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains information about the server representation in MQTT.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "clientId": {
+                    "type": "string",
+                    "description": "The client identifier."
+                },
+                "cleanSession": {
+                    "type": "boolean",
+                    "description": "Whether to create a persistent connection or not. When 'false', the connection will be persistent. This is called clean start in MQTTv5."
+                },
+                "lastWill": {
+                    "type": "object",
+                    "description": "Last Will and Testament configuration.",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "The topic where the Last Will and Testament message will be sent."
+                        },
+                        "qos": {
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2
+                            ],
+                            "description": "Defines how hard the broker/client will try to ensure that the Last Will and Testament message is received. Its value MUST be either 0, 1 or 2."
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Last Will message."
+                        },
+                        "retain": {
+                            "type": "boolean",
+                            "description": "Whether the broker should retain the Last Will and Testament message or not."
+                        }
+                    }
+                },
+                "keepAlive": {
+                    "type": "integer",
+                    "description": "Interval in seconds of the longest period of time the broker and the client can endure without sending a message."
+                },
+                "sessionExpiryInterval": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Interval time in seconds or a Schema Object containing the definition of the interval.  The broker maintains a session for a disconnected client until this interval expires."
+                },
+                "maximumPacketSize": {
+                    "oneOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4294967295
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+                        }
+                    ],
+                    "description": "Number of bytes or a Schema Object representing the Maximum Packet Size the Client is willing to accept."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "clientId": "guest",
+                    "cleanSession": true,
+                    "lastWill": {
+                        "topic": "/last-wills",
+                        "qos": 2,
+                        "message": "Guest gone offline.",
+                        "retain": false
+                    },
+                    "keepAlive": 60,
+                    "sessionExpiryInterval": 120,
+                    "maximumPacketSize": 1024,
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/pulsar/0.1.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/pulsar/0.1.0/server.json",
+            "title": "Server Schema",
+            "description": "This object contains server information of Pulsar broker, which covers cluster and tenant admin configuration. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "tenant": {
+                    "type": "string",
+                    "description": "The pulsar tenant. If omitted, 'public' MUST be assumed."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ],
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+                }
+            },
+            "examples": [
+                {
+                    "tenant": "contoso",
+                    "bindingVersion": "0.1.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/ros2/0.1.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/ros2/0.1.0/server.json",
+            "description": "This object contains information about the server representation in ROS 2.",
+            "examples": [
+                {
+                    "domainId": "0",
+                    "rmwImplementation": "rmw_fastrtps_cpp"
+                }
+            ],
+            "type": "object",
+            "properties": {
+                "bindingVersion": {
+                    "description": "The version of this binding. If omitted, 'latest' MUST be assumed.",
+                    "type": "string",
+                    "enum": [
+                        "0.1.0"
+                    ]
+                },
+                "domainId": {
+                    "description": "All ROS 2 nodes use domain ID 0 by default. To prevent interference between different groups of computers running ROS 2 on the same network, a group can be set with a unique domain ID.",
+                    "type": "integer",
+                    "maximum": 231,
+                    "minimum": 0
+                },
+                "rmwImplementation": {
+                    "description": "Specifies the ROS 2 middleware implementation to be used. This determines the underlying middleware implementation that handles communication.",
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            }
+        },
+        "http://asyncapi.com/bindings/solace/0.4.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.4.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msgVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "clientName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160,
+                    "description": "A unique client name to use to register to the appliance. If specified, it must be a valid Topic name, and a maximum of 160 bytes in length when encoded as UTF-8."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.4.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.4.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.3.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.3.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msgVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.3.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.3.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/bindings/solace/0.2.0/server.json": {
+            "$id": "http://asyncapi.com/bindings/solace/0.2.0/server.json",
+            "title": "Solace server bindings object",
+            "description": "This object contains server connection information about the Solace broker. This object contains additional connectivity information not possible to represent within the core AsyncAPI specification.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+                }
+            },
+            "properties": {
+                "msvVpn": {
+                    "type": "string",
+                    "description": "The name of the Virtual Private Network to connect to on the Solace broker."
+                },
+                "bindingVersion": {
+                    "type": "string",
+                    "enum": [
+                        "0.2.0"
+                    ],
+                    "description": "The version of this binding."
+                }
+            },
+            "examples": [
+                {
+                    "msgVpn": "ProdVPN",
+                    "bindingVersion": "0.2.0"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/serverVariable.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/serverVariable.json",
+            "description": "An object representing a Server Variable for server URL template substitution.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description for the server variable. CommonMark syntax MAY be used for rich text representation.",
+                    "type": "string"
+                },
+                "examples": {
+                    "description": "An array of examples of the server variable.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "description": "The default value to use for substitution, and to send, if an alternate value is not supplied.",
+                    "type": "string"
+                },
+                "enum": {
+                    "description": "An enumeration of string values to be used if the substitution options are from a limited set.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "host": "rabbitmq.in.mycompany.com:5672",
+                    "pathname": "/{env}",
+                    "protocol": "amqp",
+                    "description": "RabbitMQ broker. Use the `env` variable to point to either `production` or `staging`.",
+                    "variables": {
+                        "env": {
+                            "description": "Environment to connect to. It can be either `production` or `staging`.",
+                            "enum": [
+                                "production",
+                                "staging"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/server.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/server.json",
+            "description": "An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data.",
+            "type": "object",
+            "required": [
+                "host",
+                "protocol"
+            ],
+            "properties": {
+                "title": {
+                    "description": "A human-friendly title for the server.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A longer description of the server. CommonMark is allowed.",
+                    "type": "string"
+                },
+                "bindings": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/serverBindingsObject.json"
+                        }
+                    ]
+                },
+                "externalDocs": {
+                    "oneOf": [
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                        },
+                        {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                        }
+                    ]
+                },
+                "host": {
+                    "description": "The server host name. It MAY include the port. This field supports Server Variables. Variable substitutions will be made when a variable is named in {braces}.",
+                    "type": "string"
+                },
+                "pathname": {
+                    "description": "The path to a resource in the host. This field supports Server Variables. Variable substitutions will be made when a variable is named in {braces}.",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "The protocol this server supports for connection.",
+                    "type": "string"
+                },
+                "protocolVersion": {
+                    "description": "An optional string describing the server. CommonMark syntax MAY be used for rich text representation.",
+                    "type": "string"
+                },
+                "security": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/securityRequirements.json"
+                },
+                "summary": {
+                    "description": "A brief summary of the server.",
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                            },
+                            {
+                                "$ref": "http://asyncapi.com/definitions/3.1.0/tag.json"
+                            }
+                        ]
+                    }
+                },
+                "variables": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/serverVariables.json"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "host": "kafka.in.mycompany.com:9092",
+                    "description": "Production Kafka broker.",
+                    "protocol": "kafka",
+                    "protocolVersion": "3.2"
+                },
+                {
+                    "host": "rabbitmq.in.mycompany.com:5672",
+                    "pathname": "/production",
+                    "protocol": "amqp",
+                    "description": "Production RabbitMQ broker (uses the `production` vhost)."
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/serverVariables.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/serverVariables.json",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/serverVariable.json"
+                    }
+                ]
+            }
+        },
+        "http://asyncapi.com/definitions/3.1.0/info.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/info.json",
+            "description": "The object provides metadata about the API. The metadata can be used by the clients if needed.",
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "version",
+                        "title"
+                    ],
+                    "properties": {
+                        "title": {
+                            "description": "A unique and precise title of the API.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "A longer description of the API. Should be different from the title. CommonMark is allowed.",
+                            "type": "string"
+                        },
+                        "contact": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/contact.json"
+                        },
+                        "externalDocs": {
+                            "oneOf": [
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                },
+                                {
+                                    "$ref": "http://asyncapi.com/definitions/3.1.0/externalDocs.json"
+                                }
+                            ]
+                        },
+                        "license": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/license.json"
+                        },
+                        "tags": {
+                            "description": "A list of tags for application API documentation control. Tags can be used for logical grouping of applications.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                                    },
+                                    {
+                                        "$ref": "http://asyncapi.com/definitions/3.1.0/tag.json"
+                                    }
+                                ]
+                            }
+                        },
+                        "termsOfService": {
+                            "description": "A URL to the Terms of Service for the API. MUST be in the format of a URL.",
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "version": {
+                            "description": "A semantic version number of the API.",
+                            "type": "string"
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-[\\w\\d\\.\\x2d_]+$": {
+                            "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/infoExtensions.json"
+                }
+            ],
+            "examples": [
+                {
+                    "title": "AsyncAPI Sample App",
+                    "version": "1.0.1",
+                    "description": "This is a sample app.",
+                    "termsOfService": "https://asyncapi.org/terms/",
+                    "contact": {
+                        "name": "API Support",
+                        "url": "https://www.asyncapi.org/support",
+                        "email": "support@asyncapi.org"
+                    },
+                    "license": {
+                        "name": "Apache 2.0",
+                        "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                    },
+                    "externalDocs": {
+                        "description": "Find more info here",
+                        "url": "https://www.asyncapi.org"
+                    },
+                    "tags": [
+                        {
+                            "name": "e-commerce"
+                        }
+                    ]
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/contact.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/contact.json",
+            "description": "Contact information for the exposed API.",
+            "type": "object",
+            "properties": {
+                "email": {
+                    "description": "The email address of the contact person/organization.",
+                    "type": "string",
+                    "format": "email"
+                },
+                "name": {
+                    "description": "The identifying name of the contact person/organization.",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "The URL pointing to the contact information.",
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "name": "API Support",
+                    "url": "https://www.example.com/support",
+                    "email": "support@example.com"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/license.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/license.json",
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "description": "The name of the license type. It's encouraged to use an OSI compatible license.",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "The URL pointing to the license.",
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^x-[\\w\\d\\.\\x2d_]+$": {
+                    "$ref": "http://asyncapi.com/definitions/3.1.0/specificationExtension.json"
+                }
+            },
+            "additionalProperties": false,
+            "examples": [
+                {
+                    "name": "Apache 2.0",
+                    "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/infoExtensions.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/infoExtensions.json",
+            "description": "The object that lists all the extensions of Info",
+            "type": "object",
+            "properties": {
+                "x-linkedin": {
+                    "$ref": "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json"
+                },
+                "x-x": {
+                    "$ref": "http://asyncapi.com/extensions/x/0.1.0/schema.json"
+                }
+            }
+        },
+        "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json": {
+            "$id": "http://asyncapi.com/extensions/linkedin/0.1.0/schema.json",
+            "type": "string",
+            "pattern": "^http(s)?://(www\\.)?linkedin\\.com.*$",
+            "description": "This extension allows you to provide the Linkedin profile URL of the account representing the team/company of the API.",
+            "example": [
+                "https://www.linkedin.com/company/asyncapi/",
+                "https://www.linkedin.com/in/sambhavgupta0705/"
+            ]
+        },
+        "http://asyncapi.com/extensions/x/0.1.0/schema.json": {
+            "$id": "http://asyncapi.com/extensions/x/0.1.0/schema.json",
+            "type": "string",
+            "description": "This extension allows you to provide the Twitter username of the account representing the team/company of the API.",
+            "example": [
+                "sambhavgupta75",
+                "AsyncAPISpec"
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/operations.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/operations.json",
+            "description": "Holds a dictionary with all the operations this application MUST implement.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/operation.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "onUserSignUp": {
+                        "title": "User sign up",
+                        "summary": "Action to sign a user up.",
+                        "description": "A longer description",
+                        "channel": {
+                            "$ref": "#/channels/userSignup"
+                        },
+                        "action": "send",
+                        "tags": [
+                            {
+                                "name": "user"
+                            },
+                            {
+                                "name": "signup"
+                            },
+                            {
+                                "name": "register"
+                            }
+                        ],
+                        "bindings": {
+                            "amqp": {
+                                "ack": false
+                            }
+                        },
+                        "traits": [
+                            {
+                                "$ref": "#/components/operationTraits/kafka"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "http://asyncapi.com/definitions/3.1.0/servers.json": {
+            "$id": "http://asyncapi.com/definitions/3.1.0/servers.json",
+            "description": "An object representing multiple servers.",
+            "type": "object",
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/Reference.json"
+                    },
+                    {
+                        "$ref": "http://asyncapi.com/definitions/3.1.0/server.json"
+                    }
+                ]
+            },
+            "examples": [
+                {
+                    "development": {
+                        "host": "localhost:5672",
+                        "description": "Development AMQP broker.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:development",
+                                "description": "This environment is meant for developers to run their own tests."
+                            }
+                        ]
+                    },
+                    "staging": {
+                        "host": "rabbitmq-staging.in.mycompany.com:5672",
+                        "description": "RabbitMQ broker for the staging environment.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:staging",
+                                "description": "This environment is a replica of the production environment."
+                            }
+                        ]
+                    },
+                    "production": {
+                        "host": "rabbitmq.in.mycompany.com:5672",
+                        "description": "RabbitMQ broker for the production environment.",
+                        "protocol": "amqp",
+                        "protocolVersion": "0-9-1",
+                        "tags": [
+                            {
+                                "name": "env:production",
+                                "description": "This environment is the live environment available for final users."
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "description": "!!Auto generated!! \n Do not manually edit. "
+}

--- a/schemas/oas/2.0/schema.json
+++ b/schemas/oas/2.0/schema.json
@@ -1,0 +1,1607 @@
+{
+  "title": "A JSON Schema for Swagger 2.0 API.",
+  "id": "http://swagger.io/v2/schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "swagger",
+    "info",
+    "paths"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {
+      "$ref": "#/definitions/vendorExtension"
+    }
+  },
+  "properties": {
+    "swagger": {
+      "type": "string",
+      "enum": [
+        "2.0"
+      ],
+      "description": "The Swagger version of this document."
+    },
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "host": {
+      "type": "string",
+      "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
+      "description": "The host (name or ip) of the API. Example: 'swagger.io'"
+    },
+    "basePath": {
+      "type": "string",
+      "pattern": "^/",
+      "description": "The base path to the API. Example: '/api'."
+    },
+    "schemes": {
+      "$ref": "#/definitions/schemesList"
+    },
+    "consumes": {
+      "description": "A list of MIME types accepted by the API.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "produces": {
+      "description": "A list of MIME types the API can produce.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/definitions/paths"
+    },
+    "definitions": {
+      "$ref": "#/definitions/definitions"
+    },
+    "parameters": {
+      "$ref": "#/definitions/parameterDefinitions"
+    },
+    "responses": {
+      "$ref": "#/definitions/responseDefinitions"
+    },
+    "security": {
+      "$ref": "#/definitions/security"
+    },
+    "securityDefinitions": {
+      "$ref": "#/definitions/securityDefinitions"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tag"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/externalDocs"
+    }
+  },
+  "definitions": {
+    "info": {
+      "type": "object",
+      "description": "General information about the API.",
+      "required": [
+        "version",
+        "title"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "A unique and precise title of the API."
+        },
+        "version": {
+          "type": "string",
+          "description": "A semantic version number of the API."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed."
+        },
+        "termsOfService": {
+          "type": "string",
+          "description": "The terms of service for the API."
+        },
+        "contact": {
+          "$ref": "#/definitions/contact"
+        },
+        "license": {
+          "$ref": "#/definitions/license"
+        }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "description": "Contact information for the owners of the API.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The identifying name of the contact person/organization."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the contact information.",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "description": "The email address of the contact person/organization.",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the license.",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        },
+        "^/": {
+          "$ref": "#/definitions/pathItem"
+        }
+      },
+      "additionalProperties": false
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/schema"
+      },
+      "description": "One or more JSON objects describing the schemas being consumed and produced by the API."
+    },
+    "parameterDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "description": "One or more JSON representations for parameters"
+    },
+    "responseDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/response"
+      },
+      "description": "One or more JSON representations for responses"
+    },
+    "externalDocs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "information about external documentation",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mimeType": {
+      "type": "string",
+      "description": "The MIME type of the HTTP message."
+    },
+    "operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "summary": {
+          "type": "string",
+          "description": "A brief summary of the operation."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the operation, GitHub Flavored Markdown is allowed."
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "operationId": {
+          "type": "string",
+          "description": "A unique identifier of the operation."
+        },
+        "produces": {
+          "description": "A list of MIME types the API can produce.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "consumes": {
+          "description": "A list of MIME types the API can consume.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        },
+        "responses": {
+          "$ref": "#/definitions/responses"
+        },
+        "schemes": {
+          "$ref": "#/definitions/schemesList"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "$ref": "#/definitions/security"
+        }
+      }
+    },
+    "pathItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/operation"
+        },
+        "put": {
+          "$ref": "#/definitions/operation"
+        },
+        "post": {
+          "$ref": "#/definitions/operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/operation"
+        },
+        "options": {
+          "$ref": "#/definitions/operation"
+        },
+        "head": {
+          "$ref": "#/definitions/operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/operation"
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "description": "Response objects names can either be any valid HTTP status code or 'default'.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^([0-9]{3})$|^(default)$": {
+          "$ref": "#/definitions/responseValue"
+        },
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "not": {
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      }
+    },
+    "responseValue": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/response"
+        },
+        {
+          "$ref": "#/definitions/jsonReference"
+        }
+      ]
+    },
+    "response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "$ref": "#/definitions/fileSchema"
+            }
+          ]
+        },
+        "headers": {
+          "$ref": "#/definitions/headers"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/header"
+      }
+    },
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "vendorExtension": {
+      "description": "Any property starting with x- is valid.",
+      "additionalProperties": true,
+      "additionalItems": true
+    },
+    "bodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "schema"
+      ],
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "body"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "schema": {
+          "$ref": "#/definitions/schema"
+        }
+      },
+      "additionalProperties": false
+    },
+    "headerParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "header"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "queryParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "formDataParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "formData"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array",
+            "file"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "pathParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "enum": [
+            true
+          ],
+          "description": "Determines whether or not this parameter is required or optional."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "path"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "nonBodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "type"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/headerParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/formDataParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/queryParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/pathParameterSubSchema"
+        }
+      ]
+    },
+    "parameter": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/bodyParameter"
+        },
+        {
+          "$ref": "#/definitions/nonBodyParameter"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "multipleOf": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+        },
+        "maximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "pattern": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+        },
+        "maxItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "uniqueItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+        },
+        "maxProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "enum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+        },
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": {}
+        },
+        "type": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            }
+          ],
+          "default": {}
+        },
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/schema"
+          },
+          "default": {}
+        },
+        "discriminator": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/xml"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "fileSchema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "primitivesItems": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/securityRequirement"
+      },
+      "uniqueItems": true
+    },
+    "securityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true
+      }
+    },
+    "xml": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "securityDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/basicAuthenticationSecurity"
+          },
+          {
+            "$ref": "#/definitions/apiKeySecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ImplicitSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2PasswordSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ApplicationSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2AccessCodeSecurity"
+          }
+        ]
+      }
+    },
+    "basicAuthenticationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "basic"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "apiKeySecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ImplicitSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "implicit"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2PasswordSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "password"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ApplicationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "application"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2AccessCodeSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "accessCode"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2Scopes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "mediaTypeList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/mimeType"
+      },
+      "uniqueItems": true
+    },
+    "parametersList": {
+      "type": "array",
+      "description": "The parameters needed to send a valid API call.",
+      "additionalItems": false,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/parameter"
+          },
+          {
+            "$ref": "#/definitions/jsonReference"
+          }
+        ]
+      },
+      "uniqueItems": true
+    },
+    "schemesList": {
+      "type": "array",
+      "description": "The transfer protocol of the API.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "http",
+          "https",
+          "ws",
+          "wss"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "collectionFormat": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes"
+      ],
+      "default": "csv"
+    },
+    "collectionFormatWithMulti": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes",
+        "multi"
+      ],
+      "default": "csv"
+    },
+    "title": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+    },
+    "description": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+    },
+    "default": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+    },
+    "multipleOf": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+    },
+    "maximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+    },
+    "exclusiveMaximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+    },
+    "minimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+    },
+    "exclusiveMinimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+    },
+    "maxLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "pattern": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+    },
+    "maxItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "uniqueItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+    },
+    "enum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+    },
+    "jsonReference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/oas/3.0/schema.json
+++ b/schemas/oas/3.0/schema.json
@@ -1,0 +1,1651 @@
+{
+  "id": "https://spec.openapis.org/oas/3.0/schema/2024-10-18",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The description of OpenAPI v3.0.x Documents",
+  "type": "object",
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.0\\.\\d(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/definitions/Info"
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/ExternalDocumentation"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Server"
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SecurityRequirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      },
+      "uniqueItems": true
+    },
+    "paths": {
+      "$ref": "#/definitions/Paths"
+    },
+    "components": {
+      "$ref": "#/definitions/Components"
+    }
+  },
+  "patternProperties": {
+    "^x-": {}
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "patternProperties": {
+        "^\\$ref$": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      }
+    },
+    "Info": {
+      "type": "object",
+      "required": [
+        "title",
+        "version"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/definitions/Contact"
+        },
+        "license": {
+          "$ref": "#/definitions/License"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "License": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Server": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ServerVariable"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ServerVariable": {
+      "type": "object",
+      "required": [
+        "default"
+      ],
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Components": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Schema"
+                },
+                {
+                  "$ref": "#/definitions/Reference"
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Response"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Parameter"
+                }
+              ]
+            }
+          }
+        },
+        "examples": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Example"
+                }
+              ]
+            }
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/RequestBody"
+                }
+              ]
+            }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Header"
+                }
+              ]
+            }
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/SecurityScheme"
+                }
+              ]
+            }
+          }
+        },
+        "links": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Link"
+                }
+              ]
+            }
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Callback"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "multipleOf": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "boolean",
+          "default": false
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "pattern": {
+          "type": "string",
+          "format": "regex"
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "uniqueItems": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxProperties": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minProperties": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "minItems": 1,
+          "uniqueItems": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "array",
+            "boolean",
+            "integer",
+            "number",
+            "object",
+            "string"
+          ]
+        },
+        "not": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "allOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": true
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "default": {},
+        "nullable": {
+          "type": "boolean",
+          "default": false
+        },
+        "discriminator": {
+          "$ref": "#/definitions/Discriminator"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "writeOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "example": {},
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/XML"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Discriminator": {
+      "type": "object",
+      "required": [
+        "propertyName"
+      ],
+      "properties": {
+        "propertyName": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "XML": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "format": "uri"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Link"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "MediaType": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Encoding"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        }
+      ]
+    },
+    "Example": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {},
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Header": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ]
+    },
+    "Paths": {
+      "type": "object",
+      "patternProperties": {
+        "^\\/": {
+          "$ref": "#/definitions/PathItem"
+        },
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "PathItem": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/Operation"
+        },
+        "put": {
+          "$ref": "#/definitions/Operation"
+        },
+        "post": {
+          "$ref": "#/definitions/Operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/Operation"
+        },
+        "options": {
+          "$ref": "#/definitions/Operation"
+        },
+        "head": {
+          "$ref": "#/definitions/Operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/Operation"
+        },
+        "trace": {
+          "$ref": "#/definitions/Operation"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "requestBody": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RequestBody"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "responses": {
+          "$ref": "#/definitions/Responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Callback"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Responses": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:\\d{2}|XX)$": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "^x-": {}
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ExternalDocumentation": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ExampleXORExamples": {
+      "description": "Example and examples are mutually exclusive",
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "SchemaXORContent": {
+      "description": "Schema and content are mutually exclusive, at least one is required",
+      "not": {
+        "required": [
+          "schema",
+          "content"
+        ]
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ],
+          "description": "Some properties are not allowed if content is present",
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "style"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "explode"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "allowReserved"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "example"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "examples"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "in"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/PathParameter"
+        },
+        {
+          "$ref": "#/definitions/QueryParameter"
+        },
+        {
+          "$ref": "#/definitions/HeaderParameter"
+        },
+        {
+          "$ref": "#/definitions/CookieParameter"
+        }
+      ]
+    },
+    "PathParameter": {
+      "description": "Parameter in path",
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "in": {
+          "enum": [
+            "path"
+          ]
+        },
+        "style": {
+          "enum": [
+            "matrix",
+            "label",
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "required": {
+          "enum": [
+            true
+          ]
+        }
+      }
+    },
+    "QueryParameter": {
+      "description": "Parameter in query",
+      "properties": {
+        "in": {
+          "enum": [
+            "query"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ],
+          "default": "form"
+        }
+      }
+    },
+    "HeaderParameter": {
+      "description": "Parameter in header",
+      "properties": {
+        "in": {
+          "enum": [
+            "header"
+          ]
+        },
+        "style": {
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        }
+      }
+    },
+    "CookieParameter": {
+      "description": "Parameter in cookie",
+      "properties": {
+        "in": {
+          "enum": [
+            "cookie"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form"
+          ],
+          "default": "form"
+        }
+      }
+    },
+    "RequestBody": {
+      "type": "object",
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "SecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/APIKeySecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/HTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OAuth2SecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+        }
+      ]
+    },
+    "APIKeySecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "HTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "description": "Bearer",
+          "properties": {
+            "scheme": {
+              "type": "string",
+              "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+            }
+          }
+        },
+        {
+          "description": "Non Bearer",
+          "not": {
+            "required": [
+              "bearerFormat"
+            ]
+          },
+          "properties": {
+            "scheme": {
+              "not": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "OAuth2SecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "flows"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flows": {
+          "$ref": "#/definitions/OAuthFlows"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "OpenIdConnectSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "openIdConnectUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "openIdConnect"
+          ]
+        },
+        "openIdConnectUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "OAuthFlows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/definitions/ImplicitOAuthFlow"
+        },
+        "password": {
+          "$ref": "#/definitions/PasswordOAuthFlow"
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/ClientCredentialsFlow"
+        },
+        "authorizationCode": {
+          "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ImplicitOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "PasswordOAuthFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ClientCredentialsFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "AuthorizationCodeOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "type": "string"
+        },
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "requestBody": {},
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/definitions/Server"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "not": {
+        "description": "Operation Id and Operation Ref are mutually exclusive",
+        "required": [
+          "operationId",
+          "operationRef"
+        ]
+      }
+    },
+    "Callback": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/PathItem"
+      },
+      "patternProperties": {
+        "^x-": {}
+      }
+    },
+    "Encoding": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/oas/3.1/dialect.json
+++ b/schemas/oas/3.1/dialect.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OpenAPI 3.1 Schema Object Dialect",
+  "description": "A JSON Schema dialect describing schemas found in OpenAPI v3.1 Descriptions",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true,
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://spec.openapis.org/oas/3.1/vocab/base": false
+  },
+  "allOf": [
+    {
+      "$ref": "https://json-schema.org/draft/2020-12/schema"
+    },
+    {
+      "$ref": "https://spec.openapis.org/oas/3.1/meta/2024-11-10"
+    }
+  ]
+}

--- a/schemas/oas/3.1/meta.json
+++ b/schemas/oas/3.1/meta.json
@@ -1,0 +1,92 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/meta/2024-11-10",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OAS Base Vocabulary",
+  "description": "A JSON Schema Vocabulary used in the OpenAPI Schema Dialect",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://spec.openapis.org/oas/3.1/vocab/base": true
+  },
+  "type": [
+    "object",
+    "boolean"
+  ],
+  "properties": {
+    "discriminator": {
+      "$ref": "#/$defs/discriminator"
+    },
+    "example": true,
+    "externalDocs": {
+      "$ref": "#/$defs/external-docs"
+    },
+    "xml": {
+      "$ref": "#/$defs/xml"
+    }
+  },
+  "$defs": {
+    "discriminator": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "propertyName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "propertyName"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "extensible": {
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "external-docs": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "format": "uri-reference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "xml": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "attribute": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "format": "uri",
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "wrapped": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/schemas/oas/3.1/schema-base.json
+++ b/schemas/oas/3.1/schema-base.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema-base/2025-11-23",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x Documents using the OpenAPI JSON Schema dialect",
+  "$ref": "https://spec.openapis.org/oas/3.1/schema/2025-11-23",
+  "properties": {
+    "jsonSchemaDialect": {
+      "$ref": "#/$defs/dialect"
+    }
+  },
+  "$defs": {
+    "dialect": {
+      "const": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10"
+    },
+    "schema": {
+      "$dynamicAnchor": "meta",
+      "$ref": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10",
+      "properties": {
+        "$schema": {
+          "$ref": "#/$defs/dialect"
+        }
+      }
+    }
+  }
+}

--- a/schemas/oas/3.1/schema.json
+++ b/schemas/oas/3.1/schema.json
@@ -1,0 +1,1412 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2025-11-23",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x Documents without Schema Object validation",
+  "type": "object",
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.1\\.\\d+(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "jsonSchemaDialect": {
+      "type": "string",
+      "format": "uri-reference",
+      "default": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      },
+      "default": [
+        {
+          "url": "/"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/$defs/paths"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/security-requirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tag"
+      }
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-documentation"
+    }
+  },
+  "required": [
+    "openapi",
+    "info"
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#info-object",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/$defs/contact"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#contact-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#license-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#server-object",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/server-variable"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#server-variable-object",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#components-object",
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/response-or-reference"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/request-body-or-reference"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/security-scheme-or-reference"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "pathItems": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/path-item"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(?:schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems)$": {
+          "$comment": "Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#paths-object",
+      "type": "object",
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/$defs/path-item"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#path-item-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
+          "$ref": "#/$defs/operation"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#operation-object",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-or-reference"
+        },
+        "responses": {
+          "$ref": "#/$defs/responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/security-requirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#external-documentation-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#parameter-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "enum": [
+            "query",
+            "header",
+            "path",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "required": [
+        "name",
+        "in"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "if": {
+        "properties": {
+          "in": {
+            "const": "query"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "allowEmptyValue": {
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "explode": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/examples"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
+            }
+          ],
+          "$defs": {
+            "styles-for-path": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "path"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "name": {
+                    "pattern": "^[^{}]+$"
+                  },
+                  "style": {
+                    "default": "simple",
+                    "enum": [
+                      "matrix",
+                      "label",
+                      "simple"
+                    ]
+                  },
+                  "required": {
+                    "const": true
+                  },
+                  "explode": {
+                    "default": false
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "styles-for-header": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "header"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "const": "simple"
+                  },
+                  "explode": {
+                    "default": false
+                  }
+                }
+              }
+            },
+            "styles-for-query": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "query"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "spaceDelimited",
+                      "pipeDelimited",
+                      "deepObject"
+                    ]
+                  },
+                  "allowReserved": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "$ref": "#/$defs/explode-for-form"
+              }
+            },
+            "styles-for-cookie": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "cookie"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "const": "form"
+                  }
+                },
+                "$ref": "#/$defs/explode-for-form"
+              }
+            }
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#request-body-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/request-body"
+      }
+    },
+    "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#fixed-fields-10",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/media-type"
+      },
+      "propertyNames": {
+        "format": "media-range"
+      }
+    },
+    "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#media-type-object",
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/examples"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#encoding-object",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "format": "media-range"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "style": {
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean"
+        }
+      },
+      "dependentSchemas": {
+        "style": {
+          "properties": {
+            "allowReserved": {
+              "default": false
+            }
+          },
+          "$ref": "#/$defs/explode-for-form"
+        },
+        "explode": {
+          "properties": {
+            "style": {
+              "default": "form"
+            },
+            "allowReserved": {
+              "default": false
+            }
+          }
+        },
+        "allowReserved": {
+          "properties": {
+            "style": {
+              "default": "form"
+            }
+          },
+          "$ref": "#/$defs/explode-for-form"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#responses-object",
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "minProperties": 1,
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "if": {
+        "$comment": "either default, or at least one response code property must exist",
+        "patternProperties": {
+          "^[1-5](?:[0-9]{2}|XX)$": false
+        }
+      },
+      "then": {
+        "required": [
+          "default"
+        ]
+      }
+    },
+    "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#response-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/response"
+      }
+    },
+    "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#callback-object",
+      "type": "object",
+      "$ref": "#/$defs/specification-extensions",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "callbacks-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/callbacks"
+      }
+    },
+    "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#example-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": true,
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "not": {
+        "required": [
+          "value",
+          "externalValue"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "example-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/example"
+      }
+    },
+    "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#link-object",
+      "type": "object",
+      "properties": {
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/map-of-strings"
+        },
+        "requestBody": true,
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/$defs/server"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "operationRef"
+          ]
+        },
+        {
+          "required": [
+            "operationId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "link-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#header-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "default": "simple",
+              "const": "simple"
+            },
+            "explode": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "$ref": "#/$defs/examples"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "header-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/header"
+      }
+    },
+    "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#tag-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#reference-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#schema-object",
+      "$dynamicAnchor": "meta",
+      "type": [
+        "object",
+        "boolean"
+      ]
+    },
+    "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#security-scheme-object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "oauth2",
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-apikey"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http-bearer"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oauth2"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oidc"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "type-apikey": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "apiKey"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "in"
+            ]
+          }
+        },
+        "type-http": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ]
+          }
+        },
+        "type-http-bearer": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ]
+          },
+          "then": {
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type-oauth2": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "flows": {
+                "$ref": "#/$defs/oauth-flows"
+              }
+            },
+            "required": [
+              "flows"
+            ]
+          }
+        },
+        "type-oidc": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openIdConnect"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            },
+            "required": [
+              "openIdConnectUrl"
+            ]
+          }
+        }
+      }
+    },
+    "security-scheme-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/security-scheme"
+      }
+    },
+    "oauth-flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/$defs/oauth-flows/$defs/implicit"
+        },
+        "password": {
+          "$ref": "#/$defs/oauth-flows/$defs/password"
+        },
+        "clientCredentials": {
+          "$ref": "#/$defs/oauth-flows/$defs/client-credentials"
+        },
+        "authorizationCode": {
+          "$ref": "#/$defs/oauth-flows/$defs/authorization-code"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "$defs": {
+        "implicit": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "client-credentials": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "authorization-code": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#security-requirement-object",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#specification-extensions",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "examples": {
+      "properties": {
+        "example": true,
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        }
+      },
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "map-of-strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "explode-for-form": {
+      "$comment": "for encoding objects, and query and cookie parameters, style=form is the default",
+      "if": {
+        "properties": {
+          "style": {
+            "const": "form"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "explode": {
+            "default": true
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "explode": {
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/oas/3.2/dialect.json
+++ b/schemas/oas/3.2/dialect.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OpenAPI 3.2 Schema Object Dialect",
+  "description": "A JSON Schema dialect describing schemas found in OpenAPI v3.2.x Descriptions",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true,
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://spec.openapis.org/oas/3.2/vocab/base": false
+  },
+  "allOf": [
+    {
+      "$ref": "https://json-schema.org/draft/2020-12/schema"
+    },
+    {
+      "$ref": "https://spec.openapis.org/oas/3.2/meta/2025-09-17"
+    }
+  ]
+}

--- a/schemas/oas/3.2/meta.json
+++ b/schemas/oas/3.2/meta.json
@@ -1,0 +1,114 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.2/meta/2025-09-17",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OAS Base Vocabulary",
+  "description": "A JSON Schema Vocabulary used in the OpenAPI JSON Schema Dialect",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://spec.openapis.org/oas/3.2/vocab/base": true
+  },
+  "type": [
+    "object",
+    "boolean"
+  ],
+  "properties": {
+    "discriminator": {
+      "$ref": "#/$defs/discriminator"
+    },
+    "example": {
+      "deprecated": true
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-docs"
+    },
+    "xml": {
+      "$ref": "#/$defs/xml"
+    }
+  },
+  "$defs": {
+    "discriminator": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "defaultMapping": {
+          "type": "string"
+        },
+        "propertyName": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "extensible": {
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "external-docs": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "format": "uri-reference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "xml": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "element",
+            "attribute",
+            "text",
+            "cdata",
+            "none"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "format": "iri",
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "deprecated": true
+        },
+        "wrapped": {
+          "type": "boolean",
+          "deprecated": true
+        }
+      },
+      "type": "object",
+      "dependentSchemas": {
+        "nodeType": {
+          "properties": {
+            "attribute": false,
+            "wrapped": false
+          }
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/schemas/oas/3.2/schema-base.json
+++ b/schemas/oas/3.2/schema-base.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.2/schema-base/2025-11-23",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.2.x Documents using the OpenAPI JSON Schema dialect",
+  "$ref": "https://spec.openapis.org/oas/3.2/schema/2025-11-23",
+  "properties": {
+    "jsonSchemaDialect": {
+      "$ref": "#/$defs/dialect"
+    }
+  },
+  "$defs": {
+    "dialect": {
+      "const": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17"
+    },
+    "schema": {
+      "$dynamicAnchor": "meta",
+      "$ref": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17",
+      "properties": {
+        "$schema": {
+          "$ref": "#/$defs/dialect"
+        }
+      }
+    }
+  }
+}

--- a/schemas/oas/3.2/schema.json
+++ b/schemas/oas/3.2/schema.json
@@ -1,0 +1,1684 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.2/schema/2025-11-23",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.2.x Documents without Schema Object validation",
+  "type": "object",
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.2\\.\\d+(-.+)?$"
+    },
+    "$self": {
+      "type": "string",
+      "format": "uri-reference",
+      "$comment": "MUST NOT contain a fragment",
+      "pattern": "^[^#]*$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "jsonSchemaDialect": {
+      "type": "string",
+      "format": "uri-reference",
+      "default": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      },
+      "default": [
+        {
+          "url": "/"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/$defs/paths"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/security-requirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tag"
+      }
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-documentation"
+    }
+  },
+  "required": [
+    "openapi",
+    "info"
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#info-object",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/$defs/contact"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#contact-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#license-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#server-object",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/server-variable"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#server-variable-object",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#components-object",
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/response-or-reference"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/request-body-or-reference"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/security-scheme-or-reference"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "pathItems": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/path-item"
+          }
+        },
+        "mediaTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/media-type-or-reference"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(?:schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems|mediaTypes)$": {
+          "$comment": "Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#paths-object",
+      "type": "object",
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/$defs/path-item"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#path-item-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        },
+        "parameters": {
+          "$ref": "#/$defs/parameters"
+        },
+        "additionalOperations": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/operation"
+          },
+          "propertyNames": {
+            "$comment": "RFC9110 restricts methods to \"1*tchar\" in ABNF",
+            "pattern": "^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$",
+            "not": {
+              "enum": [
+                "GET",
+                "PUT",
+                "POST",
+                "DELETE",
+                "OPTIONS",
+                "HEAD",
+                "PATCH",
+                "TRACE",
+                "QUERY"
+              ]
+            }
+          }
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
+          "$ref": "#/$defs/operation"
+        },
+        "query": {
+          "$ref": "#/$defs/operation"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#operation-object",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/parameters"
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-or-reference"
+        },
+        "responses": {
+          "$ref": "#/$defs/responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/security-requirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#external-documentation-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/parameter-or-reference"
+      },
+      "not": {
+        "allOf": [
+          {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "in": {
+                  "const": "query"
+                }
+              },
+              "required": [
+                "in"
+              ]
+            }
+          },
+          {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "in": {
+                  "const": "querystring"
+                }
+              },
+              "required": [
+                "in"
+              ]
+            }
+          }
+        ]
+      },
+      "contains": {
+        "type": "object",
+        "properties": {
+          "in": {
+            "const": "querystring"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#parameter-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "enum": [
+            "query",
+            "querystring",
+            "header",
+            "path",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "required": [
+        "name",
+        "in"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "allOf": [
+        {
+          "$ref": "#/$defs/examples"
+        },
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "if": {
+            "properties": {
+              "in": {
+                "const": "query"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "allowEmptyValue": {
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "in": {
+                "const": "querystring"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "content"
+            ]
+          }
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "explode": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
+            }
+          ],
+          "$defs": {
+            "styles-for-path": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "path"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "name": {
+                    "pattern": "^[^{}]+$"
+                  },
+                  "style": {
+                    "default": "simple",
+                    "enum": [
+                      "matrix",
+                      "label",
+                      "simple"
+                    ]
+                  },
+                  "required": {
+                    "const": true
+                  },
+                  "explode": {
+                    "default": false
+                  },
+                  "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "styles-for-header": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "header"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "const": "simple"
+                  },
+                  "explode": {
+                    "default": false
+                  }
+                }
+              }
+            },
+            "styles-for-query": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "query"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "spaceDelimited",
+                      "pipeDelimited",
+                      "deepObject"
+                    ]
+                  },
+                  "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "$ref": "#/$defs/explode-for-form"
+              }
+            },
+            "styles-for-cookie": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "cookie"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "cookie"
+                    ]
+                  },
+                  "explode": {
+                    "default": true
+                  }
+                },
+                "if": {
+                  "properties": {
+                    "style": {
+                      "const": "form"
+                    }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "allowReserved": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "parameter-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#request-body-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/request-body"
+      }
+    },
+    "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#fixed-fields-10",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/media-type-or-reference"
+      },
+      "propertyNames": {
+        "format": "media-range"
+      }
+    },
+    "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#media-type-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "itemSchema": {
+          "$dynamicRef": "#meta"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        },
+        "prefixEncoding": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/encoding"
+          }
+        },
+        "itemEncoding": {
+          "$ref": "#/$defs/encoding"
+        }
+      },
+      "dependentSchemas": {
+        "encoding": {
+          "properties": {
+            "prefixEncoding": false,
+            "itemEncoding": false
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/examples"
+        },
+        {
+          "$ref": "#/$defs/specification-extensions"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "media-type-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/media-type"
+      }
+    },
+    "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#encoding-object",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "format": "media-range"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "style": {
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        },
+        "prefixEncoding": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/encoding"
+          }
+        },
+        "itemEncoding": {
+          "$ref": "#/$defs/encoding"
+        }
+      },
+      "dependentSchemas": {
+        "encoding": {
+          "properties": {
+            "prefixEncoding": false,
+            "itemEncoding": false
+          }
+        },
+        "style": {
+          "properties": {
+            "allowReserved": {
+              "default": false
+            }
+          },
+          "$ref": "#/$defs/explode-for-form"
+        },
+        "explode": {
+          "properties": {
+            "style": {
+              "default": "form"
+            },
+            "allowReserved": {
+              "default": false
+            }
+          }
+        },
+        "allowReserved": {
+          "properties": {
+            "style": {
+              "default": "form"
+            }
+          },
+          "$ref": "#/$defs/explode-for-form"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#responses-object",
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "minProperties": 1,
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "if": {
+        "$comment": "either default, or at least one response code property must exist",
+        "patternProperties": {
+          "^[1-5](?:[0-9]{2}|XX)$": false
+        }
+      },
+      "then": {
+        "required": [
+          "default"
+        ]
+      }
+    },
+    "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#response-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/response"
+      }
+    },
+    "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#callback-object",
+      "type": "object",
+      "$ref": "#/$defs/specification-extensions",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "callbacks-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/callbacks"
+      }
+    },
+    "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#example-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "dataValue": true,
+        "serializedValue": {
+          "type": "string"
+        },
+        "value": true,
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": [
+              "value",
+              "externalValue"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "value",
+              "dataValue"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "value",
+              "serializedValue"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "serializedValue",
+              "externalValue"
+            ]
+          }
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "example-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/example"
+      }
+    },
+    "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#link-object",
+      "type": "object",
+      "properties": {
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/map-of-strings"
+        },
+        "requestBody": true,
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/$defs/server"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "operationRef"
+          ]
+        },
+        {
+          "required": [
+            "operationId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "link-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#header-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "default": "simple",
+              "const": "simple"
+            },
+            "explode": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/examples"
+        },
+        {
+          "$ref": "#/$defs/specification-extensions"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "header-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/header"
+      }
+    },
+    "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#tag-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#reference-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#schema-object",
+      "$dynamicAnchor": "meta",
+      "type": [
+        "object",
+        "boolean"
+      ]
+    },
+    "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#security-scheme-object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "oauth2",
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-apikey"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http-bearer"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oauth2"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oidc"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "type-apikey": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "apiKey"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "in"
+            ]
+          }
+        },
+        "type-http": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ]
+          }
+        },
+        "type-http-bearer": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ]
+          },
+          "then": {
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type-oauth2": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "flows": {
+                "$ref": "#/$defs/oauth-flows"
+              },
+              "oauth2MetadataUrl": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            },
+            "required": [
+              "flows"
+            ]
+          }
+        },
+        "type-oidc": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openIdConnect"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            },
+            "required": [
+              "openIdConnectUrl"
+            ]
+          }
+        }
+      }
+    },
+    "security-scheme-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/security-scheme"
+      }
+    },
+    "oauth-flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/$defs/oauth-flows/$defs/implicit"
+        },
+        "password": {
+          "$ref": "#/$defs/oauth-flows/$defs/password"
+        },
+        "clientCredentials": {
+          "$ref": "#/$defs/oauth-flows/$defs/client-credentials"
+        },
+        "authorizationCode": {
+          "$ref": "#/$defs/oauth-flows/$defs/authorization-code"
+        },
+        "deviceAuthorization": {
+          "$ref": "#/$defs/oauth-flows/$defs/device-authorization"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "$defs": {
+        "implicit": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "client-credentials": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "authorization-code": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "device-authorization": {
+          "type": "object",
+          "properties": {
+            "deviceAuthorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "deviceAuthorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#security-requirement-object",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.2#specification-extensions",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "examples": {
+      "properties": {
+        "example": true,
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        }
+      },
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "map-of-strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "explode-for-form": {
+      "$comment": "for encoding objects, and query and cookie parameters, style=form is the default",
+      "if": {
+        "properties": {
+          "style": {
+            "const": "form"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "explode": {
+            "default": true
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "explode": {
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/overlay/1.0/schema.json
+++ b/schemas/overlay/1.0/schema.json
@@ -1,0 +1,89 @@
+{
+  "$id": "https://spec.openapis.org/overlay/1.0/schema/2026-04-01",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of Overlay v1.0.x documents",
+  "type": "object",
+  "properties": {
+    "overlay": {
+      "type": "string",
+      "pattern": "^1\\.0\\.\\d+$"
+    },
+    "info": {
+      "$ref": "#/$defs/info-object"
+    },
+    "extends": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/action-object"
+      }
+    }
+  },
+  "required": [
+    "overlay",
+    "info",
+    "actions"
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info-object": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "action-object": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": "string",
+          "pattern": "^\\$"
+        },
+        "description": {
+          "type": "string"
+        },
+        "update": {
+          "type": [
+            "string",
+            "boolean",
+            "object",
+            "array",
+            "number",
+            "null"
+          ]
+        },
+        "remove": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "specification-extensions": {
+      "patternProperties": {
+        "^x-": true
+      }
+    }
+  }
+}

--- a/schemas/overlay/1.1/schema.json
+++ b/schemas/overlay/1.1/schema.json
@@ -1,0 +1,95 @@
+{
+  "$id": "https://spec.openapis.org/overlay/1.1/schema/2026-04-01",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of Overlay v1.1.x documents",
+  "type": "object",
+  "properties": {
+    "overlay": {
+      "type": "string",
+      "pattern": "^1\\.1\\.\\d+$"
+    },
+    "info": {
+      "$ref": "#/$defs/info-object"
+    },
+    "extends": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/action-object"
+      }
+    }
+  },
+  "required": [
+    "overlay",
+    "info",
+    "actions"
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info-object": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "action-object": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": "string",
+          "pattern": "^\\$"
+        },
+        "description": {
+          "type": "string"
+        },
+        "update": {
+          "type": [
+            "string",
+            "boolean",
+            "object",
+            "array",
+            "number",
+            "null"
+          ]
+        },
+        "copy": {
+          "type": "string"
+        },
+        "remove": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "specification-extensions": {
+      "patternProperties": {
+        "^x-": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a root `schemas/` folder holding the authoritative JSON Schema for each specification version this workspace implements, as reference material alongside the typed models and validators. Nothing in the build reads them — no crate manifest, feature, or test touches the folder.

- **OpenAPI** — 2.0, 3.0.x, 3.1.x, 3.2.x. For 3.1 and 3.2 that is four documents each: `schema.json` (base vocabulary), `schema-base.json` (requires the OAS dialect on embedded Schema Objects), plus the `dialect` and `meta` schemas they reference. Versions are pinned to the newest published *iteration* (e.g. `oas/3.2/schema/2025-11-23`); 2.0 has no schema on `spec.openapis.org`, so it comes from the archived `swagger.io/v2/schema.json` kept in the OpenAPI-Specification repo.
- **Arazzo** — 1.0 (2025-10-15) and 1.1 (2026-04-15), the same iterations already cited in the crate docs.
- **Overlay** — 1.0 and 1.1, both 2026-04-01.
- **AsyncAPI** — 2.6.0, 3.0.0, 3.1.0, as reference for the AsyncAPI source descriptions and channel steps an Arazzo v1.1 workflow can point at. Taken from `asyncapi/spec-json-schemas` at commit `61cc6ad` and verified byte-identical to what `asyncapi.com/schema-store/` serves; these are the `$id`-bearing documents rather than the `-without-$id` twins that `all.schema-store.json` refs for schemastore.org bundling.

`schemas/README.md` records the exact source URL and iteration date behind every file, plus how to refresh them: the OAI publishes dated iterations listed in `OAI/spec.openapis.org`, while AsyncAPI corrects a version's schema in place, so refreshing there means bumping the pinned commit.