### PR TITLE
roas-asyncapi: AsyncAPI v2.6 model + validation

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -129,6 +129,11 @@ component_management:
         - crates/roas-arazzo/tests/v1_1_test.rs
 
     # ---- per AsyncAPI version (within the `roas-asyncapi` crate) ----
+    - component_id: asyncapi-v2_6
+      name: asyncapi-v2.6
+      paths:
+        - crates/roas-asyncapi/src/v2_6/**
+        - crates/roas-asyncapi/tests/v2_6_test.rs
     - component_id: asyncapi-common
       name: asyncapi-common
       paths:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ subcommand reference, piping examples, and the live-reload preview server.
   upconversion.
 - **AsyncAPI** — parse and validate
   [AsyncAPI](https://www.asyncapi.com/docs/reference/specification/v3.1.0)
-  documents (v3.0 / v3.1) via [`roas-asyncapi`](crates/roas-asyncapi), the
+  documents (v2.6 / v3.0 / v3.1) via [`roas-asyncapi`](crates/roas-asyncapi), the
   event-driven counterpart to an OpenAPI description, including
   v3.0 → v3.1 upconversion.
 - **Pluggable loader** — `ResourceFetcher` / `AsyncResourceFetcher` traits
@@ -83,7 +83,7 @@ v1.1) and [Arazzo](https://spec.openapis.org/arazzo/v1.0.1.html) (v1.0 / v1.1)
 specifications are supported too — see [`roas-overlay`](crates/roas-overlay)
 and [`roas-arazzo`](crates/roas-arazzo) — as is
 [AsyncAPI](https://www.asyncapi.com/docs/reference/specification/v3.1.0)
-(v3.0 / v3.1) via [`roas-asyncapi`](crates/roas-asyncapi).
+(v2.6 / v3.0 / v3.1) via [`roas-asyncapi`](crates/roas-asyncapi).
 
 See each crate's `README.md` for usage examples, and `AGENTS.md` at the
 repository root for contributor guidelines.

--- a/crates/roas-asyncapi/Cargo.toml
+++ b/crates/roas-asyncapi/Cargo.toml
@@ -20,6 +20,9 @@ all-features = true
 
 [features]
 default = ["v3_1"]
+# Support for AsyncAPI v2.6.0 — the pre-v3 model, pinned to that exact
+# version by the schema's single-value enum.
+v2_6 = []
 # Support for AsyncAPI v3.0.0 — the schema pins `asyncapi` to that
 # exact string, so there is no patch range.
 v3_0 = []

--- a/crates/roas-asyncapi/README.md
+++ b/crates/roas-asyncapi/README.md
@@ -1,6 +1,6 @@
 # roas-asyncapi
 
-Rust implementation of the [AsyncAPI Specification](https://www.asyncapi.com/docs/reference/specification/v3.0.0): parse and validate AsyncAPI documents.
+Rust implementation of the AsyncAPI Specification ([v2.6](https://www.asyncapi.com/docs/reference/specification/v2.6.0) / [v3.0](https://www.asyncapi.com/docs/reference/specification/v3.0.0) / [v3.1](https://www.asyncapi.com/docs/reference/specification/v3.1.0)): parse and validate AsyncAPI documents.
 
 [![crates.io](https://img.shields.io/crates/v/roas-asyncapi.svg)](https://crates.io/crates/roas-asyncapi)
 [![docs.rs](https://docs.rs/roas-asyncapi/badge.svg)](https://docs.rs/roas-asyncapi)
@@ -15,9 +15,9 @@ This crate is a sibling of [`roas`](https://crates.io/crates/roas) (the typed pa
 |------------------|------------------|-----------------|-----------------------------------------------------------|
 | 3.0              | `v3_0`           | ✅ implemented  | —                                                          |
 | 3.1              | `v3_1` (default) | ✅ implemented  | Adds its own `schemaFormat` values and the `ros2` bindings |
-| 2.6              | —                | 🚧 planned      | The pre-v3 model: channels keyed by path, `publish` / `subscribe` |
+| 2.6              | `v2_6`           | ✅ implemented  | The pre-v3 model: channels keyed by path, `publish` / `subscribe` |
 
-`v3_0` and `v3_1` are independent — enable whichever you need. With both enabled, an `impl From<v3_0::Document> for v3_1::Document` upconverts a 3.0 document; since 3.1 left the object model untouched, nothing is dropped or approximated and only the `asyncapi` version string changes.
+`v2_6`, `v3_0`, and `v3_1` are independent — enable whichever you need. With `v3_0` and `v3_1` both enabled, an `impl From<v3_0::Document> for v3_1::Document` upconverts a 3.0 document; since 3.1 left the object model untouched, nothing is dropped or approximated and only the `asyncapi` version string changes. A 2.6 → 3.0 conversion, which has genuinely lossy cases, follows separately.
 
 ## Quick start
 
@@ -69,6 +69,23 @@ YAML documents work the same way — parse with `serde_yaml_ng` (or any other YA
 One limit is worth stating: `enum` uniqueness compares numbers after the parser has rounded non-integer literals to `f64`, so two decimals differing only past `f64`'s precision (17+ significant digits) are treated as one. Preserving the exact text would need `serde_json`'s `arbitrary_precision`, which changes how every `serde_json::Value` serializes through other serializers — YAML output becomes `$serde_json::private::Number` maps — and Cargo feature unification would impose that on the sibling crates as well.
 
 `ValidationOptions` (EnumSet): `IgnoreEmptyInfoTitle`, `IgnoreEmptyInfoVersion`, `IgnoreUnusedChannelParameter`, and `ErrorOnExternalReference`. Behind the `clap` feature, the enum implements `clap::ValueEnum` so downstream CLIs can surface it directly.
+
+## What 2.6 does differently
+
+2.6 is a different document rather than an earlier draft of v3, so `v2_6` is its own model rather than a variation on `v3_0`:
+
+| | 2.6 | 3.x |
+|---|---|---|
+| Channels | required, keyed by the channel *path* | keyed by a name, with a separate `address` |
+| Operations | `publish` / `subscribe` under a channel, from the *consumer's* point of view | a top-level map, `send` / `receive` from the *application's* point of view |
+| Messages | one message, or `{ "oneOf": [...] }`, on the operation | the channel's `messages` map, referenced by the operation |
+| Payload dialect | `schemaFormat` on the message, payload alongside it | a Multi Format Schema Object wrapping both |
+| Parameters | carry a full `Schema` | strings constrained by `enum` / `default` / `examples` |
+| Security | OpenAPI-style requirement maps (name → scopes) | inline schemes; OAuth's `scopes` renamed `availableScopes` |
+| `tags` / `externalDocs` | at the document root | under `info` |
+| Servers | one `url` | `host` + `pathname` |
+
+The `publish` / `subscribe` inversion is the migration trap worth naming: 2.6's `publish` describes messages *others* publish to the channel, so the application being described receives them — which is why it maps to v3's `receive`, not `send`.
 
 ## Scope
 

--- a/crates/roas-asyncapi/src/common/reference.rs
+++ b/crates/roas-asyncapi/src/common/reference.rs
@@ -23,6 +23,78 @@ pub struct Reference {
     pub reference: String,
 }
 
+/// Decode one RFC 6901 reference token.
+///
+/// A pointer travels in a URI fragment, so it is percent-encoded (RFC
+/// 3986) *around* the pointer's own escapes (RFC 6901): the fragment is
+/// percent-decoded first, then `~1` becomes `/` and `~0` becomes `~`.
+///
+/// Returns `None` for a malformed token — a truncated or non-hex `%`
+/// escape, or a `~` not followed by `0` or `1` — which RFC 6901 leaves
+/// undefined rather than literal.
+#[must_use]
+pub(crate) fn decode_token(token: &str) -> Option<String> {
+    let bytes = token.as_bytes();
+    let mut percent_decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hex = token.get(i + 1..i + 3)?;
+            percent_decoded.push(u8::from_str_radix(hex, 16).ok()?);
+            i += 3;
+        } else {
+            percent_decoded.push(bytes[i]);
+            i += 1;
+        }
+    }
+    let decoded = String::from_utf8(percent_decoded).ok()?;
+
+    let mut out = String::with_capacity(decoded.len());
+    let mut chars = decoded.chars();
+    while let Some(c) = chars.next() {
+        if c != '~' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('0') => out.push('~'),
+            Some('1') => out.push('/'),
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+
+/// Split a document-local fragment into decoded RFC 6901 tokens.
+///
+/// The fragment is percent-decoded per token *before* tokenizing, so a
+/// `%2F` is a literal `/` inside a key rather than a separator — the
+/// separator is the raw `/` in the fragment.
+#[must_use]
+pub(crate) fn pointer_tokens(pointer: &str) -> Option<Vec<String>> {
+    if pointer.is_empty() {
+        return Some(Vec::new());
+    }
+    pointer
+        .strip_prefix('/')?
+        .split('/')
+        .map(decode_token)
+        .collect()
+}
+
+/// Parse an RFC 6901 array index: digits only, and no leading zero
+/// unless the index *is* zero.
+#[must_use]
+pub(crate) fn array_index(token: &str) -> Option<usize> {
+    if token.len() > 1 && token.starts_with('0') {
+        return None;
+    }
+    if !token.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    token.parse().ok()
+}
+
 impl Reference {
     /// The fragment part of a document-local reference.
     ///
@@ -48,25 +120,22 @@ impl Reference {
     /// containing a slash round-trips.
     #[must_use]
     pub fn local_key(&self) -> Option<String> {
-        let pointer = self.local_pointer()?;
-        let last = pointer.rsplit('/').next()?;
-        if last.is_empty() {
-            return None;
-        }
-        Some(last.replace("~1", "/").replace("~0", "~"))
+        let tokens = pointer_tokens(self.local_pointer()?)?;
+        let last = tokens.last()?;
+        (!last.is_empty()).then(|| last.clone())
     }
 
     /// Whether this is a local reference into `#/components/<kind>/…`,
     /// returning the component key when it is.
     #[must_use]
     pub fn component_key(&self, kind: &str) -> Option<String> {
-        let pointer = self.local_pointer()?;
-        let rest = pointer.strip_prefix("/components/")?.strip_prefix(kind)?;
-        let key = rest.strip_prefix('/')?;
-        if key.is_empty() || key.contains('/') {
-            return None;
+        let tokens = pointer_tokens(self.local_pointer()?)?;
+        match tokens.as_slice() {
+            [components, this_kind, key] if components == "components" && this_kind == kind => {
+                (!key.is_empty()).then(|| key.clone())
+            }
+            _ => None,
         }
-        Some(key.replace("~1", "/").replace("~0", "~"))
     }
 }
 
@@ -245,6 +314,60 @@ mod tests {
             reference: "#/channels/user".into(),
         };
         assert_eq!(not_components.component_key("channels"), None);
+    }
+
+    #[test]
+    fn tokens_are_percent_decoded_then_unescaped() {
+        assert_eq!(
+            pointer_tokens("/channels/source%2Fpath").unwrap(),
+            vec!["channels", "source/path"],
+            "`%2F` is a literal `/` inside one token",
+        );
+        assert_eq!(
+            pointer_tokens("/channels/source~1path").unwrap(),
+            vec!["channels", "source/path"],
+        );
+        assert_eq!(pointer_tokens("").unwrap(), Vec::<String>::new());
+        assert_eq!(decode_token("a%20b").unwrap(), "a b");
+        assert_eq!(decode_token("a~0b").unwrap(), "a~b");
+
+        // Malformed escapes are not literal.
+        for bad in ["a~2b", "a~", "a%2", "a%zz"] {
+            assert!(decode_token(bad).is_none(), "{bad} must not decode");
+        }
+        assert!(pointer_tokens("/channels/bad~2escape").is_none());
+        assert!(pointer_tokens("no-leading-slash").is_none());
+    }
+
+    #[test]
+    fn array_indices_follow_rfc_6901() {
+        assert_eq!(array_index("0"), Some(0));
+        assert_eq!(array_index("12"), Some(12));
+        for bad in ["01", "007", "-1", "1.0", "x", "", " 1"] {
+            assert!(array_index(bad).is_none(), "{bad} must not be an index");
+        }
+    }
+
+    #[test]
+    fn component_keys_are_decoded_too() {
+        let r = Reference {
+            reference: "#/components/securitySchemes/oauth%2Dscheme".into(),
+        };
+        assert_eq!(
+            r.component_key("securitySchemes").as_deref(),
+            Some("oauth-scheme")
+        );
+
+        // Wrong kind, extra depth, and malformed escapes all decline.
+        assert_eq!(r.component_key("messages"), None);
+        let deep = Reference {
+            reference: "#/components/messages/a/b".into(),
+        };
+        assert_eq!(deep.component_key("messages"), None);
+        let malformed = Reference {
+            reference: "#/components/messages/a~9b".into(),
+        };
+        assert_eq!(malformed.component_key("messages"), None);
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/common/reference.rs
+++ b/crates/roas-asyncapi/src/common/reference.rs
@@ -70,20 +70,29 @@ impl Reference {
     }
 }
 
+/// Report a `$ref` that leaves the document, when the caller asked for
+/// a self-contained one.
+///
+/// Shared with the version modules that carry `$ref` as a *field* of an
+/// object — an AsyncAPI 2.6 Channel Item, a Schema Object — rather than
+/// as a whole [`Reference`], so
+/// [`ErrorOnExternalReference`](crate::validation::ValidationOptions::ErrorOnExternalReference)
+/// means the same thing wherever a reference appears.
+pub(crate) fn check_external(ctx: &mut Context, reference: &str) {
+    let is_external = !reference.is_empty() && !reference.starts_with('#');
+    if is_external && ctx.is_option(crate::validation::ValidationOptions::ErrorOnExternalReference)
+    {
+        ctx.error_field(
+            "$ref",
+            format!("external reference `{reference}` cannot be resolved by this crate"),
+        );
+    }
+}
+
 impl ValidateWithContext for Reference {
     fn validate_with_context(&self, ctx: &mut Context) {
         ctx.require_non_empty("$ref", &self.reference);
-        if self.is_external()
-            && ctx.is_option(crate::validation::ValidationOptions::ErrorOnExternalReference)
-        {
-            ctx.error_field(
-                "$ref",
-                format!(
-                    "external reference `{}` cannot be resolved by this crate",
-                    self.reference
-                ),
-            );
-        }
+        check_external(ctx, &self.reference);
     }
 }
 

--- a/crates/roas-asyncapi/src/common/reference.rs
+++ b/crates/roas-asyncapi/src/common/reference.rs
@@ -84,6 +84,11 @@ pub(crate) fn pointer_tokens(pointer: &str) -> Option<Vec<String>> {
 
 /// Parse an RFC 6901 array index: digits only, and no leading zero
 /// unless the index *is* zero.
+///
+/// Only the version modules that step through arrays by pointer need
+/// this; gating it keeps a feature build that includes none of them
+/// free of dead code.
+#[cfg(any(feature = "v2_6", test))]
 #[must_use]
 pub(crate) fn array_index(token: &str) -> Option<usize> {
     if token.len() > 1 && token.starts_with('0') {

--- a/crates/roas-asyncapi/src/lib.rs
+++ b/crates/roas-asyncapi/src/lib.rs
@@ -13,6 +13,8 @@
 //! - [`validation`] — [`Validate`](validation::Validate) trait,
 //!   [`ValidationOptions`](validation::ValidationOptions) flag set,
 //!   `Context` / `ValidationError` types.
+//! - `v2_6` — AsyncAPI v2.6 document model + `Validate` impls, behind
+//!   the `v2_6` feature.
 //! - `v3_0` — AsyncAPI v3.0 document model + `Validate` impls, behind
 //!   the `v3_0` feature.
 //! - `v3_1` — AsyncAPI v3.1 document model + `Validate` impls, behind
@@ -78,16 +80,23 @@
 //!
 //! ## Versions
 //!
-//! v3.0.0 (`v3_0`) and v3.1.0 (`v3_1`, the default feature) are both
-//! implemented; enable whichever you need. Each version's schema pins
+//! v2.6.0 (`v2_6`), v3.0.0 (`v3_0`), and v3.1.0 (`v3_1`, the default
+//! feature) are all implemented; enable whichever you need. 2.6 is a
+//! different document rather than an earlier draft of the same one —
+//! channels keyed by path, `publish` / `subscribe` operations, and
+//! parameters carrying full schemas. Each version's schema pins
 //! its `asyncapi` field to exactly that string, so a document is parsed
 //! by one module or rejected. With both features enabled, an
 //! `impl From<v3_0::Document> for v3_1::Document` is available for
 //! upconverting a 3.0 document — v3.1 left the object model untouched,
-//! so nothing is dropped or approximated. Support for 2.6 follows.
+//! so nothing is dropped or approximated. A 2.6 → 3.0 conversion, which
+//! has genuinely lossy cases, follows.
 
 pub mod common;
 pub mod validation;
+
+#[cfg(feature = "v2_6")]
+pub mod v2_6;
 
 #[cfg(feature = "v3_0")]
 pub mod v3_0;

--- a/crates/roas-asyncapi/src/v2_6/channel_item.rs
+++ b/crates/roas-asyncapi/src/v2_6/channel_item.rs
@@ -15,7 +15,7 @@ use crate::v2_6::parameter::Parameter;
 use crate::v2_6::server::placeholders;
 use crate::validation::{Context, ValidateWithContext, ValidationOptions};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ChannelItem {
@@ -67,17 +67,20 @@ pub struct ChannelItem {
 }
 
 impl ChannelItem {
-    /// Check this item's `parameters` against the `{placeholders}` of
-    /// the channel path it is keyed by.
+    /// Check a channel path's `{placeholders}` against the parameters
+    /// declared anywhere along its `$ref` chain.
     ///
-    /// Only that pairing — the item's own fields are validated by
-    /// [`ValidateWithContext`], which the caller runs separately, since
-    /// a `$ref`'d channel is validated where it is declared while its
-    /// parameters answer to the path that references it.
-    pub(crate) fn validate_against_path(&self, ctx: &mut Context, path: &str) {
+    /// `$ref` siblings are preserved, so a parameter may sit beside the
+    /// reference, on the target, or on a hop in between — any of which
+    /// satisfies the path.
+    pub(crate) fn validate_path_parameters(ctx: &mut Context, path: &str, chain: &[&ChannelItem]) {
+        let declared: BTreeSet<&str> = chain
+            .iter()
+            .flat_map(|item| item.parameters.keys().map(String::as_str))
+            .collect();
         let used = placeholders(path);
         for name in &used {
-            if !self.parameters.contains_key(*name) {
+            if !declared.contains(*name) {
                 ctx.error_field(
                     "parameters",
                     format!("`{{{name}}}` in the channel path is not declared in `parameters`"),
@@ -85,8 +88,8 @@ impl ChannelItem {
             }
         }
         if !ctx.is_option(ValidationOptions::IgnoreUnusedChannelParameter) {
-            for name in self.parameters.keys() {
-                if !used.contains(&name.as_str()) {
+            for name in declared {
+                if !used.contains(&name) {
                     ctx.error_field(
                         "parameters",
                         format!("`{name}` is declared but never used in the channel path"),
@@ -109,6 +112,7 @@ impl ValidateWithContext for ChannelItem {
     fn validate_with_context(&self, ctx: &mut Context) {
         if let Some(reference) = &self.reference {
             ctx.require_non_empty("$ref", reference);
+            crate::common::reference::check_external(ctx, reference);
         }
         ctx.validate_map_keys("parameters", &self.parameters);
 
@@ -147,7 +151,7 @@ mod tests {
         let item: ChannelItem = serde_json::from_value(value).unwrap();
         let mut ctx = Context::with_path(EnumSet::empty(), "#.channels.user");
         item.validate_with_context(&mut ctx);
-        item.validate_against_path(&mut ctx, path);
+        ChannelItem::validate_path_parameters(&mut ctx, path, &[&item]);
         ctx.errors.iter().map(ToString::to_string).collect()
     }
 
@@ -198,7 +202,7 @@ mod tests {
             "#.channels.user",
         );
         item.validate_with_context(&mut ctx);
-        item.validate_against_path(&mut ctx, "user/signedup");
+        ChannelItem::validate_path_parameters(&mut ctx, "user/signedup", &[&item]);
         assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
     }
 

--- a/crates/roas-asyncapi/src/v2_6/channel_item.rs
+++ b/crates/roas-asyncapi/src/v2_6/channel_item.rs
@@ -1,0 +1,232 @@
+//! AsyncAPI v2.6 `Channel Item` object.
+//!
+//! Per [Channel Item Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#channelItemObject).
+//!
+//! A 2.6 channel *is* its path: the `channels` map is keyed by the
+//! address, which may carry `{parameter}` placeholders, and the
+//! operations hang off it as `publish` / `subscribe`. v3 split those
+//! apart — a channel key, a separate `address`, and operations hoisted
+//! to the document root.
+
+use crate::common::bindings::Bindings;
+use crate::common::reference::RefOr;
+use crate::v2_6::operation::Operation;
+use crate::v2_6::parameter::Parameter;
+use crate::v2_6::server::placeholders;
+use crate::validation::{Context, ValidateWithContext, ValidationOptions};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct ChannelItem {
+    /// An optional description of this channel item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The names of the servers on which this channel is available.
+    /// Absent or empty means every server. Unlike v3's `$ref` list,
+    /// these are plain server names.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub servers: Vec<String>,
+
+    /// A description of the operation that publishes messages *to* this
+    /// channel — which this application therefore receives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publish: Option<Operation>,
+
+    /// A description of the operation that subscribes to this channel —
+    /// whose messages this application therefore sends.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscribe: Option<Operation>,
+
+    /// Parameters for each `{placeholder}` in the channel path.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub parameters: BTreeMap<String, RefOr<Parameter>>,
+
+    /// Whether this channel is deprecated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    /// Protocol-specific definitions for the channel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bindings: Option<RefOr<Bindings>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ChannelItem {
+    /// Validate against the channel path this item is keyed by, whose
+    /// `{placeholders}` its `parameters` must match.
+    pub(crate) fn validate_against_path(&self, ctx: &mut Context, path: &str) {
+        let used = placeholders(path);
+        for name in &used {
+            if !self.parameters.contains_key(*name) {
+                ctx.error_field(
+                    "parameters",
+                    format!("`{{{name}}}` in the channel path is not declared in `parameters`"),
+                );
+            }
+        }
+        if !ctx.is_option(ValidationOptions::IgnoreUnusedChannelParameter) {
+            for name in self.parameters.keys() {
+                if !used.contains(&name.as_str()) {
+                    ctx.error_field(
+                        "parameters",
+                        format!("`{name}` is declared but never used in the channel path"),
+                    );
+                }
+            }
+        }
+        self.validate_with_context(ctx);
+    }
+}
+
+impl ValidateWithContext for ChannelItem {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.validate_map_keys("parameters", &self.parameters);
+
+        for (i, server) in self.servers.iter().enumerate() {
+            if server.is_empty() {
+                ctx.in_index("servers", i, |ctx| ctx.error("must not be empty"));
+            } else if self.servers[..i].contains(server) {
+                ctx.in_index("servers", i, |ctx| {
+                    ctx.error(format!("duplicate server `{server}`"));
+                });
+            }
+        }
+        for (kind, operation) in [("publish", &self.publish), ("subscribe", &self.subscribe)] {
+            if let Some(operation) = operation {
+                ctx.in_field(kind, |ctx| operation.validate_with_context(ctx));
+            }
+        }
+        for (name, parameter) in &self.parameters {
+            ctx.in_key("parameters", name, |ctx| {
+                parameter.validate_with_context(ctx);
+            });
+        }
+        if let Some(bindings) = &self.bindings {
+            ctx.in_field("bindings", |ctx| bindings.validate_with_context(ctx));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn errors_against(path: &str, value: serde_json::Value) -> Vec<String> {
+        let item: ChannelItem = serde_json::from_value(value).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.channels.user");
+        item.validate_against_path(&mut ctx, path);
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn round_trips_a_full_channel_item() {
+        let value = json!({
+            "description": "User events",
+            "servers": ["production"],
+            "publish": { "operationId": "receiveSignup", "message": { "name": "Signup" } },
+            "subscribe": { "operationId": "sendWelcome", "message": { "name": "Welcome" } },
+            "parameters": { "userId": { "description": "Id", "schema": { "type": "string" } } },
+            "deprecated": false,
+            "bindings": { "kafka": { "topic": "signups" } },
+            "x-owner": "team"
+        });
+        let item: ChannelItem = serde_json::from_value(value.clone()).unwrap();
+        assert!(item.publish.is_some() && item.subscribe.is_some());
+        assert_eq!(serde_json::to_value(&item).unwrap(), value);
+        assert!(errors_against("user/{userId}/signedup", value).is_empty());
+    }
+
+    #[test]
+    fn path_placeholders_and_parameters_must_agree() {
+        let errors = errors_against(
+            "user/{userId}/{tenant}",
+            json!({ "parameters": { "userId": {}, "unused": {} } }),
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("`{tenant}` in the channel path is not declared")),
+            "got: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("`unused` is declared but never used")),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn unused_parameters_can_be_ignored() {
+        let item: ChannelItem =
+            serde_json::from_value(json!({ "parameters": { "unused": {} } })).unwrap();
+        let mut ctx = Context::with_path(
+            EnumSet::only(ValidationOptions::IgnoreUnusedChannelParameter),
+            "#.channels.user",
+        );
+        item.validate_against_path(&mut ctx, "user/signedup");
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn server_names_must_be_non_empty_and_unique() {
+        let errors = errors_against("user", json!({ "servers": ["prod", "", "prod"] }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.channels.user.servers[1]: must not be empty")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.channels.user.servers[2]: duplicate server `prod`")
+        );
+    }
+
+    #[test]
+    fn invalid_parameter_keys_are_reported() {
+        let errors = errors_against("user/{bad key}", json!({ "parameters": { "bad key": {} } }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("#.channels.user.parameters.bad key")),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn nested_errors_carry_their_path() {
+        let errors = errors_against(
+            "user",
+            json!({
+                "publish": { "operationId": "" },
+                "subscribe": { "tags": [ { "name": "" } ] },
+                "bindings": { "kafka": 1 }
+            }),
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.channels.user.publish.operationId: must not be empty")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.channels.user.subscribe.tags[0].name: must not be empty")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.starts_with("#.channels.user.bindings.kafka"))
+        );
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/channel_item.rs
+++ b/crates/roas-asyncapi/src/v2_6/channel_item.rs
@@ -19,6 +19,14 @@ use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct ChannelItem {
+    /// A reference to another Channel Item.
+    ///
+    /// `$ref` is a *field* of the Channel Item here, not a replacement
+    /// for it, so it may sit alongside `description`, `servers`,
+    /// `parameters` and the rest — all of which survive a round-trip.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+
     /// An optional description of this channel item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -59,8 +67,13 @@ pub struct ChannelItem {
 }
 
 impl ChannelItem {
-    /// Validate against the channel path this item is keyed by, whose
-    /// `{placeholders}` its `parameters` must match.
+    /// Check this item's `parameters` against the `{placeholders}` of
+    /// the channel path it is keyed by.
+    ///
+    /// Only that pairing — the item's own fields are validated by
+    /// [`ValidateWithContext`], which the caller runs separately, since
+    /// a `$ref`'d channel is validated where it is declared while its
+    /// parameters answer to the path that references it.
     pub(crate) fn validate_against_path(&self, ctx: &mut Context, path: &str) {
         let used = placeholders(path);
         for name in &used {
@@ -81,12 +94,22 @@ impl ChannelItem {
                 }
             }
         }
-        self.validate_with_context(ctx);
+    }
+}
+
+impl ChannelItem {
+    /// Whether this item is (also) a reference to another one.
+    #[must_use]
+    pub fn is_reference(&self) -> bool {
+        self.reference.is_some()
     }
 }
 
 impl ValidateWithContext for ChannelItem {
     fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(reference) = &self.reference {
+            ctx.require_non_empty("$ref", reference);
+        }
         ctx.validate_map_keys("parameters", &self.parameters);
 
         for (i, server) in self.servers.iter().enumerate() {
@@ -123,6 +146,7 @@ mod tests {
     fn errors_against(path: &str, value: serde_json::Value) -> Vec<String> {
         let item: ChannelItem = serde_json::from_value(value).unwrap();
         let mut ctx = Context::with_path(EnumSet::empty(), "#.channels.user");
+        item.validate_with_context(&mut ctx);
         item.validate_against_path(&mut ctx, path);
         ctx.errors.iter().map(ToString::to_string).collect()
     }
@@ -173,6 +197,7 @@ mod tests {
             EnumSet::only(ValidationOptions::IgnoreUnusedChannelParameter),
             "#.channels.user",
         );
+        item.validate_with_context(&mut ctx);
         item.validate_against_path(&mut ctx, "user/signedup");
         assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
     }

--- a/crates/roas-asyncapi/src/v2_6/channel_item.rs
+++ b/crates/roas-asyncapi/src/v2_6/channel_item.rs
@@ -49,7 +49,7 @@ pub struct ChannelItem {
 
     /// Protocol-specific definitions for the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bindings: Option<RefOr<Bindings>>,
+    pub bindings: Option<Bindings>,
 
     /// `x-`-prefixed Specification Extensions.
     #[serde(flatten)]

--- a/crates/roas-asyncapi/src/v2_6/components.rs
+++ b/crates/roas-asyncapi/src/v2_6/components.rs
@@ -1,0 +1,150 @@
+//! AsyncAPI v2.6 `Components` object.
+//!
+//! Per [Components Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#componentsObject).
+//!
+//! 2.6 holds fourteen maps; v3 added `operations`, `replies`,
+//! `replyAddresses`, `tags`, and `externalDocs` to that set.
+
+use crate::common::bindings::Bindings;
+use crate::common::reference::RefOr;
+use crate::v2_6::channel_item::ChannelItem;
+use crate::v2_6::correlation_id::CorrelationId;
+use crate::v2_6::message::{Message, MessageTrait};
+use crate::v2_6::operation::OperationTrait;
+use crate::v2_6::parameter::Parameter;
+use crate::v2_6::schema::Schema;
+use crate::v2_6::security_scheme::SecurityScheme;
+use crate::v2_6::server::{Server, ServerVariable};
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+macro_rules! component_maps {
+    ($( $field:ident : $ty:ty => $name:literal ),+ $(,)?) => {
+        #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+        pub struct Components {
+            $(
+                #[serde(rename = $name, default, skip_serializing_if = "BTreeMap::is_empty")]
+                pub $field: BTreeMap<String, $ty>,
+            )+
+
+            /// `x-`-prefixed Specification Extensions.
+            #[serde(flatten)]
+            #[serde(with = "crate::common::extensions")]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+        }
+
+        impl ValidateWithContext for Components {
+            fn validate_with_context(&self, ctx: &mut Context) {
+                $(
+                    ctx.validate_map_keys($name, &self.$field);
+                    for (key, value) in &self.$field {
+                        ctx.in_key($name, key, |ctx| value.validate_with_context(ctx));
+                    }
+                )+
+            }
+        }
+    };
+}
+
+component_maps! {
+    schemas: RefOr<Schema> => "schemas",
+    servers: RefOr<Server> => "servers",
+    channels: RefOr<ChannelItem> => "channels",
+    server_variables: RefOr<ServerVariable> => "serverVariables",
+    messages: RefOr<Message> => "messages",
+    security_schemes: RefOr<SecurityScheme> => "securitySchemes",
+    parameters: RefOr<Parameter> => "parameters",
+    correlation_ids: RefOr<CorrelationId> => "correlationIds",
+    operation_traits: RefOr<OperationTrait> => "operationTraits",
+    message_traits: RefOr<MessageTrait> => "messageTraits",
+    server_bindings: RefOr<Bindings> => "serverBindings",
+    channel_bindings: RefOr<Bindings> => "channelBindings",
+    operation_bindings: RefOr<Bindings> => "operationBindings",
+    message_bindings: RefOr<Bindings> => "messageBindings",
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn round_trips_every_component_map() {
+        let value = json!({
+            "schemas": { "user": { "type": "object" } },
+            "servers": { "prod": { "url": "amqp://e", "protocol": "amqp" } },
+            "channels": { "user": { "description": "d" } },
+            "serverVariables": { "port": { "default": "5672" } },
+            "messages": { "signup": { "name": "Signup" } },
+            "securitySchemes": { "sasl": { "type": "scramSha256" } },
+            "parameters": { "userId": { "description": "id" } },
+            "correlationIds": { "trace": { "location": "$message.header#/id" } },
+            "operationTraits": { "common": { "summary": "s" } },
+            "messageTraits": { "common": { "contentType": "application/json" } },
+            "serverBindings": { "kafka": { "kafka": {} } },
+            "channelBindings": { "kafka": { "kafka": {} } },
+            "operationBindings": { "kafka": { "kafka": {} } },
+            "messageBindings": { "kafka": { "kafka": {} } },
+            "x-owner": "team"
+        });
+        let components: Components = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(components.schemas.len(), 1);
+        assert_eq!(components.message_bindings.len(), 1);
+        assert_eq!(serde_json::to_value(&components).unwrap(), value);
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.components");
+        components.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn v3_only_maps_are_not_component_fields_here() {
+        // `operations`, `replies`, `replyAddresses`, `tags` and
+        // `externalDocs` arrived in v3.
+        let components: Components = serde_json::from_value(json!({
+            "operations": { "o": {} },
+            "replies": { "r": {} },
+            "tags": { "t": { "name": "x" } }
+        }))
+        .unwrap();
+        assert_eq!(serde_json::to_value(&components).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn empty_components_serialize_to_an_empty_object() {
+        let components = Components::default();
+        assert_eq!(serde_json::to_value(&components).unwrap(), json!({}));
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.components");
+        components.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+    }
+
+    #[test]
+    fn invalid_keys_and_nested_errors_are_reported() {
+        let components: Components = serde_json::from_value(json!({
+            "messages": { "bad key": {} },
+            "servers": { "prod": { "url": "", "protocol": "" } },
+            "correlationIds": { "trace": { "location": "nope" } }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.components");
+        components.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        assert!(
+            msgs.iter()
+                .any(|e| e.contains("#.components.messages.bad key"))
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.components.servers.prod.url: must not be empty")
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e.starts_with("#.components.correlationIds.trace.location"))
+        );
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/components.rs
+++ b/crates/roas-asyncapi/src/v2_6/components.rs
@@ -4,6 +4,11 @@
 //!
 //! 2.6 holds fourteen maps; v3 added `operations`, `replies`,
 //! `replyAddresses`, `tags`, and `externalDocs` to that set.
+//!
+//! Only `messages`, `securitySchemes`, and `correlationIds` accept a
+//! `$ref` in place of the object — the other maps are typed directly,
+//! matching the schema field by field. `schemas` uses [`SubSchema`]
+//! because draft-07 allows a boolean where a schema is expected.
 
 use crate::common::bindings::Bindings;
 use crate::common::reference::RefOr;
@@ -12,7 +17,7 @@ use crate::v2_6::correlation_id::CorrelationId;
 use crate::v2_6::message::{Message, MessageTrait};
 use crate::v2_6::operation::OperationTrait;
 use crate::v2_6::parameter::Parameter;
-use crate::v2_6::schema::Schema;
+use crate::v2_6::schema::SubSchema;
 use crate::v2_6::security_scheme::SecurityScheme;
 use crate::v2_6::server::{Server, ServerVariable};
 use crate::validation::{Context, ValidateWithContext};
@@ -49,20 +54,20 @@ macro_rules! component_maps {
 }
 
 component_maps! {
-    schemas: RefOr<Schema> => "schemas",
-    servers: RefOr<Server> => "servers",
+    schemas: SubSchema => "schemas",
+    servers: Server => "servers",
     channels: RefOr<ChannelItem> => "channels",
-    server_variables: RefOr<ServerVariable> => "serverVariables",
+    server_variables: ServerVariable => "serverVariables",
     messages: RefOr<Message> => "messages",
     security_schemes: RefOr<SecurityScheme> => "securitySchemes",
-    parameters: RefOr<Parameter> => "parameters",
+    parameters: Parameter => "parameters",
     correlation_ids: RefOr<CorrelationId> => "correlationIds",
-    operation_traits: RefOr<OperationTrait> => "operationTraits",
-    message_traits: RefOr<MessageTrait> => "messageTraits",
-    server_bindings: RefOr<Bindings> => "serverBindings",
-    channel_bindings: RefOr<Bindings> => "channelBindings",
-    operation_bindings: RefOr<Bindings> => "operationBindings",
-    message_bindings: RefOr<Bindings> => "messageBindings",
+    operation_traits: OperationTrait => "operationTraits",
+    message_traits: MessageTrait => "messageTraits",
+    server_bindings: Bindings => "serverBindings",
+    channel_bindings: Bindings => "channelBindings",
+    operation_bindings: Bindings => "operationBindings",
+    message_bindings: Bindings => "messageBindings",
 }
 
 #[cfg(test)]
@@ -111,6 +116,38 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(serde_json::to_value(&components).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn schemas_accept_the_boolean_form() {
+        // `components.schemas: { "Never": false }` is a legal draft-07
+        // schema map.
+        let value = json!({ "schemas": { "Never": false, "Any": true } });
+        let components: Components = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(components.schemas.len(), 2);
+        assert_eq!(serde_json::to_value(&components).unwrap(), value);
+    }
+
+    #[test]
+    fn only_the_maps_the_schema_allows_take_a_reference() {
+        // `messages`, `securitySchemes` and `correlationIds` are
+        // `oneOf: [Reference, …]`; the rest are typed directly.
+        let referenced = json!({
+            "messages": { "a": { "$ref": "#/components/messages/b" } },
+            "securitySchemes": { "s": { "$ref": "#/x" } },
+            "correlationIds": { "c": { "$ref": "#/x" } }
+        });
+        let components: Components = serde_json::from_value(referenced.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&components).unwrap(), referenced);
+
+        // A `$ref` where the schema expects the object itself does not
+        // parse.
+        assert!(
+            serde_json::from_value::<Components>(json!({
+                "servers": { "s": { "$ref": "#/x" } }
+            }))
+            .is_err(),
+        );
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/v2_6/components.rs
+++ b/crates/roas-asyncapi/src/v2_6/components.rs
@@ -5,10 +5,14 @@
 //! 2.6 holds fourteen maps; v3 added `operations`, `replies`,
 //! `replyAddresses`, `tags`, and `externalDocs` to that set.
 //!
-//! Only `messages`, `securitySchemes`, and `correlationIds` accept a
-//! `$ref` in place of the object — the other maps are typed directly,
-//! matching the schema field by field. `schemas` uses [`SubSchema`]
-//! because draft-07 allows a boolean where a schema is expected.
+//! Which maps accept a `$ref` *in place of* the object is decided per
+//! map by the schema, following its delegation: `messages`,
+//! `parameters`, `servers`, `serverVariables`, `securitySchemes`, and
+//! `correlationIds` do; the trait and binding maps do not.
+//!
+//! `channels` and `schemas` are neither — there `$ref` is a *field* of
+//! the object itself, so it coexists with siblings and is modeled as
+//! one, on [`ChannelItem`] and on the Schema Object.
 
 use crate::common::bindings::Bindings;
 use crate::common::reference::RefOr;
@@ -55,12 +59,12 @@ macro_rules! component_maps {
 
 component_maps! {
     schemas: SubSchema => "schemas",
-    servers: Server => "servers",
-    channels: RefOr<ChannelItem> => "channels",
-    server_variables: ServerVariable => "serverVariables",
+    servers: RefOr<Server> => "servers",
+    channels: ChannelItem => "channels",
+    server_variables: RefOr<ServerVariable> => "serverVariables",
     messages: RefOr<Message> => "messages",
     security_schemes: RefOr<SecurityScheme> => "securitySchemes",
-    parameters: Parameter => "parameters",
+    parameters: RefOr<Parameter> => "parameters",
     correlation_ids: RefOr<CorrelationId> => "correlationIds",
     operation_traits: OperationTrait => "operationTraits",
     message_traits: MessageTrait => "messageTraits",
@@ -119,6 +123,34 @@ mod tests {
     }
 
     #[test]
+    fn a_component_channel_keeps_its_ref_siblings() {
+        // `$ref` is a Channel Item *field*, so it coexists with the
+        // rest instead of replacing them.
+        let value = json!({
+            "channels": {
+                "user": { "$ref": "#/channels/other", "description": "d", "deprecated": true }
+            }
+        });
+        let components: Components = serde_json::from_value(value.clone()).unwrap();
+        let channel = &components.channels["user"];
+        assert_eq!(channel.reference.as_deref(), Some("#/channels/other"));
+        assert_eq!(channel.description.as_deref(), Some("d"));
+        assert!(channel.is_reference());
+        assert_eq!(serde_json::to_value(&components).unwrap(), value);
+    }
+
+    #[test]
+    fn a_schema_keeps_its_ref_siblings() {
+        let value = json!({
+            "schemas": {
+                "user": { "$ref": "#/components/schemas/base", "description": "d", "x-note": 1 }
+            }
+        });
+        let components: Components = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&components).unwrap(), value);
+    }
+
+    #[test]
     fn schemas_accept_the_boolean_form() {
         // `components.schemas: { "Never": false }` is a legal draft-07
         // schema map.
@@ -140,14 +172,25 @@ mod tests {
         let components: Components = serde_json::from_value(referenced.clone()).unwrap();
         assert_eq!(serde_json::to_value(&components).unwrap(), referenced);
 
-        // A `$ref` where the schema expects the object itself does not
-        // parse.
-        assert!(
-            serde_json::from_value::<Components>(json!({
-                "servers": { "s": { "$ref": "#/x" } }
-            }))
-            .is_err(),
-        );
+        // `servers`, `serverVariables` and `parameters` delegate to
+        // definitions that also allow a Reference, so those round-trip
+        // as references rather than collapsing to `{}`.
+        let delegated = json!({
+            "servers": { "s": { "$ref": "#/x" } },
+            "serverVariables": { "v": { "$ref": "#/x" } },
+            "parameters": { "p": { "$ref": "#/x" } }
+        });
+        let components: Components = serde_json::from_value(delegated.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&components).unwrap(), delegated);
+
+        // The trait and binding maps take the object itself, so a
+        // `$ref` there is not a reference — and a trait has no required
+        // field to reject it, which is exactly why the distinction is
+        // worth pinning.
+        let components: Components =
+            serde_json::from_value(json!({ "operationTraits": { "t": { "summary": "s" } } }))
+                .unwrap();
+        assert_eq!(components.operation_traits.len(), 1);
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/v2_6/correlation_id.rs
+++ b/crates/roas-asyncapi/src/v2_6/correlation_id.rs
@@ -1,0 +1,95 @@
+//! AsyncAPI v2.6 `Correlation ID` object.
+//!
+//! Per [Correlation ID Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#correlationIdObject).
+
+use crate::common::runtime_expression;
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct CorrelationId {
+    /// **Required** A runtime expression selecting the correlation ID,
+    /// e.g. `$message.header#/correlationId`.
+    pub location: String,
+
+    /// An optional description of the identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for CorrelationId {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if self.location.is_empty() {
+            ctx.error_field("location", "must not be empty");
+        } else if let Err(err) = runtime_expression::parse(&self.location) {
+            ctx.error_field(
+                "location",
+                format!(
+                    "`{}` is not a valid runtime expression: {}",
+                    self.location,
+                    err.message()
+                ),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_header_and_payload_expressions() {
+        for location in [
+            "$message.header#/correlationId",
+            "$message.payload#/user/id",
+            // `#` alone selects the whole payload.
+            "$message.payload#",
+        ] {
+            let id: CorrelationId =
+                serde_json::from_value(json!({ "location": location })).unwrap();
+            let mut ctx = Context::with_path(EnumSet::empty(), "#.correlationId");
+            id.validate_with_context(&mut ctx);
+            assert!(ctx.errors.is_empty(), "{location}: {:?}", ctx.errors);
+        }
+    }
+
+    #[test]
+    fn round_trips_with_description() {
+        let value = json!({ "location": "$message.header#/id", "description": "The id" });
+        let id: CorrelationId = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&id).unwrap(), value);
+    }
+
+    #[test]
+    fn rejects_empty_and_malformed_locations() {
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.correlationId");
+        CorrelationId::default().validate_with_context(&mut ctx);
+        assert!(ctx.errors[0] == "#.correlationId.location: must not be empty");
+
+        // A wrong prefix, and a bare source with no `#` fragment — the
+        // schema pattern requires it.
+        for location in ["$request.header#/id", "$message.payload"] {
+            let bad: CorrelationId =
+                serde_json::from_value(json!({ "location": location })).unwrap();
+            let mut ctx = Context::with_path(EnumSet::empty(), "#.correlationId");
+            bad.validate_with_context(&mut ctx);
+            assert!(
+                ctx.errors
+                    .iter()
+                    .any(|e| e.contains("is not a valid runtime expression")),
+                "{location}: {:?}",
+                ctx.errors
+            );
+        }
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/document.rs
+++ b/crates/roas-asyncapi/src/v2_6/document.rs
@@ -129,17 +129,57 @@ fn message_pointer_shape(pointer: &str) -> bool {
     pointer.starts_with("/components/messages/") || pointer.starts_with("/channels/")
 }
 
-/// Split one RFC 6901 segment off a pointer, decoding its escapes.
+/// Split one RFC 6901 segment off a pointer and decode it.
 ///
-/// `~1` is an encoded `/`, so `source/path` is *two* segments and
-/// cannot be one channel key — `source~1path` is how that key is
-/// spelled.
-fn split_segment(pointer: &str) -> (String, &str) {
+/// A pointer travels in a URI fragment, so it is percent-encoded (RFC
+/// 3986) around escapes for the pointer's own separators (RFC 6901):
+/// `%20` is a space, `~1` is a `/`, and `~0` is a `~`. `source/path` is
+/// therefore *two* segments and cannot name one channel — that key is
+/// spelled `source~1path`.
+///
+/// Returns `None` when the segment is malformed: a `~` followed by
+/// anything but `0` or `1`, or a truncated / non-hex `%` escape. RFC
+/// 6901 leaves those undefined rather than literal.
+fn split_segment(pointer: &str) -> Option<(String, &str)> {
     let (segment, rest) = match pointer.find('/') {
         Some(i) => (&pointer[..i], &pointer[i..]),
         None => (pointer, ""),
     };
-    (segment.replace("~1", "/").replace("~0", "~"), rest)
+    Some((decode_segment(segment)?, rest))
+}
+
+/// Percent-decode, then undo the RFC 6901 escapes.
+fn decode_segment(segment: &str) -> Option<String> {
+    let bytes = segment.as_bytes();
+    let mut percent_decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hex = segment.get(i + 1..i + 3)?;
+            percent_decoded.push(u8::from_str_radix(hex, 16).ok()?);
+            i += 3;
+        } else {
+            percent_decoded.push(bytes[i]);
+            i += 1;
+        }
+    }
+    let decoded = String::from_utf8(percent_decoded).ok()?;
+
+    let mut out = String::with_capacity(decoded.len());
+    let mut chars = decoded.chars();
+    while let Some(c) = chars.next() {
+        if c != '~' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('0') => out.push('~'),
+            Some('1') => out.push('/'),
+            // `~` must be followed by `0` or `1`.
+            _ => return None,
+        }
+    }
+    Some(out)
 }
 
 impl Document {
@@ -181,21 +221,25 @@ impl Document {
         }
     }
 
-    /// The channel a document-local pointer names.
-    fn channel_at(&self, pointer: &str) -> Option<&ChannelItem> {
-        if let Some(rest) = pointer.strip_prefix("/components/channels/") {
-            let (key, rest) = split_segment(rest);
-            return rest
-                .is_empty()
-                .then(|| self.components.as_ref()?.channels.get(&key))?;
-        }
-        let rest = pointer.strip_prefix("/channels/")?;
-        let (key, rest) = split_segment(rest);
-        rest.is_empty().then(|| self.channels.get(&key))?
+    /// The channel a document-local pointer names, in either map.
+    fn channel_at<'a>(&'a self, pointer: &str) -> Option<&'a ChannelItem> {
+        let (map, rest) = self.channel_map_at(pointer)?;
+        let (key, rest) = split_segment(rest)?;
+        rest.is_empty().then(|| map.get(&key))?
     }
 
-    /// Whether a local pointer at least *looks* like it names a channel,
-    /// used to tell "names nothing" from "wrong kind entirely".
+    /// The channel map a pointer addresses, and what follows the map's
+    /// own prefix.
+    fn channel_map_at<'a, 'p>(
+        &'a self,
+        pointer: &'p str,
+    ) -> Option<(&'a BTreeMap<String, ChannelItem>, &'p str)> {
+        if let Some(rest) = pointer.strip_prefix("/components/channels/") {
+            return Some((&self.components.as_ref()?.channels, rest));
+        }
+        Some((&self.channels, pointer.strip_prefix("/channels/")?))
+    }
+
     fn security_scheme_at(&self, name: &str) -> Resolution<'_, SecurityScheme> {
         let Some(components) = self.components.as_ref() else {
             return Resolution::Missing;
@@ -237,13 +281,30 @@ impl Document {
                     if reference.is_external() {
                         return Resolution::External;
                     }
-                    let Some(key) = reference.component_key("servers") else {
+                    let Some(pointer) = reference.local_pointer() else {
                         return Resolution::Unrecognized;
                     };
-                    if !seen.insert(key.clone()) {
+                    if !seen.insert(pointer.to_owned()) {
                         return Resolution::Cycle;
                     }
-                    match self.components.as_ref().and_then(|c| c.servers.get(&key)) {
+                    // Either map may hold the target: `#/servers/…` as
+                    // well as `#/components/servers/…`.
+                    let entry = if let Some(rest) = pointer.strip_prefix("/components/servers/") {
+                        match split_segment(rest) {
+                            Some((key, "")) => {
+                                self.components.as_ref().and_then(|c| c.servers.get(&key))
+                            }
+                            _ => return Resolution::Unrecognized,
+                        }
+                    } else if let Some(rest) = pointer.strip_prefix("/servers/") {
+                        match split_segment(rest) {
+                            Some((key, "")) => self.servers.get(&key),
+                            _ => return Resolution::Unrecognized,
+                        }
+                    } else {
+                        return Resolution::Unrecognized;
+                    };
+                    match entry {
                         Some(next) => current = next,
                         None => return Resolution::Missing,
                     }
@@ -283,27 +344,32 @@ impl Document {
 
     /// The message entry a document-local pointer names — either a
     /// component message or one hanging off a channel's operation.
-    fn message_at(&self, pointer: &str) -> Option<&RefOr<Message>> {
+    ///
+    /// A JSON Pointer walks the document *as written*: the channel it
+    /// steps through is the item at that key, not whatever that item's
+    /// `$ref` resolves to, so a message declared beside a `$ref` is
+    /// reachable and one on the target is not (through this pointer).
+    fn message_at<'a>(&'a self, pointer: &str) -> Option<&'a RefOr<Message>> {
         if let Some(rest) = pointer.strip_prefix("/components/messages/") {
-            let (key, rest) = split_segment(rest);
+            let (key, rest) = split_segment(rest)?;
             if !rest.is_empty() {
                 return None;
             }
             return self.components.as_ref()?.messages.get(&key);
         }
 
-        // `#/channels/<path>/publish|subscribe/message[/oneOf/<i>]`
-        let rest = pointer.strip_prefix("/channels/")?;
-        let (key, rest) = split_segment(rest);
-        let channel = self.channels.get(&key)?;
-        let channel = self.resolve_channel(channel).found()?;
-        let (kind, rest) = split_segment(rest.strip_prefix('/')?);
+        // `#/channels/<path>/publish|subscribe/message[/oneOf/<i>]`,
+        // and the same under `#/components/channels/…`.
+        let (map, rest) = self.channel_map_at(pointer)?;
+        let (key, rest) = split_segment(rest)?;
+        let channel = map.get(&key)?;
+        let (kind, rest) = split_segment(rest.strip_prefix('/')?)?;
         let operation = match kind.as_str() {
             "publish" => channel.publish.as_ref()?,
             "subscribe" => channel.subscribe.as_ref()?,
             _ => return None,
         };
-        let (field, rest) = split_segment(rest.strip_prefix('/')?);
+        let (field, rest) = split_segment(rest.strip_prefix('/')?)?;
         if field != "message" {
             return None;
         }
@@ -311,11 +377,11 @@ impl Document {
         let mut rest = rest;
         // Walk any `oneOf/<index>` steps.
         while !rest.is_empty() {
-            let (step, tail) = split_segment(rest.strip_prefix('/')?);
+            let (step, tail) = split_segment(rest.strip_prefix('/')?)?;
             if step != "oneOf" {
                 return None;
             }
-            let (index, tail) = split_segment(tail.strip_prefix('/')?);
+            let (index, tail) = split_segment(tail.strip_prefix('/')?)?;
             let index: usize = index.parse().ok()?;
             let OperationMessage::OneOf(one_of) = message else {
                 return None;
@@ -338,7 +404,7 @@ impl Document {
     pub fn operations(&self) -> Vec<(&str, OperationKind, &Operation)> {
         let mut found = Vec::new();
         for (path, channel) in &self.channels {
-            for item in self.channel_and_target(channel) {
+            for item in self.channel_chain(channel) {
                 if let Some(operation) = &item.publish {
                     found.push((path.as_str(), OperationKind::Publish, operation));
                 }
@@ -350,16 +416,34 @@ impl Document {
         found
     }
 
-    /// A channel item together with the item it references, when that
-    /// resolves to a *different* object.
-    fn channel_and_target<'a>(&'a self, channel: &'a ChannelItem) -> Vec<&'a ChannelItem> {
-        let mut items = vec![channel];
-        if let Some(target) = self.resolve_channel(channel).found()
-            && !std::ptr::eq(target, channel)
-        {
-            items.push(target);
+    /// Every channel item along a `$ref` chain, starting with the one
+    /// given.
+    ///
+    /// `$ref` siblings are preserved here rather than discarded, so an
+    /// intermediate hop can declare servers, parameters and operations
+    /// of its own — all of which the document has to check.
+    fn channel_chain<'a>(&'a self, channel: &'a ChannelItem) -> Vec<&'a ChannelItem> {
+        let mut chain = vec![channel];
+        let mut current = channel;
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        while let Some(reference) = current.reference.as_deref() {
+            if !seen.insert(reference) {
+                break;
+            }
+            let Some(pointer) = Reference {
+                reference: reference.to_owned(),
+            }
+            .local_pointer()
+            .map(str::to_owned) else {
+                break;
+            };
+            let Some(next) = self.channel_at(&pointer) else {
+                break;
+            };
+            chain.push(next);
+            current = next;
         }
-        items
+        chain
     }
 
     /// Every message the document declares, inline or in `components`,
@@ -518,25 +602,19 @@ impl Document {
                 // placeholders must match.
                 channel.validate_with_context(ctx);
                 let resolution = self.resolve_channel(channel);
-                match &resolution {
-                    Resolution::Found(resolved) => resolved.validate_against_path(ctx, path),
-                    // An external terminus is accepted; anything else
-                    // local is a document bug.
-                    other => {
-                        if let Some(problem) = other.problem()
-                            && let Some(reference) = channel.reference.as_deref()
-                            && !reference.is_empty()
-                        {
-                            ctx.error_field("$ref", format!("channel `{reference}` {problem}"));
-                        }
-                        // The item's own parameters still answer to the
-                        // path it is keyed by.
-                        channel.validate_against_path(ctx, path);
-                    }
+                if let Some(problem) = resolution.problem()
+                    && let Some(reference) = channel.reference.as_deref()
+                    && !reference.is_empty()
+                {
+                    ctx.error_field("$ref", format!("channel `{reference}` {problem}"));
                 }
+                // The path's placeholders answer to the parameters
+                // declared anywhere along the chain, since `$ref`
+                // siblings are kept.
+                ChannelItem::validate_path_parameters(ctx, path, &self.channel_chain(channel));
                 // `$ref` siblings are preserved, so the item as written
                 // is checked as well as the channel it references.
-                for item in self.channel_and_target(channel) {
+                for item in self.channel_chain(channel) {
                     // A channel's servers are plain names into `servers`.
                     for (i, server) in item.servers.iter().enumerate() {
                         if !server.is_empty() && !self.servers.contains_key(server) {
@@ -1293,6 +1371,212 @@ mod tests {
             value["channels"]["target"]["subscribe"]["message"] = json!({ "$ref": pointer });
             assert!(!errors_for(value).is_empty(), "{pointer} must not resolve");
         }
+    }
+
+    #[test]
+    fn every_hop_of_a_ref_chain_is_validated() {
+        // A → B → C: B's own siblings must not be skipped.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "servers": { "prod": { "url": "kafka://e", "protocol": "kafka" } },
+            "channels": { "a": { "$ref": "#/components/channels/b" } },
+            "components": {
+                "channels": {
+                    "b": {
+                        "$ref": "#/components/channels/c",
+                        "servers": ["missing"],
+                        "publish": { "operationId": "onB" }
+                    },
+                    "c": { "subscribe": { "operationId": "onC" } }
+                }
+            }
+        });
+        let doc: Document = serde_json::from_value(value.clone()).unwrap();
+        let ids: Vec<_> = doc
+            .operations()
+            .iter()
+            .filter_map(|(_, _, op)| op.operation_id.as_deref())
+            .collect();
+        assert!(
+            ids.contains(&"onB"),
+            "the middle hop's operation counts: {ids:?}"
+        );
+        assert!(ids.contains(&"onC"), "so does the terminal one: {ids:?}");
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("server `missing` is not declared")),
+            "a middle hop's servers are checked too",
+        );
+    }
+
+    #[test]
+    fn parameters_may_sit_anywhere_along_the_chain() {
+        // Declared beside the `$ref`, with the target declaring none.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "user/{id}": {
+                    "$ref": "#/components/channels/target",
+                    "parameters": { "id": { "schema": { "type": "string" } } }
+                }
+            },
+            "components": { "channels": { "target": { "publish": {} } } }
+        });
+        assert!(
+            errors_for(value).is_empty(),
+            "a sibling parameter satisfies the path"
+        );
+
+        // …and on the target, with the reference declaring none.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": { "user/{id}": { "$ref": "#/components/channels/target" } },
+            "components": {
+                "channels": {
+                    "target": { "parameters": { "id": { "schema": { "type": "string" } } } }
+                }
+            }
+        });
+        assert!(errors_for(value).is_empty());
+
+        // A placeholder declared nowhere is still reported.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": { "user/{id}": { "$ref": "#/components/channels/target" } },
+            "components": { "channels": { "target": { "publish": {} } } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("`{id}` in the channel path is not declared")),
+        );
+    }
+
+    #[test]
+    fn message_pointers_walk_the_document_as_written() {
+        // A message declared *beside* a channel's `$ref` is reachable
+        // by pointer, because a JSON Pointer does not resolve as it
+        // walks.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source": {
+                    "$ref": "#/components/channels/elsewhere",
+                    "publish": { "message": { "name": "Beside" } }
+                },
+                "target": {
+                    "subscribe": { "message": { "$ref": "#/channels/source/publish/message" } }
+                }
+            },
+            "components": { "channels": { "elsewhere": { "subscribe": {} } } }
+        });
+        assert!(
+            errors_for(value).is_empty(),
+            "a sibling message is reachable"
+        );
+
+        // Pointers through a component channel work too.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "target": {
+                    "subscribe": {
+                        "message": { "$ref": "#/components/channels/source/publish/message" }
+                    }
+                }
+            },
+            "components": {
+                "channels": { "source": { "publish": { "message": { "name": "S" } } } }
+            }
+        });
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn a_server_may_reference_another_root_server() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {},
+            "servers": {
+                "base": { "url": "kafka://e", "protocol": "kafka" },
+                "alias": { "$ref": "#/servers/base" }
+            }
+        });
+        assert!(
+            errors_for(value).is_empty(),
+            "`#/servers/…` is a legal target"
+        );
+    }
+
+    #[test]
+    fn pointer_segments_are_percent_decoded_and_escape_checked() {
+        // `%20` decodes to a space…
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source path": { "publish": {} },
+                "alias": { "$ref": "#/channels/source%20path" }
+            }
+        });
+        let doc: Document = serde_json::from_value(value.clone()).unwrap();
+        assert!(
+            doc.resolve_channel(&doc.channels["alias"])
+                .found()
+                .is_some()
+        );
+        assert!(errors_for(value).is_empty());
+
+        // …while `~2` is not a valid escape, so the pointer is not a
+        // literal key.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source~2path": { "publish": {} },
+                "alias": { "$ref": "#/channels/source~2path" }
+            }
+        });
+        assert!(
+            !errors_for(value).is_empty(),
+            "an invalid tilde escape must not resolve",
+        );
+    }
+
+    #[test]
+    fn strict_mode_reports_external_refs_on_channel_items_and_schemas() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": { "user": { "$ref": "./other.yaml#/channels/user" } },
+            "components": {
+                "schemas": { "s": { "$ref": "./other.yaml#/schemas/s" } }
+            }
+        });
+        let doc: Document = serde_json::from_value(value).unwrap();
+        doc.validate(EnumSet::empty())
+            .expect("external refs pass by default");
+
+        let err = doc
+            .validate(EnumSet::only(ValidationOptions::ErrorOnExternalReference))
+            .unwrap_err();
+        let errors: Vec<_> = err.errors.iter().map(ToString::to_string).collect();
+        assert_eq!(
+            errors
+                .iter()
+                .filter(|e| e.contains("external reference"))
+                .count(),
+            2,
+            "both the channel item and the schema `$ref` count: {errors:?}",
+        );
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/v2_6/document.rs
+++ b/crates/roas-asyncapi/src/v2_6/document.rs
@@ -8,7 +8,7 @@
 //! and a security requirement must name a declared scheme — listing
 //! scopes only where the scheme's type allows them.
 
-use crate::common::reference::RefOr;
+use crate::common::reference::{RefOr, Reference};
 use crate::v2_6::channel_item::ChannelItem;
 use crate::v2_6::components::Components;
 use crate::v2_6::external_documentation::ExternalDocumentation;
@@ -49,7 +49,10 @@ pub struct Document {
 
     /// **Required** The channels this application uses, keyed by their
     /// path. Unlike v3, the key *is* the address.
-    pub channels: BTreeMap<String, RefOr<ChannelItem>>,
+    ///
+    /// A channel item carries any `$ref` as its own field, so this is
+    /// not a `RefOr` — see [`ChannelItem::reference`].
+    pub channels: BTreeMap<String, ChannelItem>,
 
     /// Reusable objects referenced throughout the document.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,38 +74,48 @@ pub struct Document {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-/// How many `$ref` hops to follow before declaring a cycle. Component
-/// channels referencing each other is legal but pointless, so the bound
-/// only needs to be past any sane document.
-const MAX_REF_DEPTH: usize = 32;
-
 impl Document {
     /// Resolve a channel entry, following document-local
     /// `#/components/channels/…` references.
     ///
     /// Returns `None` for an external reference, one that names nothing,
     /// or a cycle — none of which this crate can see through.
-    pub fn resolve_channel<'a>(
-        &'a self,
-        channel: &'a RefOr<ChannelItem>,
-    ) -> Option<&'a ChannelItem> {
+    pub fn resolve_channel<'a>(&'a self, channel: &'a ChannelItem) -> Option<&'a ChannelItem> {
         let mut current = channel;
-        // A component channel may itself be a `$ref`, so follow the
-        // chain — and stop if it ever revisits a key.
-        let mut seen: BTreeSet<String> = BTreeSet::new();
-        for _ in 0..MAX_REF_DEPTH {
-            match current {
-                RefOr::Item(item) => return Some(item),
-                RefOr::Reference(reference) => {
-                    let key = reference.component_key("channels")?;
-                    if !seen.insert(key.clone()) {
-                        return None;
-                    }
-                    current = self.components.as_ref()?.channels.get(&key)?;
-                }
+        // Follow the chain, stopping if it ever revisits a pointer —
+        // which also bounds the walk, so no separate hop limit is
+        // needed.
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        loop {
+            let Some(reference) = current.reference.as_deref() else {
+                return Some(current);
+            };
+            if !seen.insert(reference) {
+                return None;
             }
+            current = self.channel_at(reference)?;
         }
-        None
+    }
+
+    /// The channel a document-local pointer names, whether it points
+    /// into the root `channels` map or into `components.channels`.
+    ///
+    /// Root channel keys are paths, so their pointers carry RFC 6901
+    /// escapes (`~1` for `/`), which [`Reference::local_key`] decodes.
+    fn channel_at(&self, reference: &str) -> Option<&ChannelItem> {
+        let reference = Reference {
+            reference: reference.to_owned(),
+        };
+        if let Some(key) = reference.component_key("channels") {
+            return self.components.as_ref()?.channels.get(&key);
+        }
+        let pointer = reference.local_pointer()?;
+        let key = pointer.strip_prefix("/channels/")?;
+        if key.is_empty() {
+            return None;
+        }
+        let key = key.replace("~1", "/").replace("~0", "~");
+        self.channels.get(&key)
     }
 
     /// Every operation in the document, with the channel path and the
@@ -159,9 +172,57 @@ impl Document {
     }
 
     /// The security scheme declared under `components.securitySchemes`,
-    /// when it is inline and resolvable.
+    /// following a document-local `$ref` so a referenced scheme is
+    /// judged by its real type.
     fn security_scheme(&self, name: &str) -> Option<&SecurityScheme> {
-        self.components.as_ref()?.security_schemes.get(name)?.item()
+        let mut entry = self.components.as_ref()?.security_schemes.get(name)?;
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        loop {
+            match entry {
+                RefOr::Item(scheme) => return Some(scheme),
+                RefOr::Reference(reference) => {
+                    let key = reference.component_key("securitySchemes")?;
+                    if !seen.insert(key.clone()) {
+                        return None;
+                    }
+                    entry = self.components.as_ref()?.security_schemes.get(&key)?;
+                }
+            }
+        }
+    }
+
+    /// Check that a document-local message `$ref` lands on a declared
+    /// component message.
+    fn validate_message_refs(&self, ctx: &mut Context, message: &OperationMessage) {
+        match message {
+            OperationMessage::Single(single) => {
+                if let RefOr::Reference(reference) = single.as_ref() {
+                    if reference.is_external() || reference.reference.is_empty() {
+                        return;
+                    }
+                    let declared = reference
+                        .component_key("messages")
+                        .and_then(|key| Some(self.components.as_ref()?.messages.contains_key(&key)))
+                        .unwrap_or(false);
+                    if !declared {
+                        ctx.error_field(
+                            "$ref",
+                            format!(
+                                "message `{}` is not declared in `components.messages`",
+                                reference.reference
+                            ),
+                        );
+                    }
+                }
+            }
+            OperationMessage::OneOf(one_of) => {
+                for (i, alternative) in one_of.one_of.iter().enumerate() {
+                    ctx.in_index("oneOf", i, |ctx| {
+                        self.validate_message_refs(ctx, alternative);
+                    });
+                }
+            }
+        }
     }
 
     /// Whether `components.securitySchemes` names `name` at all — a
@@ -229,26 +290,29 @@ impl Document {
                 ctx.error_field("channels", "a channel path must not be empty");
             }
             ctx.in_key("channels", path, |ctx| {
-                match channel {
-                    RefOr::Reference(reference) => {
-                        reference.validate_with_context(ctx);
-                        // A local `$ref` resolves, so the target's
-                        // parameters are still checked against this
-                        // path — the placeholders belong to the key,
-                        // not to the referenced item.
-                        if let Some(item) = self.resolve_channel(channel) {
-                            item.validate_against_path(ctx, path);
-                        } else if !reference.is_external() && !reference.reference.is_empty() {
-                            ctx.error_field(
-                                "$ref",
-                                format!(
-                                    "`{}` does not resolve to a declared channel",
-                                    reference.reference
-                                ),
-                            );
+                // The item's own fields are checked either way; a
+                // `$ref` additionally has to land on a channel, and the
+                // *resolved* item's parameters are what this path's
+                // placeholders must match.
+                channel.validate_with_context(ctx);
+                match self.resolve_channel(channel) {
+                    Some(resolved) => resolved.validate_against_path(ctx, path),
+                    None => {
+                        if let Some(reference) = channel.reference.as_deref() {
+                            let reference = Reference {
+                                reference: reference.to_owned(),
+                            };
+                            if !reference.is_external() && !reference.reference.is_empty() {
+                                ctx.error_field(
+                                    "$ref",
+                                    format!(
+                                        "`{}` does not resolve to a declared channel",
+                                        reference.reference
+                                    ),
+                                );
+                            }
                         }
                     }
-                    RefOr::Item(item) => item.validate_against_path(ctx, path),
                 }
                 if let Some(item) = self.resolve_channel(channel) {
                     // A channel's servers are plain names into `servers`.
@@ -265,6 +329,11 @@ impl Document {
                         if let Some(operation) = operation {
                             ctx.in_field(kind, |ctx| {
                                 self.validate_security(ctx, "security", &operation.security);
+                                if let Some(message) = &operation.message {
+                                    ctx.in_field("message", |ctx| {
+                                        self.validate_message_refs(ctx, message);
+                                    });
+                                }
                             });
                         }
                     }
@@ -589,6 +658,97 @@ mod tests {
             }
         });
         assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn a_referenced_security_scheme_is_resolved_before_judging_scopes() {
+        let mut value = minimal();
+        value["components"] = json!({
+            "securitySchemes": {
+                "alias": { "$ref": "#/components/securitySchemes/basic" },
+                "basic": { "type": "userPassword" }
+            }
+        });
+        value["channels"] = json!({
+            "user": { "publish": { "security": [ { "alias": ["read"] } ] } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e
+                    .contains("must not list scopes: the `userPassword` scheme type takes none")),
+            "a referenced scheme must be followed to its type",
+        );
+    }
+
+    #[test]
+    fn a_message_reference_must_name_a_declared_component_message() {
+        let mut value = minimal();
+        value["channels"] = json!({
+            "user": { "publish": { "message": { "$ref": "#/components/messages/missing" } } }
+        });
+        assert!(errors_for(value).iter().any(|e| e.contains(
+            "message `#/components/messages/missing` is not declared in `components.messages`"
+        )),);
+
+        // Declared is fine; external is left alone; `oneOf` members are
+        // checked individually.
+        let mut value = minimal();
+        value["components"] = json!({ "messages": { "signup": { "name": "S" } } });
+        value["channels"] = json!({
+            "user": {
+                "publish": {
+                    "message": {
+                        "oneOf": [
+                            { "$ref": "#/components/messages/signup" },
+                            { "$ref": "./other.yaml#/signup" }
+                        ]
+                    }
+                }
+            }
+        });
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn a_root_channel_pointer_resolves_too() {
+        // `#/channels/<path>` is as legal as the components form, and
+        // the path's `/` is RFC 6901-escaped.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "user/signedup": { "publish": { "operationId": "handle" } },
+                "alias": { "$ref": "#/channels/user~1signedup" }
+            }
+        });
+        let doc: Document = serde_json::from_value(value.clone()).unwrap();
+        assert!(doc.resolve_channel(&doc.channels["alias"]).is_some());
+        // Both the target and the alias contribute their operation, so
+        // the duplicate `operationId` is reported.
+        assert_eq!(doc.operations().len(), 2);
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("duplicate operationId `handle`")),
+        );
+    }
+
+    #[test]
+    fn a_channel_item_keeps_its_ref_siblings() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "user": { "$ref": "#/components/channels/target", "description": "d" }
+            },
+            "components": { "channels": { "target": { "publish": {} } } }
+        });
+        let doc: Document = serde_json::from_value(value.clone()).unwrap();
+        let channel = &doc.channels["user"];
+        assert_eq!(channel.description.as_deref(), Some("d"));
+        assert!(channel.is_reference());
+        assert_eq!(serde_json::to_value(&doc).unwrap(), value);
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/v2_6/document.rs
+++ b/crates/roas-asyncapi/src/v2_6/document.rs
@@ -74,67 +74,292 @@ pub struct Document {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-impl Document {
-    /// Resolve a channel entry, following document-local
-    /// `#/components/channels/…` references.
+/// What following a document-local pointer turned out to be.
+///
+/// The distinctions matter: an external terminus is accepted (this
+/// crate does not fetch other documents), while a local pointer that
+/// names nothing, revisits itself, or has a shape that cannot denote
+/// the kind of object expected is a document bug.
+#[derive(Debug)]
+pub(crate) enum Resolution<'a, T> {
+    /// Resolved to a concrete object in this document.
+    Found(&'a T),
+    /// The chain ends at a reference into another document.
+    External,
+    /// A local pointer that names nothing.
+    Missing,
+    /// The chain revisits a pointer it already followed.
+    Cycle,
+    /// A local pointer whose shape cannot denote this kind of object.
+    Unrecognized,
+}
+
+impl<'a, T> Resolution<'a, T> {
+    /// The object, if the pointer resolved inside this document.
     ///
-    /// Returns `None` for an external reference, one that names nothing,
-    /// or a cycle — none of which this crate can see through.
-    pub fn resolve_channel<'a>(&'a self, channel: &'a ChannelItem) -> Option<&'a ChannelItem> {
+    /// Takes `self` so the borrow is the document's, not this
+    /// `Resolution`'s — callers routinely resolve into a temporary.
+    pub(crate) fn found(self) -> Option<&'a T> {
+        match self {
+            Resolution::Found(item) => Some(item),
+            _ => None,
+        }
+    }
+
+    /// Why this pointer is a document bug, if it is one. `None` means
+    /// it resolved or left the document.
+    fn problem(&self) -> Option<&'static str> {
+        match self {
+            Resolution::Found(_) | Resolution::External => None,
+            Resolution::Missing => Some("names nothing in this document"),
+            Resolution::Cycle => Some("is part of a reference cycle"),
+            Resolution::Unrecognized => Some("does not point at an object of the expected kind"),
+        }
+    }
+}
+
+/// Whether a local pointer has the shape of a channel pointer, used to
+/// tell "names nothing" from "wrong kind entirely".
+fn channel_pointer_shape(pointer: &str) -> bool {
+    pointer.starts_with("/channels/") || pointer.starts_with("/components/channels/")
+}
+
+/// The same, for a message pointer.
+fn message_pointer_shape(pointer: &str) -> bool {
+    pointer.starts_with("/components/messages/") || pointer.starts_with("/channels/")
+}
+
+/// Split one RFC 6901 segment off a pointer, decoding its escapes.
+///
+/// `~1` is an encoded `/`, so `source/path` is *two* segments and
+/// cannot be one channel key — `source~1path` is how that key is
+/// spelled.
+fn split_segment(pointer: &str) -> (String, &str) {
+    let (segment, rest) = match pointer.find('/') {
+        Some(i) => (&pointer[..i], &pointer[i..]),
+        None => (pointer, ""),
+    };
+    (segment.replace("~1", "/").replace("~0", "~"), rest)
+}
+
+impl Document {
+    /// Resolve a channel item, following its `$ref` field through both
+    /// `#/channels/…` and `#/components/channels/…` pointers.
+    ///
+    /// An item without a `$ref` resolves to itself.
+    pub(crate) fn resolve_channel<'a>(
+        &'a self,
+        channel: &'a ChannelItem,
+    ) -> Resolution<'a, ChannelItem> {
         let mut current = channel;
-        // Follow the chain, stopping if it ever revisits a pointer —
-        // which also bounds the walk, so no separate hop limit is
-        // needed.
         let mut seen: BTreeSet<&str> = BTreeSet::new();
         loop {
             let Some(reference) = current.reference.as_deref() else {
-                return Some(current);
+                return Resolution::Found(current);
             };
-            if !seen.insert(reference) {
-                return None;
+            let reference = Reference {
+                reference: reference.to_owned(),
+            };
+            if reference.is_external() {
+                return Resolution::External;
             }
-            current = self.channel_at(reference)?;
+            let Some(pointer) = reference.local_pointer() else {
+                return Resolution::Unrecognized;
+            };
+            if !seen.insert(current.reference.as_deref().unwrap_or_default()) {
+                return Resolution::Cycle;
+            }
+            match self.channel_at(pointer) {
+                Some(next) => current = next,
+                None => {
+                    return match channel_pointer_shape(pointer) {
+                        true => Resolution::Missing,
+                        false => Resolution::Unrecognized,
+                    };
+                }
+            }
         }
     }
 
-    /// The channel a document-local pointer names, whether it points
-    /// into the root `channels` map or into `components.channels`.
-    ///
-    /// Root channel keys are paths, so their pointers carry RFC 6901
-    /// escapes (`~1` for `/`), which [`Reference::local_key`] decodes.
-    fn channel_at(&self, reference: &str) -> Option<&ChannelItem> {
-        let reference = Reference {
-            reference: reference.to_owned(),
-        };
-        if let Some(key) = reference.component_key("channels") {
-            return self.components.as_ref()?.channels.get(&key);
+    /// The channel a document-local pointer names.
+    fn channel_at(&self, pointer: &str) -> Option<&ChannelItem> {
+        if let Some(rest) = pointer.strip_prefix("/components/channels/") {
+            let (key, rest) = split_segment(rest);
+            return rest
+                .is_empty()
+                .then(|| self.components.as_ref()?.channels.get(&key))?;
         }
-        let pointer = reference.local_pointer()?;
-        let key = pointer.strip_prefix("/channels/")?;
-        if key.is_empty() {
+        let rest = pointer.strip_prefix("/channels/")?;
+        let (key, rest) = split_segment(rest);
+        rest.is_empty().then(|| self.channels.get(&key))?
+    }
+
+    /// Whether a local pointer at least *looks* like it names a channel,
+    /// used to tell "names nothing" from "wrong kind entirely".
+    fn security_scheme_at(&self, name: &str) -> Resolution<'_, SecurityScheme> {
+        let Some(components) = self.components.as_ref() else {
+            return Resolution::Missing;
+        };
+        let Some(mut entry) = components.security_schemes.get(name) else {
+            return Resolution::Missing;
+        };
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        loop {
+            match entry {
+                RefOr::Item(scheme) => return Resolution::Found(scheme),
+                RefOr::Reference(reference) => {
+                    if reference.is_external() {
+                        return Resolution::External;
+                    }
+                    let Some(key) = reference.component_key("securitySchemes") else {
+                        return Resolution::Unrecognized;
+                    };
+                    if !seen.insert(key.clone()) {
+                        return Resolution::Cycle;
+                    }
+                    match components.security_schemes.get(&key) {
+                        Some(next) => entry = next,
+                        None => return Resolution::Missing,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Resolve a `RefOr<Server>`, following `#/components/servers/…`.
+    fn resolve_server<'a>(&'a self, entry: &'a RefOr<Server>) -> Resolution<'a, Server> {
+        let mut current = entry;
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        loop {
+            match current {
+                RefOr::Item(server) => return Resolution::Found(server),
+                RefOr::Reference(reference) => {
+                    if reference.is_external() {
+                        return Resolution::External;
+                    }
+                    let Some(key) = reference.component_key("servers") else {
+                        return Resolution::Unrecognized;
+                    };
+                    if !seen.insert(key.clone()) {
+                        return Resolution::Cycle;
+                    }
+                    match self.components.as_ref().and_then(|c| c.servers.get(&key)) {
+                        Some(next) => current = next,
+                        None => return Resolution::Missing,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Resolve a message `$ref`, following component aliases and
+    /// pointers into a channel's operations.
+    fn resolve_message(&self, reference: &Reference) -> Resolution<'_, Message> {
+        let mut current = reference.clone();
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        loop {
+            if current.is_external() {
+                return Resolution::External;
+            }
+            let Some(pointer) = current.local_pointer() else {
+                return Resolution::Unrecognized;
+            };
+            if !seen.insert(current.reference.clone()) {
+                return Resolution::Cycle;
+            }
+            match self.message_at(pointer) {
+                Some(RefOr::Item(message)) => return Resolution::Found(message),
+                Some(RefOr::Reference(next)) => current = next.clone(),
+                None => {
+                    return if message_pointer_shape(pointer) {
+                        Resolution::Missing
+                    } else {
+                        Resolution::Unrecognized
+                    };
+                }
+            }
+        }
+    }
+
+    /// The message entry a document-local pointer names — either a
+    /// component message or one hanging off a channel's operation.
+    fn message_at(&self, pointer: &str) -> Option<&RefOr<Message>> {
+        if let Some(rest) = pointer.strip_prefix("/components/messages/") {
+            let (key, rest) = split_segment(rest);
+            if !rest.is_empty() {
+                return None;
+            }
+            return self.components.as_ref()?.messages.get(&key);
+        }
+
+        // `#/channels/<path>/publish|subscribe/message[/oneOf/<i>]`
+        let rest = pointer.strip_prefix("/channels/")?;
+        let (key, rest) = split_segment(rest);
+        let channel = self.channels.get(&key)?;
+        let channel = self.resolve_channel(channel).found()?;
+        let (kind, rest) = split_segment(rest.strip_prefix('/')?);
+        let operation = match kind.as_str() {
+            "publish" => channel.publish.as_ref()?,
+            "subscribe" => channel.subscribe.as_ref()?,
+            _ => return None,
+        };
+        let (field, rest) = split_segment(rest.strip_prefix('/')?);
+        if field != "message" {
             return None;
         }
-        let key = key.replace("~1", "/").replace("~0", "~");
-        self.channels.get(&key)
+        let mut message = operation.message.as_ref()?;
+        let mut rest = rest;
+        // Walk any `oneOf/<index>` steps.
+        while !rest.is_empty() {
+            let (step, tail) = split_segment(rest.strip_prefix('/')?);
+            if step != "oneOf" {
+                return None;
+            }
+            let (index, tail) = split_segment(tail.strip_prefix('/')?);
+            let index: usize = index.parse().ok()?;
+            let OperationMessage::OneOf(one_of) = message else {
+                return None;
+            };
+            message = one_of.one_of.get(index)?;
+            rest = tail;
+        }
+        match message {
+            OperationMessage::Single(single) => Some(single.as_ref()),
+            OperationMessage::OneOf(_) => None,
+        }
     }
 
     /// Every operation in the document, with the channel path and the
-    /// half it came from. Channels that are a document-local `$ref` are
-    /// resolved first.
+    /// half it came from.
+    ///
+    /// A channel item contributes its own operations *and* those of the
+    /// channel it references, since `$ref` siblings are preserved here
+    /// rather than discarded.
     pub fn operations(&self) -> Vec<(&str, OperationKind, &Operation)> {
         let mut found = Vec::new();
         for (path, channel) in &self.channels {
-            let Some(channel) = self.resolve_channel(channel) else {
-                continue;
-            };
-            if let Some(operation) = &channel.publish {
-                found.push((path.as_str(), OperationKind::Publish, operation));
-            }
-            if let Some(operation) = &channel.subscribe {
-                found.push((path.as_str(), OperationKind::Subscribe, operation));
+            for item in self.channel_and_target(channel) {
+                if let Some(operation) = &item.publish {
+                    found.push((path.as_str(), OperationKind::Publish, operation));
+                }
+                if let Some(operation) = &item.subscribe {
+                    found.push((path.as_str(), OperationKind::Subscribe, operation));
+                }
             }
         }
         found
+    }
+
+    /// A channel item together with the item it references, when that
+    /// resolves to a *different* object.
+    fn channel_and_target<'a>(&'a self, channel: &'a ChannelItem) -> Vec<&'a ChannelItem> {
+        let mut items = vec![channel];
+        if let Some(target) = self.resolve_channel(channel).found()
+            && !std::ptr::eq(target, channel)
+        {
+            items.push(target);
+        }
+        items
     }
 
     /// Every message the document declares, inline or in `components`,
@@ -171,48 +396,18 @@ impl Document {
         found
     }
 
-    /// The security scheme declared under `components.securitySchemes`,
-    /// following a document-local `$ref` so a referenced scheme is
-    /// judged by its real type.
-    fn security_scheme(&self, name: &str) -> Option<&SecurityScheme> {
-        let mut entry = self.components.as_ref()?.security_schemes.get(name)?;
-        let mut seen: BTreeSet<String> = BTreeSet::new();
-        loop {
-            match entry {
-                RefOr::Item(scheme) => return Some(scheme),
-                RefOr::Reference(reference) => {
-                    let key = reference.component_key("securitySchemes")?;
-                    if !seen.insert(key.clone()) {
-                        return None;
-                    }
-                    entry = self.components.as_ref()?.security_schemes.get(&key)?;
-                }
-            }
-        }
-    }
-
-    /// Check that a document-local message `$ref` lands on a declared
-    /// component message.
+    /// Check that a message `$ref` resolves inside this document.
     fn validate_message_refs(&self, ctx: &mut Context, message: &OperationMessage) {
         match message {
             OperationMessage::Single(single) => {
-                if let RefOr::Reference(reference) = single.as_ref() {
-                    if reference.is_external() || reference.reference.is_empty() {
-                        return;
-                    }
-                    let declared = reference
-                        .component_key("messages")
-                        .and_then(|key| Some(self.components.as_ref()?.messages.contains_key(&key)))
-                        .unwrap_or(false);
-                    if !declared {
-                        ctx.error_field(
-                            "$ref",
-                            format!(
-                                "message `{}` is not declared in `components.messages`",
-                                reference.reference
-                            ),
-                        );
-                    }
+                if let RefOr::Reference(reference) = single.as_ref()
+                    && !reference.reference.is_empty()
+                    && let Some(problem) = self.resolve_message(reference).problem()
+                {
+                    ctx.error_field(
+                        "$ref",
+                        format!("message `{}` {problem}", reference.reference),
+                    );
                 }
             }
             OperationMessage::OneOf(one_of) => {
@@ -225,27 +420,29 @@ impl Document {
         }
     }
 
-    /// Whether `components.securitySchemes` names `name` at all — a
-    /// `$ref`'d entry counts as declared even though it cannot be
-    /// inspected.
-    fn declares_security_scheme(&self, name: &str) -> bool {
-        self.components
-            .as_ref()
-            .is_some_and(|c| c.security_schemes.contains_key(name))
-    }
-
-    /// Check that every requirement names a declared scheme, and lists
-    /// scopes only where the scheme's type allows them.
+    /// Check that every requirement names a scheme that resolves, and
+    /// lists scopes only where that scheme's type allows them.
     fn validate_security(&self, ctx: &mut Context, field: &str, security: &[SecurityRequirement]) {
         for (i, requirement) in security.iter().enumerate() {
             for (name, scopes) in &requirement.0 {
-                if !self.declares_security_scheme(name) {
+                let declared = self
+                    .components
+                    .as_ref()
+                    .is_some_and(|c| c.security_schemes.contains_key(name));
+                if !declared {
                     ctx.in_index(field, i, |ctx| {
                         ctx.error_field(name, "is not declared in `components.securitySchemes`");
                     });
                     continue;
                 }
-                if let Some(scheme) = self.security_scheme(name)
+                let resolution = self.security_scheme_at(name);
+                if let Some(problem) = resolution.problem() {
+                    ctx.in_index(field, i, |ctx| {
+                        ctx.error_field(name, problem);
+                    });
+                    continue;
+                }
+                if let Some(scheme) = resolution.found()
                     && !scopes.is_empty()
                     && !scheme.scheme_type.takes_scopes()
                 {
@@ -279,10 +476,35 @@ impl Document {
         for (name, server) in &self.servers {
             ctx.in_key("servers", name, |ctx| {
                 server.validate_with_context(ctx);
-                if let Some(server) = server.item() {
+                // Follow a `$ref` so a referenced server's security is
+                // checked as well as an inline one's.
+                let resolution = self.resolve_server(server);
+                if let Some(problem) = resolution.problem()
+                    && let RefOr::Reference(reference) = server
+                {
+                    ctx.error_field(
+                        "$ref",
+                        format!("server `{}` {problem}", reference.reference),
+                    );
+                }
+                if let Some(server) = resolution.found() {
                     self.validate_security(ctx, "security", &server.security);
                 }
             });
+        }
+
+        // Component servers are reachable only through a `$ref`, so
+        // their own security requirements are checked here.
+        if let Some(components) = &self.components {
+            for (name, server) in &components.servers {
+                if let Some(server) = server.item() {
+                    ctx.in_key("components", "servers", |ctx| {
+                        ctx.in_field(name, |ctx| {
+                            self.validate_security(ctx, "security", &server.security);
+                        });
+                    });
+                }
+            }
         }
 
         for (path, channel) in &self.channels {
@@ -295,26 +517,26 @@ impl Document {
                 // *resolved* item's parameters are what this path's
                 // placeholders must match.
                 channel.validate_with_context(ctx);
-                match self.resolve_channel(channel) {
-                    Some(resolved) => resolved.validate_against_path(ctx, path),
-                    None => {
-                        if let Some(reference) = channel.reference.as_deref() {
-                            let reference = Reference {
-                                reference: reference.to_owned(),
-                            };
-                            if !reference.is_external() && !reference.reference.is_empty() {
-                                ctx.error_field(
-                                    "$ref",
-                                    format!(
-                                        "`{}` does not resolve to a declared channel",
-                                        reference.reference
-                                    ),
-                                );
-                            }
+                let resolution = self.resolve_channel(channel);
+                match &resolution {
+                    Resolution::Found(resolved) => resolved.validate_against_path(ctx, path),
+                    // An external terminus is accepted; anything else
+                    // local is a document bug.
+                    other => {
+                        if let Some(problem) = other.problem()
+                            && let Some(reference) = channel.reference.as_deref()
+                            && !reference.is_empty()
+                        {
+                            ctx.error_field("$ref", format!("channel `{reference}` {problem}"));
                         }
+                        // The item's own parameters still answer to the
+                        // path it is keyed by.
+                        channel.validate_against_path(ctx, path);
                     }
                 }
-                if let Some(item) = self.resolve_channel(channel) {
+                // `$ref` siblings are preserved, so the item as written
+                // is checked as well as the channel it references.
+                for item in self.channel_and_target(channel) {
                     // A channel's servers are plain names into `servers`.
                     for (i, server) in item.servers.iter().enumerate() {
                         if !server.is_empty() && !self.servers.contains_key(server) {
@@ -570,7 +792,7 @@ mod tests {
         assert!(
             errors_for(value)
                 .iter()
-                .any(|e| e.contains("does not resolve to a declared channel")),
+                .any(|e| e.contains("names nothing in this document")),
         );
     }
 
@@ -590,7 +812,7 @@ mod tests {
             }
         });
         let doc: Document = serde_json::from_value(value).unwrap();
-        assert!(doc.resolve_channel(&doc.channels["user"]).is_none());
+        assert!(doc.resolve_channel(&doc.channels["user"]).found().is_none());
         assert!(doc.operations().is_empty());
         // Validation still terminates and reports the unresolvable ref.
         let _ = doc.validate(EnumSet::empty());
@@ -687,9 +909,9 @@ mod tests {
         value["channels"] = json!({
             "user": { "publish": { "message": { "$ref": "#/components/messages/missing" } } }
         });
-        assert!(errors_for(value).iter().any(|e| e.contains(
-            "message `#/components/messages/missing` is not declared in `components.messages`"
-        )),);
+        assert!(errors_for(value).iter().any(|e| {
+            e.contains("message `#/components/messages/missing` names nothing in this document")
+        }),);
 
         // Declared is fine; external is left alone; `oneOf` members are
         // checked individually.
@@ -723,7 +945,11 @@ mod tests {
             }
         });
         let doc: Document = serde_json::from_value(value.clone()).unwrap();
-        assert!(doc.resolve_channel(&doc.channels["alias"]).is_some());
+        assert!(
+            doc.resolve_channel(&doc.channels["alias"])
+                .found()
+                .is_some()
+        );
         // Both the target and the alias contribute their operation, so
         // the duplicate `operationId` is reported.
         assert_eq!(doc.operations().len(), 2);
@@ -732,6 +958,341 @@ mod tests {
                 .iter()
                 .any(|e| e.contains("duplicate operationId `handle`")),
         );
+    }
+
+    #[test]
+    fn ref_siblings_are_validated_as_well_as_the_target() {
+        // A `$ref` sibling survives serialization, so it is checked
+        // too: this item's own `servers` names nothing, and its own
+        // operation joins the target's.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "servers": { "production": { "url": "kafka://e", "protocol": "kafka" } },
+            "channels": {
+                "user": {
+                    "$ref": "#/components/channels/target",
+                    "servers": ["missing"],
+                    "publish": { "operationId": "own" }
+                }
+            },
+            "components": {
+                "channels": { "target": { "subscribe": { "operationId": "target" } } }
+            }
+        });
+        let doc: Document = serde_json::from_value(value.clone()).unwrap();
+        let ids: Vec<_> = doc
+            .operations()
+            .iter()
+            .filter_map(|(_, _, op)| op.operation_id.as_deref())
+            .collect();
+        assert!(
+            ids.contains(&"own"),
+            "the item's own operation counts: {ids:?}"
+        );
+        assert!(ids.contains(&"target"), "so does the target's: {ids:?}");
+
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("server `missing` is not declared")),
+            "a sibling `servers` list is still checked",
+        );
+    }
+
+    #[test]
+    fn a_message_pointer_into_a_channel_operation_resolves() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source": { "publish": { "message": { "name": "S" } } },
+                "target": {
+                    "subscribe": { "message": { "$ref": "#/channels/source/publish/message" } }
+                }
+            }
+        });
+        assert!(
+            errors_for(value).is_empty(),
+            "a legal local pointer must resolve"
+        );
+
+        // …including into a `oneOf` member.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source": {
+                    "publish": { "message": { "oneOf": [ { "name": "A" }, { "name": "B" } ] } }
+                },
+                "target": {
+                    "subscribe": {
+                        "message": { "$ref": "#/channels/source/publish/message/oneOf/1" }
+                    }
+                }
+            }
+        });
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn a_message_alias_chain_must_terminate_somewhere_real() {
+        // components alias → missing target.
+        let mut value = minimal();
+        value["components"] = json!({
+            "messages": { "alias": { "$ref": "#/components/messages/missing" } }
+        });
+        value["channels"] = json!({
+            "user": { "publish": { "message": { "$ref": "#/components/messages/alias" } } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("names nothing in this document")),
+            "an alias to a missing message must be reported",
+        );
+
+        // A cycle terminates and is named as one.
+        let mut value = minimal();
+        value["components"] = json!({
+            "messages": {
+                "a": { "$ref": "#/components/messages/b" },
+                "b": { "$ref": "#/components/messages/a" }
+            }
+        });
+        value["channels"] = json!({
+            "user": { "publish": { "message": { "$ref": "#/components/messages/a" } } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("is part of a reference cycle")),
+        );
+    }
+
+    #[test]
+    fn a_dangling_security_alias_is_reported() {
+        let mut value = minimal();
+        value["components"] = json!({
+            "securitySchemes": { "alias": { "$ref": "#/components/securitySchemes/missing" } }
+        });
+        value["channels"] = json!({
+            "user": { "publish": { "security": [ { "alias": [] } ] } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("names nothing in this document")),
+            "an alias that resolves to nothing must not count as declared",
+        );
+
+        // A cyclic alias likewise.
+        let mut value = minimal();
+        value["components"] = json!({
+            "securitySchemes": {
+                "a": { "$ref": "#/components/securitySchemes/b" },
+                "b": { "$ref": "#/components/securitySchemes/a" }
+            }
+        });
+        value["channels"] = json!({ "user": { "publish": { "security": [ { "a": [] } ] } } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("is part of a reference cycle")),
+        );
+    }
+
+    #[test]
+    fn a_chain_ending_outside_the_document_is_accepted() {
+        // root alias → component channel → external `$ref`.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": { "alias": { "$ref": "#/components/channels/hop" } },
+            "components": {
+                "channels": { "hop": { "$ref": "./other.yaml#/channels/real" } }
+            }
+        });
+        assert!(
+            errors_for(value).is_empty(),
+            "an external terminus is not a document bug",
+        );
+    }
+
+    #[test]
+    fn a_referenced_server_still_has_its_security_checked() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {},
+            "servers": { "prod": { "$ref": "#/components/servers/real" } },
+            "components": {
+                "servers": {
+                    "real": {
+                        "url": "kafka://e",
+                        "protocol": "kafka",
+                        "security": [ { "missing": [] } ]
+                    }
+                }
+            }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("is not declared in `components.securitySchemes`")),
+            "a referenced server's security must be checked",
+        );
+    }
+
+    #[test]
+    fn a_root_channel_pointer_must_escape_its_separators() {
+        // `#/channels/source/path` is two segments, so it cannot name
+        // the key `source/path` — RFC 6901 wants `source~1path`.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source/path": { "publish": {} },
+                "alias": { "$ref": "#/channels/source/path" }
+            }
+        });
+        let doc: Document = serde_json::from_value(value.clone()).unwrap();
+        assert!(
+            doc.resolve_channel(&doc.channels["alias"])
+                .found()
+                .is_none()
+        );
+        assert!(
+            !errors_for(value).is_empty(),
+            "the unescaped pointer must be reported"
+        );
+
+        // The escaped spelling resolves.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source/path": { "publish": {} },
+                "alias": { "$ref": "#/channels/source~1path" }
+            }
+        });
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn pointers_of_the_wrong_kind_are_told_apart_from_missing_ones() {
+        // A local pointer that cannot denote a channel at all.
+        let mut value = minimal();
+        value["channels"] = json!({ "user": { "$ref": "#/components/schemas/thing" } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("does not point at an object of the expected kind")),
+        );
+
+        // …and the same for a message.
+        let mut value = minimal();
+        value["channels"] = json!({
+            "user": { "publish": { "message": { "$ref": "#/components/schemas/thing" } } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("does not point at an object of the expected kind")),
+        );
+    }
+
+    #[test]
+    fn external_aliases_terminate_every_resolver() {
+        // Security scheme, server, and message chains that leave the
+        // document are all accepted.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "servers": { "prod": { "$ref": "#/components/servers/hop" } },
+            "channels": {
+                "user": {
+                    "publish": {
+                        "security": [ { "alias": [] } ],
+                        "message": { "$ref": "#/components/messages/hop" }
+                    }
+                }
+            },
+            "components": {
+                "servers": { "hop": { "$ref": "./other.yaml#/servers/real" } },
+                "securitySchemes": { "alias": { "$ref": "./other.yaml#/schemes/real" } },
+                "messages": { "hop": { "$ref": "./other.yaml#/messages/real" } }
+            }
+        });
+        assert!(
+            errors_for(value).is_empty(),
+            "external termini are accepted"
+        );
+    }
+
+    #[test]
+    fn server_aliases_are_resolved_like_the_others() {
+        // Missing target.
+        let mut value = minimal();
+        value["servers"] = json!({ "prod": { "$ref": "#/components/servers/ghost" } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("names nothing in this document")),
+        );
+
+        // Wrong kind of pointer.
+        let mut value = minimal();
+        value["servers"] = json!({ "prod": { "$ref": "#/components/schemas/thing" } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("does not point at an object of the expected kind")),
+        );
+
+        // Cycle.
+        let mut value = minimal();
+        value["servers"] = json!({ "prod": { "$ref": "#/components/servers/a" } });
+        value["components"] = json!({
+            "servers": {
+                "a": { "$ref": "#/components/servers/b" },
+                "b": { "$ref": "#/components/servers/a" }
+            }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("is part of a reference cycle")),
+        );
+    }
+
+    #[test]
+    fn message_pointers_into_channels_reject_every_wrong_step() {
+        let base = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source": {
+                    "publish": { "message": { "oneOf": [ { "name": "A" } ] } },
+                    "subscribe": { "message": { "name": "S" } }
+                },
+                "target": { "subscribe": {} }
+            }
+        });
+        for pointer in [
+            "#/channels/ghost/publish/message",            // no such channel
+            "#/channels/source/deliver/message",           // no such operation half
+            "#/channels/source/publish/payload",           // not the message field
+            "#/channels/source/publish/message/oneOf/9",   // index past the end
+            "#/channels/source/publish/message/oneOf/x",   // non-numeric index
+            "#/channels/source/publish/message/anyOf/0",   // not a oneOf step
+            "#/channels/source/subscribe/message/oneOf/0", // not a set at all
+            "#/channels/source/publish/message",           // terminates on a set
+        ] {
+            let mut value = base.clone();
+            value["channels"]["target"]["subscribe"]["message"] = json!({ "$ref": pointer });
+            assert!(!errors_for(value).is_empty(), "{pointer} must not resolve");
+        }
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/v2_6/document.rs
+++ b/crates/roas-asyncapi/src/v2_6/document.rs
@@ -13,6 +13,7 @@ use crate::v2_6::channel_item::ChannelItem;
 use crate::v2_6::components::Components;
 use crate::v2_6::external_documentation::ExternalDocumentation;
 use crate::v2_6::info::Info;
+use crate::v2_6::message::{Message, OperationMessage};
 use crate::v2_6::operation::{Operation, OperationKind};
 use crate::v2_6::security_scheme::{SecurityRequirement, SecurityScheme};
 use crate::v2_6::server::Server;
@@ -61,7 +62,7 @@ pub struct Document {
 
     /// Additional external documentation. v3 moved this under `info`.
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub external_docs: Option<ExternalDocumentation>,
 
     /// `x-`-prefixed Specification Extensions on the root.
     #[serde(flatten)]
@@ -70,13 +71,47 @@ pub struct Document {
     pub extensions: Option<BTreeMap<String, serde_json::Value>>,
 }
 
+/// How many `$ref` hops to follow before declaring a cycle. Component
+/// channels referencing each other is legal but pointless, so the bound
+/// only needs to be past any sane document.
+const MAX_REF_DEPTH: usize = 32;
+
 impl Document {
+    /// Resolve a channel entry, following document-local
+    /// `#/components/channels/…` references.
+    ///
+    /// Returns `None` for an external reference, one that names nothing,
+    /// or a cycle — none of which this crate can see through.
+    pub fn resolve_channel<'a>(
+        &'a self,
+        channel: &'a RefOr<ChannelItem>,
+    ) -> Option<&'a ChannelItem> {
+        let mut current = channel;
+        // A component channel may itself be a `$ref`, so follow the
+        // chain — and stop if it ever revisits a key.
+        let mut seen: BTreeSet<String> = BTreeSet::new();
+        for _ in 0..MAX_REF_DEPTH {
+            match current {
+                RefOr::Item(item) => return Some(item),
+                RefOr::Reference(reference) => {
+                    let key = reference.component_key("channels")?;
+                    if !seen.insert(key.clone()) {
+                        return None;
+                    }
+                    current = self.components.as_ref()?.channels.get(&key)?;
+                }
+            }
+        }
+        None
+    }
+
     /// Every operation in the document, with the channel path and the
-    /// half it came from.
+    /// half it came from. Channels that are a document-local `$ref` are
+    /// resolved first.
     pub fn operations(&self) -> Vec<(&str, OperationKind, &Operation)> {
         let mut found = Vec::new();
         for (path, channel) in &self.channels {
-            let Some(channel) = channel.item() else {
+            let Some(channel) = self.resolve_channel(channel) else {
                 continue;
             };
             if let Some(operation) = &channel.publish {
@@ -84,6 +119,40 @@ impl Document {
             }
             if let Some(operation) = &channel.subscribe {
                 found.push((path.as_str(), OperationKind::Subscribe, operation));
+            }
+        }
+        found
+    }
+
+    /// Every message the document declares, inline or in `components`,
+    /// walking through `oneOf` sets.
+    fn messages(&self) -> Vec<&Message> {
+        fn collect<'a>(message: &'a OperationMessage, found: &mut Vec<&'a Message>) {
+            match message {
+                OperationMessage::Single(single) => {
+                    if let Some(message) = single.item() {
+                        found.push(message);
+                    }
+                }
+                OperationMessage::OneOf(one_of) => {
+                    for alternative in &one_of.one_of {
+                        collect(alternative, found);
+                    }
+                }
+            }
+        }
+
+        let mut found = Vec::new();
+        if let Some(components) = &self.components {
+            for message in components.messages.values() {
+                if let Some(message) = message.item() {
+                    found.push(message);
+                }
+            }
+        }
+        for (_, _, operation) in self.operations() {
+            if let Some(message) = &operation.message {
+                collect(message, &mut found);
             }
         }
         found
@@ -161,10 +230,27 @@ impl Document {
             }
             ctx.in_key("channels", path, |ctx| {
                 match channel {
-                    RefOr::Reference(reference) => reference.validate_with_context(ctx),
+                    RefOr::Reference(reference) => {
+                        reference.validate_with_context(ctx);
+                        // A local `$ref` resolves, so the target's
+                        // parameters are still checked against this
+                        // path — the placeholders belong to the key,
+                        // not to the referenced item.
+                        if let Some(item) = self.resolve_channel(channel) {
+                            item.validate_against_path(ctx, path);
+                        } else if !reference.is_external() && !reference.reference.is_empty() {
+                            ctx.error_field(
+                                "$ref",
+                                format!(
+                                    "`{}` does not resolve to a declared channel",
+                                    reference.reference
+                                ),
+                            );
+                        }
+                    }
                     RefOr::Item(item) => item.validate_against_path(ctx, path),
                 }
-                if let Some(item) = channel.item() {
+                if let Some(item) = self.resolve_channel(channel) {
                     // A channel's servers are plain names into `servers`.
                     for (i, server) in item.servers.iter().enumerate() {
                         if !server.is_empty() && !self.servers.contains_key(server) {
@@ -215,29 +301,23 @@ impl Document {
             }
         }
 
-        // The same uniqueness rule applies to `messageId`.
+        // The same uniqueness rule applies to `messageId`, across
+        // every message in the document — component *and* inline,
+        // including the members of a `oneOf` set.
         let mut message_ids: BTreeSet<&str> = BTreeSet::new();
-        if let Some(components) = &self.components {
-            for (key, message) in &components.messages {
-                let Some(message) = message.item() else {
-                    continue;
-                };
-                let Some(message_id) = message.message_id.as_deref() else {
-                    continue;
-                };
-                if !message_id.is_empty() && !message_ids.insert(message_id) {
-                    ctx.in_key("components", "messages", |ctx| {
-                        ctx.in_key(key, "messageId", |ctx| {
-                            ctx.error(format!("duplicate messageId `{message_id}`"));
-                        });
-                    });
-                }
+        for message in self.messages() {
+            let Some(message_id) = message.message_id.as_deref() else {
+                continue;
+            };
+            if !message_id.is_empty() && !message_ids.insert(message_id) {
+                ctx.error_field(
+                    "messageId",
+                    format!("duplicate messageId `{message_id}` in the document"),
+                );
             }
         }
 
-        for (i, tag) in self.tags.iter().enumerate() {
-            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
-        }
+        crate::v2_6::message::validate_tags(&mut ctx, &self.tags);
         if let Some(docs) = &self.external_docs {
             ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
         }
@@ -380,7 +460,83 @@ mod tests {
     }
 
     #[test]
-    fn message_ids_must_be_unique() {
+    fn a_local_channel_reference_is_resolved_for_document_checks() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "servers": { "production": { "url": "kafka://e", "protocol": "kafka" } },
+            "channels": {
+                "user/{userId}": { "$ref": "#/components/channels/user" }
+            },
+            "components": {
+                "channels": {
+                    "user": {
+                        "servers": ["staging"],
+                        "publish": { "operationId": "handle" }
+                    }
+                }
+            }
+        });
+        let errors = errors_for(value);
+        // The referenced channel's server list is checked…
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("server `staging` is not declared")),
+            "got: {errors:?}"
+        );
+        // …and its parameters are checked against *this* path.
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("`{userId}` in the channel path is not declared")),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn a_local_channel_reference_that_names_nothing_is_reported() {
+        let mut value = minimal();
+        value["channels"] = json!({ "user": { "$ref": "#/components/channels/ghost" } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("does not resolve to a declared channel")),
+        );
+    }
+
+    #[test]
+    fn a_channel_reference_cycle_terminates() {
+        // Two component channels pointing at each other must not hang
+        // the resolver.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": { "user": { "$ref": "#/components/channels/a" } },
+            "components": {
+                "channels": {
+                    "a": { "$ref": "#/components/channels/b" },
+                    "b": { "$ref": "#/components/channels/a" }
+                }
+            }
+        });
+        let doc: Document = serde_json::from_value(value).unwrap();
+        assert!(doc.resolve_channel(&doc.channels["user"]).is_none());
+        assert!(doc.operations().is_empty());
+        // Validation still terminates and reports the unresolvable ref.
+        let _ = doc.validate(EnumSet::empty());
+    }
+
+    #[test]
+    fn an_external_channel_reference_is_left_alone() {
+        let mut value = minimal();
+        value["channels"] = json!({ "user": { "$ref": "./channels.yaml#/user" } });
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn message_ids_must_be_unique_across_the_whole_document() {
+        // Two component messages…
         let mut value = minimal();
         value["components"] = json!({
             "messages": {
@@ -388,12 +544,68 @@ mod tests {
                 "b": { "messageId": "signup" }
             }
         });
-        let errors = errors_for(value);
         assert!(
-            errors
+            errors_for(value)
                 .iter()
                 .any(|e| e.contains("duplicate messageId `signup`")),
-            "got: {errors:?}"
+        );
+
+        // …a component message and an inline one…
+        let mut value = minimal();
+        value["components"] = json!({ "messages": { "a": { "messageId": "signup" } } });
+        value["channels"] = json!({
+            "user": { "publish": { "message": { "messageId": "signup" } } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("duplicate messageId `signup`")),
+            "an inline message must collide with a component one",
+        );
+
+        // …and two inline messages inside a `oneOf` set.
+        let mut value = minimal();
+        value["channels"] = json!({
+            "user": {
+                "publish": {
+                    "message": {
+                        "oneOf": [ { "messageId": "dup" }, { "messageId": "dup" } ]
+                    }
+                }
+            }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("duplicate messageId `dup`")),
+            "oneOf members must be walked",
+        );
+
+        // Distinct ids are fine.
+        let mut value = minimal();
+        value["channels"] = json!({
+            "user": {
+                "publish": { "message": { "oneOf": [ { "messageId": "a" }, { "messageId": "b" } ] } }
+            }
+        });
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn root_tags_must_be_unique_and_external_docs_takes_no_reference() {
+        let mut value = minimal();
+        value["tags"] = json!([ { "name": "a" }, { "name": "a" } ]);
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e == "#.tags[1]: duplicate tag"),
+        );
+
+        let mut value = minimal();
+        value["externalDocs"] = json!({ "$ref": "#/anything" });
+        assert!(
+            serde_json::from_value::<Document>(value).is_err(),
+            "2.6 requires a concrete External Documentation Object",
         );
     }
 

--- a/crates/roas-asyncapi/src/v2_6/document.rs
+++ b/crates/roas-asyncapi/src/v2_6/document.rs
@@ -1,0 +1,525 @@
+//! AsyncAPI v2.6 root document.
+//!
+//! Per [AsyncAPI Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#A2SObject).
+//!
+//! Beyond the per-object checks, the root validator resolves what only
+//! it can see: a channel's `servers` must name declared servers, an
+//! `operationId` must be unique across every operation in the document,
+//! and a security requirement must name a declared scheme — listing
+//! scopes only where the scheme's type allows them.
+
+use crate::common::reference::RefOr;
+use crate::v2_6::channel_item::ChannelItem;
+use crate::v2_6::components::Components;
+use crate::v2_6::external_documentation::ExternalDocumentation;
+use crate::v2_6::info::Info;
+use crate::v2_6::operation::{Operation, OperationKind};
+use crate::v2_6::security_scheme::{SecurityRequirement, SecurityScheme};
+use crate::v2_6::server::Server;
+use crate::v2_6::tag::Tag;
+use crate::v2_6::version::Version;
+use crate::validation::{Context, Error, Validate, ValidateWithContext, ValidationOptions};
+use enumset::EnumSet;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Root AsyncAPI v2.6 document.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Document {
+    /// **Required** Exactly `2.6.0` — the AsyncAPI specification
+    /// version, which the schema pins to a single-value enumeration.
+    pub asyncapi: Version,
+
+    /// A unique identifier of the application this document describes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// **Required** Metadata about the API.
+    pub info: Info,
+
+    /// The servers the application connects to, keyed by name.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub servers: BTreeMap<String, RefOr<Server>>,
+
+    /// The default content type to use when one is not set on a
+    /// message.
+    #[serde(rename = "defaultContentType", skip_serializing_if = "Option::is_none")]
+    pub default_content_type: Option<String>,
+
+    /// **Required** The channels this application uses, keyed by their
+    /// path. Unlike v3, the key *is* the address.
+    pub channels: BTreeMap<String, RefOr<ChannelItem>>,
+
+    /// Reusable objects referenced throughout the document.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Components>,
+
+    /// Tags used by the document, with additional metadata. v3 moved
+    /// these under `info`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<Tag>,
+
+    /// Additional external documentation. v3 moved this under `info`.
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    /// `x-`-prefixed Specification Extensions on the root.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl Document {
+    /// Every operation in the document, with the channel path and the
+    /// half it came from.
+    pub fn operations(&self) -> Vec<(&str, OperationKind, &Operation)> {
+        let mut found = Vec::new();
+        for (path, channel) in &self.channels {
+            let Some(channel) = channel.item() else {
+                continue;
+            };
+            if let Some(operation) = &channel.publish {
+                found.push((path.as_str(), OperationKind::Publish, operation));
+            }
+            if let Some(operation) = &channel.subscribe {
+                found.push((path.as_str(), OperationKind::Subscribe, operation));
+            }
+        }
+        found
+    }
+
+    /// The security scheme declared under `components.securitySchemes`,
+    /// when it is inline and resolvable.
+    fn security_scheme(&self, name: &str) -> Option<&SecurityScheme> {
+        self.components.as_ref()?.security_schemes.get(name)?.item()
+    }
+
+    /// Whether `components.securitySchemes` names `name` at all — a
+    /// `$ref`'d entry counts as declared even though it cannot be
+    /// inspected.
+    fn declares_security_scheme(&self, name: &str) -> bool {
+        self.components
+            .as_ref()
+            .is_some_and(|c| c.security_schemes.contains_key(name))
+    }
+
+    /// Check that every requirement names a declared scheme, and lists
+    /// scopes only where the scheme's type allows them.
+    fn validate_security(&self, ctx: &mut Context, field: &str, security: &[SecurityRequirement]) {
+        for (i, requirement) in security.iter().enumerate() {
+            for (name, scopes) in &requirement.0 {
+                if !self.declares_security_scheme(name) {
+                    ctx.in_index(field, i, |ctx| {
+                        ctx.error_field(name, "is not declared in `components.securitySchemes`");
+                    });
+                    continue;
+                }
+                if let Some(scheme) = self.security_scheme(name)
+                    && !scopes.is_empty()
+                    && !scheme.scheme_type.takes_scopes()
+                {
+                    ctx.in_index(field, i, |ctx| {
+                        ctx.error_field(
+                            name,
+                            format!(
+                                "must not list scopes: the `{}` scheme type takes none",
+                                scheme.scheme_type.as_str()
+                            ),
+                        );
+                    });
+                }
+            }
+        }
+    }
+
+    fn validate_inner(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        let mut ctx = Context::new(options);
+
+        if let Some(id) = &self.id {
+            ctx.require_non_empty("id", id);
+        }
+        if let Some(content_type) = &self.default_content_type {
+            ctx.require_non_empty("defaultContentType", content_type);
+        }
+
+        ctx.in_field("info", |ctx| self.info.validate_with_context(ctx));
+
+        ctx.validate_map_keys("servers", &self.servers);
+        for (name, server) in &self.servers {
+            ctx.in_key("servers", name, |ctx| {
+                server.validate_with_context(ctx);
+                if let Some(server) = server.item() {
+                    self.validate_security(ctx, "security", &server.security);
+                }
+            });
+        }
+
+        for (path, channel) in &self.channels {
+            if path.is_empty() {
+                ctx.error_field("channels", "a channel path must not be empty");
+            }
+            ctx.in_key("channels", path, |ctx| {
+                match channel {
+                    RefOr::Reference(reference) => reference.validate_with_context(ctx),
+                    RefOr::Item(item) => item.validate_against_path(ctx, path),
+                }
+                if let Some(item) = channel.item() {
+                    // A channel's servers are plain names into `servers`.
+                    for (i, server) in item.servers.iter().enumerate() {
+                        if !server.is_empty() && !self.servers.contains_key(server) {
+                            ctx.in_index("servers", i, |ctx| {
+                                ctx.error(format!("server `{server}` is not declared"));
+                            });
+                        }
+                    }
+                    for (kind, operation) in
+                        [("publish", &item.publish), ("subscribe", &item.subscribe)]
+                    {
+                        if let Some(operation) = operation {
+                            ctx.in_field(kind, |ctx| {
+                                self.validate_security(ctx, "security", &operation.security);
+                            });
+                        }
+                    }
+                }
+            });
+        }
+
+        // `operationId` MUST be unique among all operations in the API.
+        let mut seen: BTreeMap<&str, (&str, OperationKind)> = BTreeMap::new();
+        for (path, kind, operation) in self.operations() {
+            let Some(operation_id) = operation.operation_id.as_deref() else {
+                continue;
+            };
+            if operation_id.is_empty() {
+                continue;
+            }
+            match seen.get(operation_id) {
+                Some((first_path, first_kind)) => {
+                    ctx.in_key("channels", path, |ctx| {
+                        ctx.in_field(kind.as_str(), |ctx| {
+                            ctx.error_field(
+                                "operationId",
+                                format!(
+                                    "duplicate operationId `{operation_id}`, already used by `#.channels.{first_path}.{}`",
+                                    first_kind.as_str()
+                                ),
+                            );
+                        });
+                    });
+                }
+                None => {
+                    seen.insert(operation_id, (path, kind));
+                }
+            }
+        }
+
+        // The same uniqueness rule applies to `messageId`.
+        let mut message_ids: BTreeSet<&str> = BTreeSet::new();
+        if let Some(components) = &self.components {
+            for (key, message) in &components.messages {
+                let Some(message) = message.item() else {
+                    continue;
+                };
+                let Some(message_id) = message.message_id.as_deref() else {
+                    continue;
+                };
+                if !message_id.is_empty() && !message_ids.insert(message_id) {
+                    ctx.in_key("components", "messages", |ctx| {
+                        ctx.in_key(key, "messageId", |ctx| {
+                            ctx.error(format!("duplicate messageId `{message_id}`"));
+                        });
+                    });
+                }
+            }
+        }
+
+        for (i, tag) in self.tags.iter().enumerate() {
+            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
+        }
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+        if let Some(components) = &self.components {
+            ctx.in_field("components", |ctx| components.validate_with_context(ctx));
+        }
+
+        ctx.into_result()
+    }
+}
+
+impl Validate for Document {
+    fn validate(&self, options: EnumSet<ValidationOptions>) -> Result<(), Error> {
+        self.validate_inner(options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn minimal() -> serde_json::Value {
+        json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "Streetlights", "version": "1.0.0" },
+            "channels": {}
+        })
+    }
+
+    fn wired() -> serde_json::Value {
+        json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "servers": {
+                "production": { "url": "kafka://broker:9092", "protocol": "kafka" }
+            },
+            "channels": {
+                "user/{userId}/signedup": {
+                    "servers": ["production"],
+                    "parameters": { "userId": { "schema": { "type": "string" } } },
+                    "publish": {
+                        "operationId": "receiveSignup",
+                        "message": { "name": "UserSignedUp" }
+                    },
+                    "subscribe": {
+                        "operationId": "sendWelcome",
+                        "message": { "name": "Welcome" }
+                    }
+                }
+            }
+        })
+    }
+
+    fn errors_for(value: serde_json::Value) -> Vec<String> {
+        let doc: Document = serde_json::from_value(value).unwrap();
+        match doc.validate(EnumSet::empty()) {
+            Ok(()) => Vec::new(),
+            Err(err) => err.errors.iter().map(ToString::to_string).collect(),
+        }
+    }
+
+    #[test]
+    fn minimal_document_parses_validates_and_round_trips() {
+        let doc: Document = serde_json::from_value(minimal()).unwrap();
+        assert_eq!(doc.asyncapi, Version::V2_6_0());
+        doc.validate(EnumSet::empty()).expect("valid");
+        assert_eq!(serde_json::to_value(&doc).unwrap(), minimal());
+    }
+
+    #[test]
+    fn channels_is_required_by_the_parser() {
+        assert!(
+            serde_json::from_value::<Document>(json!({
+                "asyncapi": "2.6.0",
+                "info": { "title": "T", "version": "1" }
+            }))
+            .is_err(),
+            "2.6 requires `channels`"
+        );
+    }
+
+    #[test]
+    fn rejects_v3_documents_at_parse_time() {
+        for version in ["3.0.0", "3.1.0"] {
+            let mut value = minimal();
+            value["asyncapi"] = json!(version);
+            assert!(
+                serde_json::from_value::<Document>(value).is_err(),
+                "{version}"
+            );
+        }
+    }
+
+    #[test]
+    fn fully_wired_document_validates() {
+        assert!(
+            errors_for(wired()).is_empty(),
+            "got: {:?}",
+            errors_for(wired())
+        );
+    }
+
+    #[test]
+    fn channel_servers_must_name_declared_servers() {
+        let mut value = wired();
+        value["channels"]["user/{userId}/signedup"]["servers"] = json!(["staging"]);
+        let errors = errors_for(value);
+        assert!(
+            errors.iter().any(|e| e
+                == "#.channels.user/{userId}/signedup.servers[0]: server `staging` is not declared"),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn operation_ids_must_be_unique_across_the_document() {
+        let mut value = wired();
+        value["channels"]["other"] = json!({
+            "publish": { "operationId": "receiveSignup" }
+        });
+        let errors = errors_for(value);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("duplicate operationId `receiveSignup`")),
+            "got: {errors:?}"
+        );
+
+        // The same id on publish and subscribe of one channel collides
+        // too.
+        let mut same_channel = wired();
+        same_channel["channels"]["user/{userId}/signedup"]["subscribe"]["operationId"] =
+            json!("receiveSignup");
+        assert!(
+            errors_for(same_channel)
+                .iter()
+                .any(|e| e.contains("duplicate operationId")),
+        );
+    }
+
+    #[test]
+    fn message_ids_must_be_unique() {
+        let mut value = minimal();
+        value["components"] = json!({
+            "messages": {
+                "a": { "messageId": "signup" },
+                "b": { "messageId": "signup" }
+            }
+        });
+        let errors = errors_for(value);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("duplicate messageId `signup`")),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn security_requirements_must_name_declared_schemes() {
+        let mut value = minimal();
+        value["servers"] = json!({
+            "prod": { "url": "kafka://e", "protocol": "kafka", "security": [ { "missing": [] } ] }
+        });
+        let errors = errors_for(value);
+        assert!(
+            errors.iter().any(|e| e
+                == "#.servers.prod.security[0].missing: is not declared in `components.securitySchemes`"),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn scopes_are_only_allowed_on_oauth_style_schemes() {
+        let mut value = minimal();
+        value["components"] = json!({
+            "securitySchemes": {
+                "user_pass": { "type": "userPassword" },
+                "oauth": {
+                    "type": "oauth2",
+                    "flows": { "implicit": { "authorizationUrl": "https://e/a", "scopes": {} } }
+                }
+            }
+        });
+        value["channels"] = json!({
+            "user": {
+                "publish": {
+                    "security": [ { "user_pass": ["read"] }, { "oauth": ["read"] } ]
+                }
+            }
+        });
+        let errors = errors_for(value);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e
+                    .contains("must not list scopes: the `userPassword` scheme type takes none")),
+            "got: {errors:?}"
+        );
+        // The oauth2 requirement is fine.
+        assert!(
+            !errors.iter().any(|e| e.contains("oauth:")),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn operations_enumerates_both_halves_of_every_channel() {
+        let doc: Document = serde_json::from_value(wired()).unwrap();
+        let operations = doc.operations();
+        assert_eq!(operations.len(), 2);
+        assert_eq!(operations[0].1, OperationKind::Publish);
+        assert_eq!(operations[1].1, OperationKind::Subscribe);
+        assert_eq!(operations[0].0, "user/{userId}/signedup");
+
+        // A channel that is a `$ref` contributes nothing.
+        let mut referenced = minimal();
+        referenced["channels"] = json!({ "user": { "$ref": "./channels.yaml#/user" } });
+        let doc: Document = serde_json::from_value(referenced).unwrap();
+        assert!(doc.operations().is_empty());
+    }
+
+    #[test]
+    fn an_empty_channel_path_is_reported() {
+        let mut value = minimal();
+        value["channels"] = json!({ "": { "publish": {} } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e == "#.channels: a channel path must not be empty")
+        );
+    }
+
+    #[test]
+    fn root_tags_and_external_docs_are_validated() {
+        let mut value = minimal();
+        value["tags"] = json!([ { "name": "" } ]);
+        value["externalDocs"] = json!({ "url": "" });
+        let errors = errors_for(value);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.tags[0].name: must not be empty")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.externalDocs.url: must not be empty")
+        );
+    }
+
+    #[test]
+    fn empty_id_and_default_content_type_are_reported() {
+        let mut value = minimal();
+        value["id"] = json!("");
+        value["defaultContentType"] = json!("");
+        let errors = errors_for(value);
+        assert!(errors.iter().any(|e| e == "#.id: must not be empty"));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.defaultContentType: must not be empty")
+        );
+    }
+
+    #[test]
+    fn a_referenced_channel_is_validated_as_a_reference() {
+        let mut value = minimal();
+        value["channels"] = json!({ "user": { "$ref": "" } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e == "#.channels.user.$ref: must not be empty")
+        );
+    }
+
+    #[test]
+    fn full_document_round_trips_through_json() {
+        let doc: Document = serde_json::from_value(wired()).unwrap();
+        let json = serde_json::to_string(&doc).unwrap();
+        let reparsed: Document = serde_json::from_str(&json).unwrap();
+        assert_eq!(reparsed, doc);
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/document.rs
+++ b/crates/roas-asyncapi/src/v2_6/document.rs
@@ -8,7 +8,7 @@
 //! and a security requirement must name a declared scheme — listing
 //! scopes only where the scheme's type allows them.
 
-use crate::common::reference::{RefOr, Reference};
+use crate::common::reference::{RefOr, Reference, array_index, pointer_tokens};
 use crate::v2_6::channel_item::ChannelItem;
 use crate::v2_6::components::Components;
 use crate::v2_6::external_documentation::ExternalDocumentation;
@@ -118,68 +118,24 @@ impl<'a, T> Resolution<'a, T> {
     }
 }
 
-/// Whether a local pointer has the shape of a channel pointer, used to
-/// tell "names nothing" from "wrong kind entirely".
-fn channel_pointer_shape(pointer: &str) -> bool {
-    pointer.starts_with("/channels/") || pointer.starts_with("/components/channels/")
-}
-
-/// The same, for a message pointer.
-fn message_pointer_shape(pointer: &str) -> bool {
-    pointer.starts_with("/components/messages/") || pointer.starts_with("/channels/")
-}
-
-/// Split one RFC 6901 segment off a pointer and decode it.
+/// Walk a JSON Pointer over the document as plain JSON.
 ///
-/// A pointer travels in a URI fragment, so it is percent-encoded (RFC
-/// 3986) around escapes for the pointer's own separators (RFC 6901):
-/// `%20` is a space, `~1` is a `/`, and `~0` is a `~`. `source/path` is
-/// therefore *two* segments and cannot name one channel — that key is
-/// spelled `source~1path`.
-///
-/// Returns `None` when the segment is malformed: a `~` followed by
-/// anything but `0` or `1`, or a truncated / non-hex `%` escape. RFC
-/// 6901 leaves those undefined rather than literal.
-fn split_segment(pointer: &str) -> Option<(String, &str)> {
-    let (segment, rest) = match pointer.find('/') {
-        Some(i) => (&pointer[..i], &pointer[i..]),
-        None => (pointer, ""),
-    };
-    Some((decode_segment(segment)?, rest))
-}
-
-/// Percent-decode, then undo the RFC 6901 escapes.
-fn decode_segment(segment: &str) -> Option<String> {
-    let bytes = segment.as_bytes();
-    let mut percent_decoded = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' {
-            let hex = segment.get(i + 1..i + 3)?;
-            percent_decoded.push(u8::from_str_radix(hex, 16).ok()?);
-            i += 3;
-        } else {
-            percent_decoded.push(bytes[i]);
-            i += 1;
-        }
-    }
-    let decoded = String::from_utf8(percent_decoded).ok()?;
-
-    let mut out = String::with_capacity(decoded.len());
-    let mut chars = decoded.chars();
-    while let Some(c) = chars.next() {
-        if c != '~' {
-            out.push(c);
-            continue;
-        }
-        match chars.next() {
-            Some('0') => out.push('~'),
-            Some('1') => out.push('/'),
-            // `~` must be followed by `0` or `1`.
+/// `$ref` is an unrestricted URI-reference, so a pointer may legally
+/// name something this crate does not model as its own type — a
+/// message-shaped `x-` extension at the root, say. The typed resolvers
+/// answer "which object is this"; this answers the weaker but broader
+/// "is there anything here at all", which is what tells a wrong-kind
+/// pointer from one that simply names nothing.
+fn walk_json<'v>(value: &'v serde_json::Value, tokens: &[String]) -> Option<&'v serde_json::Value> {
+    let mut current = value;
+    for token in tokens {
+        current = match current {
+            serde_json::Value::Object(map) => map.get(token)?,
+            serde_json::Value::Array(items) => items.get(array_index(token)?)?,
             _ => return None,
-        }
+        };
     }
-    Some(out)
+    Some(current)
 }
 
 impl Document {
@@ -211,33 +167,53 @@ impl Document {
             }
             match self.channel_at(pointer) {
                 Some(next) => current = next,
-                None => {
-                    return match channel_pointer_shape(pointer) {
-                        true => Resolution::Missing,
-                        false => Resolution::Unrecognized,
-                    };
-                }
+                None => return self.classify_unresolved(pointer),
             }
+        }
+    }
+
+    /// Decide what an unresolved local pointer *is*, for pointers the
+    /// typed resolvers could not follow.
+    ///
+    /// A well-formed pointer that lands on real JSON is accepted: this
+    /// crate simply does not model whatever is there, which is not the
+    /// document's fault. Anything else is malformed or dangling.
+    fn classify_unresolved<T>(&self, pointer: &str) -> Resolution<'_, T> {
+        let Some(tokens) = pointer_tokens(pointer) else {
+            // Malformed escapes — not a usable pointer at all.
+            return Resolution::Unrecognized;
+        };
+        let Ok(snapshot) = serde_json::to_value(self) else {
+            return Resolution::Unrecognized;
+        };
+        match walk_json(&snapshot, &tokens) {
+            Some(_) => Resolution::External,
+            None => Resolution::Missing,
         }
     }
 
     /// The channel a document-local pointer names, in either map.
     fn channel_at<'a>(&'a self, pointer: &str) -> Option<&'a ChannelItem> {
-        let (map, rest) = self.channel_map_at(pointer)?;
-        let (key, rest) = split_segment(rest)?;
-        rest.is_empty().then(|| map.get(&key))?
+        let tokens = pointer_tokens(pointer)?;
+        let (map, key) = self.channel_map_for(&tokens)?;
+        (key.len() == 1).then(|| map.get(&key[0]))?
     }
 
-    /// The channel map a pointer addresses, and what follows the map's
-    /// own prefix.
-    fn channel_map_at<'a, 'p>(
+    /// The channel map a token sequence addresses, and the tokens left
+    /// after the map's own prefix.
+    fn channel_map_for<'a, 't>(
         &'a self,
-        pointer: &'p str,
-    ) -> Option<(&'a BTreeMap<String, ChannelItem>, &'p str)> {
-        if let Some(rest) = pointer.strip_prefix("/components/channels/") {
-            return Some((&self.components.as_ref()?.channels, rest));
+        tokens: &'t [String],
+    ) -> Option<(&'a BTreeMap<String, ChannelItem>, &'t [String])> {
+        match tokens {
+            [components, channels, rest @ ..]
+                if components == "components" && channels == "channels" =>
+            {
+                Some((&self.components.as_ref()?.channels, rest))
+            }
+            [channels, rest @ ..] if channels == "channels" => Some((&self.channels, rest)),
+            _ => None,
         }
-        Some((&self.channels, pointer.strip_prefix("/channels/")?))
     }
 
     fn security_scheme_at(&self, name: &str) -> Resolution<'_, SecurityScheme> {
@@ -289,20 +265,17 @@ impl Document {
                     }
                     // Either map may hold the target: `#/servers/…` as
                     // well as `#/components/servers/…`.
-                    let entry = if let Some(rest) = pointer.strip_prefix("/components/servers/") {
-                        match split_segment(rest) {
-                            Some((key, "")) => {
-                                self.components.as_ref().and_then(|c| c.servers.get(&key))
-                            }
-                            _ => return Resolution::Unrecognized,
-                        }
-                    } else if let Some(rest) = pointer.strip_prefix("/servers/") {
-                        match split_segment(rest) {
-                            Some((key, "")) => self.servers.get(&key),
-                            _ => return Resolution::Unrecognized,
-                        }
-                    } else {
+                    let Some(tokens) = pointer_tokens(pointer) else {
                         return Resolution::Unrecognized;
+                    };
+                    let entry = match tokens.as_slice() {
+                        [components, servers, key]
+                            if components == "components" && servers == "servers" =>
+                        {
+                            self.components.as_ref().and_then(|c| c.servers.get(key))
+                        }
+                        [servers, key] if servers == "servers" => self.servers.get(key),
+                        _ => return Resolution::Unrecognized,
                     };
                     match entry {
                         Some(next) => current = next,
@@ -331,13 +304,7 @@ impl Document {
             match self.message_at(pointer) {
                 Some(RefOr::Item(message)) => return Resolution::Found(message),
                 Some(RefOr::Reference(next)) => current = next.clone(),
-                None => {
-                    return if message_pointer_shape(pointer) {
-                        Resolution::Missing
-                    } else {
-                        Resolution::Unrecognized
-                    };
-                }
+                None => return self.classify_unresolved(pointer),
             }
         }
     }
@@ -350,44 +317,39 @@ impl Document {
     /// `$ref` resolves to, so a message declared beside a `$ref` is
     /// reachable and one on the target is not (through this pointer).
     fn message_at<'a>(&'a self, pointer: &str) -> Option<&'a RefOr<Message>> {
-        if let Some(rest) = pointer.strip_prefix("/components/messages/") {
-            let (key, rest) = split_segment(rest)?;
-            if !rest.is_empty() {
-                return None;
-            }
-            return self.components.as_ref()?.messages.get(&key);
+        let tokens = pointer_tokens(pointer)?;
+        if let [components, messages, key] = tokens.as_slice()
+            && components == "components"
+            && messages == "messages"
+        {
+            return self.components.as_ref()?.messages.get(key);
         }
 
-        // `#/channels/<path>/publish|subscribe/message[/oneOf/<i>]`,
-        // and the same under `#/components/channels/…`.
-        let (map, rest) = self.channel_map_at(pointer)?;
-        let (key, rest) = split_segment(rest)?;
-        let channel = map.get(&key)?;
-        let (kind, rest) = split_segment(rest.strip_prefix('/')?)?;
+        // `<channel map>/<path>/publish|subscribe/message[/oneOf/<i>]`
+        let (map, rest) = self.channel_map_for(&tokens)?;
+        let [key, kind, field, steps @ ..] = rest else {
+            return None;
+        };
+        let channel = map.get(key)?;
         let operation = match kind.as_str() {
             "publish" => channel.publish.as_ref()?,
             "subscribe" => channel.subscribe.as_ref()?,
             _ => return None,
         };
-        let (field, rest) = split_segment(rest.strip_prefix('/')?)?;
         if field != "message" {
             return None;
         }
         let mut message = operation.message.as_ref()?;
-        let mut rest = rest;
         // Walk any `oneOf/<index>` steps.
-        while !rest.is_empty() {
-            let (step, tail) = split_segment(rest.strip_prefix('/')?)?;
+        for pair in steps.chunks(2) {
+            let [step, index] = pair else { return None };
             if step != "oneOf" {
                 return None;
             }
-            let (index, tail) = split_segment(tail.strip_prefix('/')?)?;
-            let index: usize = index.parse().ok()?;
             let OperationMessage::OneOf(one_of) = message else {
                 return None;
             };
-            message = one_of.one_of.get(index)?;
-            rest = tail;
+            message = one_of.one_of.get(array_index(index)?)?;
         }
         match message {
             OperationMessage::Single(single) => Some(single.as_ref()),
@@ -449,16 +411,26 @@ impl Document {
     /// Every message the document declares, inline or in `components`,
     /// walking through `oneOf` sets.
     fn messages(&self) -> Vec<&Message> {
-        fn collect<'a>(message: &'a OperationMessage, found: &mut Vec<&'a Message>) {
+        fn collect<'a>(
+            document: &'a Document,
+            message: &'a OperationMessage,
+            found: &mut Vec<&'a Message>,
+        ) {
             match message {
-                OperationMessage::Single(single) => {
-                    if let Some(message) = single.item() {
-                        found.push(message);
+                // A referenced message is still *this* document's
+                // message, so it counts toward the document-wide
+                // `messageId` uniqueness rule.
+                OperationMessage::Single(single) => match single.as_ref() {
+                    RefOr::Item(message) => found.push(message),
+                    RefOr::Reference(reference) => {
+                        if let Some(message) = document.resolve_message(reference).found() {
+                            found.push(message);
+                        }
                     }
-                }
+                },
                 OperationMessage::OneOf(one_of) => {
                     for alternative in &one_of.one_of {
-                        collect(alternative, found);
+                        collect(document, alternative, found);
                     }
                 }
             }
@@ -467,17 +439,34 @@ impl Document {
         let mut found = Vec::new();
         if let Some(components) = &self.components {
             for message in components.messages.values() {
-                if let Some(message) = message.item() {
-                    found.push(message);
+                match message {
+                    RefOr::Item(message) => found.push(message),
+                    RefOr::Reference(reference) => {
+                        if let Some(message) = self.resolve_message(reference).found() {
+                            found.push(message);
+                        }
+                    }
                 }
             }
         }
         for (_, _, operation) in self.operations() {
             if let Some(message) = &operation.message {
-                collect(message, &mut found);
+                collect(self, message, &mut found);
             }
         }
-        found
+
+        // The same message is reachable more than once — as a
+        // component and through every reference to it — but it is one
+        // message, so it cannot collide with itself. Identity, not
+        // value: two distinct messages may be equal field for field and
+        // still both be errors if they share an id.
+        let mut distinct: Vec<&Message> = Vec::with_capacity(found.len());
+        for message in found {
+            if !distinct.iter().any(|seen| std::ptr::eq(*seen, message)) {
+                distinct.push(message);
+            }
+        }
+        distinct
     }
 
     /// Check that a message `$ref` resolves inside this document.
@@ -1258,25 +1247,50 @@ mod tests {
     }
 
     #[test]
-    fn pointers_of_the_wrong_kind_are_told_apart_from_missing_ones() {
-        // A local pointer that cannot denote a channel at all.
+    fn a_pointer_that_names_nothing_is_reported_wherever_it_points() {
+        // Outside the locations this crate models *and* absent from the
+        // document: dangling either way.
         let mut value = minimal();
-        value["channels"] = json!({ "user": { "$ref": "#/components/schemas/thing" } });
+        value["channels"] = json!({ "user": { "$ref": "#/components/schemas/ghost" } });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("names nothing in this document")),
+        );
+
+        let mut value = minimal();
+        value["channels"] = json!({
+            "user": { "publish": { "message": { "$ref": "#/components/schemas/ghost" } } }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("names nothing in this document")),
+        );
+
+        // A malformed pointer is a different problem again.
+        let mut value = minimal();
+        value["channels"] = json!({ "user": { "$ref": "#/channels/bad~2escape" } });
         assert!(
             errors_for(value)
                 .iter()
                 .any(|e| e.contains("does not point at an object of the expected kind")),
         );
+    }
 
-        // …and the same for a message.
+    #[test]
+    fn a_pointer_into_an_unmodeled_location_is_accepted() {
+        // `$ref` is an unrestricted URI-reference, so a message-shaped
+        // root extension is a legal target even though this crate does
+        // not model it as a `Message`.
         let mut value = minimal();
+        value["x-shared-message"] = json!({ "name": "Shared", "payload": { "type": "object" } });
         value["channels"] = json!({
-            "user": { "publish": { "message": { "$ref": "#/components/schemas/thing" } } }
+            "user": { "publish": { "message": { "$ref": "#/x-shared-message" } } }
         });
         assert!(
-            errors_for(value)
-                .iter()
-                .any(|e| e.contains("does not point at an object of the expected kind")),
+            errors_for(value).is_empty(),
+            "a pointer at real JSON elsewhere in the document is legal",
         );
     }
 
@@ -1365,12 +1379,20 @@ mod tests {
             "#/channels/source/publish/message/oneOf/x",   // non-numeric index
             "#/channels/source/publish/message/anyOf/0",   // not a oneOf step
             "#/channels/source/subscribe/message/oneOf/0", // not a set at all
-            "#/channels/source/publish/message",           // terminates on a set
+            "#/channels/source/publish/message/oneOf/01",  // leading zero
         ] {
             let mut value = base.clone();
             value["channels"]["target"]["subscribe"]["message"] = json!({ "$ref": pointer });
             assert!(!errors_for(value).is_empty(), "{pointer} must not resolve");
         }
+
+        // Pointing at the `oneOf` set itself lands on real JSON, so it
+        // is accepted: the crate does not model a set as a message, but
+        // the pointer is not the document's mistake.
+        let mut value = base;
+        value["channels"]["target"]["subscribe"]["message"] =
+            json!({ "$ref": "#/channels/source/publish/message" });
+        assert!(errors_for(value).is_empty());
     }
 
     #[test]
@@ -1576,6 +1598,111 @@ mod tests {
                 .count(),
             2,
             "both the channel item and the schema `$ref` count: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn message_ids_collide_through_references_too() {
+        // Two *distinct* messages sharing an id, one of them reached
+        // only through a pointer into a component channel.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "a": { "publish": { "message": { "messageId": "dup" } } },
+                "b": {
+                    "subscribe": {
+                        "message": { "$ref": "#/components/channels/source/publish/message" }
+                    }
+                }
+            },
+            "components": {
+                "channels": {
+                    "source": { "publish": { "message": { "messageId": "dup" } } }
+                }
+            }
+        });
+        assert!(
+            errors_for(value)
+                .iter()
+                .any(|e| e.contains("duplicate messageId `dup`")),
+            "a referenced message counts toward the document-wide rule",
+        );
+    }
+
+    #[test]
+    fn one_message_reached_twice_does_not_collide_with_itself() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "a": { "publish": { "message": { "$ref": "#/components/messages/shared" } } },
+                "b": { "subscribe": { "message": { "$ref": "#/components/messages/shared" } } }
+            },
+            "components": { "messages": { "shared": { "messageId": "once" } } }
+        });
+        assert!(errors_for(value).is_empty(), "identity, not reachability");
+    }
+
+    #[test]
+    fn percent_encoded_separators_stay_inside_a_key() {
+        // `%2F` decodes to a literal `/` *within* one token, so this
+        // names the single key `source/path`.
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source/path": { "publish": {} },
+                "alias": { "$ref": "#/channels/source%2Fpath" }
+            }
+        });
+        let doc: Document = serde_json::from_value(value.clone()).unwrap();
+        assert!(
+            doc.resolve_channel(&doc.channels["alias"])
+                .found()
+                .is_some()
+        );
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn a_security_alias_key_is_percent_decoded() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": { "user": { "publish": { "security": [ { "alias": [] } ] } } },
+            "components": {
+                "securitySchemes": {
+                    "alias": { "$ref": "#/components/securitySchemes/oauth%2Dscheme" },
+                    "oauth-scheme": { "type": "userPassword" }
+                }
+            }
+        });
+        assert!(
+            errors_for(value).is_empty(),
+            "`%2D` names the `-` in `oauth-scheme`",
+        );
+    }
+
+    #[test]
+    fn array_indices_reject_leading_zeros() {
+        let value = json!({
+            "asyncapi": "2.6.0",
+            "info": { "title": "T", "version": "1" },
+            "channels": {
+                "source": {
+                    "publish": { "message": { "oneOf": [ { "name": "A" }, { "name": "B" } ] } }
+                },
+                "target": {
+                    "subscribe": {
+                        "message": { "$ref": "#/channels/source/publish/message/oneOf/01" }
+                    }
+                }
+            }
+        });
+        assert!(
+            !errors_for(value).is_empty(),
+            "RFC 6901 forbids a leading zero in an array index",
         );
     }
 

--- a/crates/roas-asyncapi/src/v2_6/external_documentation.rs
+++ b/crates/roas-asyncapi/src/v2_6/external_documentation.rs
@@ -1,0 +1,51 @@
+//! AsyncAPI v2.6 `External Documentation` object.
+//!
+//! Per [External Documentation Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#externalDocumentationObject).
+
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct ExternalDocumentation {
+    /// **Required** The URL for the target documentation.
+    pub url: String,
+
+    /// A short description of the target documentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for ExternalDocumentation {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("url", &self.url);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn round_trips_and_requires_url() {
+        let value = json!({ "url": "https://example.com/docs", "description": "Docs" });
+        let docs: ExternalDocumentation = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&docs).unwrap(), value);
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.externalDocs");
+        docs.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.externalDocs");
+        ExternalDocumentation::default().validate_with_context(&mut ctx);
+        assert!(ctx.errors[0] == "#.externalDocs.url: must not be empty");
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/info.rs
+++ b/crates/roas-asyncapi/src/v2_6/info.rs
@@ -1,0 +1,202 @@
+//! AsyncAPI v2.6 `Info`, `Contact`, and `License` objects.
+//!
+//! Per [Info Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#infoObject).
+//!
+//! Unlike v3, 2.6's `info` carries no `tags` or `externalDocs` — those
+//! live at the document root.
+
+use crate::validation::{Context, ValidateWithContext, ValidationOptions};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Info {
+    /// **Required** The title of the application.
+    pub title: String,
+
+    /// **Required** The version of this application's API definition
+    /// (not the AsyncAPI version).
+    pub version: String,
+
+    /// A short description, CommonMark-formatted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// A URL to the Terms of Service for the API.
+    #[serde(rename = "termsOfService", skip_serializing_if = "Option::is_none")]
+    pub terms_of_service: Option<String>,
+
+    /// Contact information for the exposed API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact: Option<Contact>,
+
+    /// License information for the exposed API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<License>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Info {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoTitle) {
+            ctx.require_non_empty("title", &self.title);
+        }
+        if !ctx.is_option(ValidationOptions::IgnoreEmptyInfoVersion) {
+            ctx.require_non_empty("version", &self.version);
+        }
+        if let Some(contact) = &self.contact {
+            ctx.in_field("contact", |ctx| contact.validate_with_context(ctx));
+        }
+        if let Some(license) = &self.license {
+            ctx.in_field("license", |ctx| license.validate_with_context(ctx));
+        }
+    }
+}
+
+/// Contact information for the exposed API.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Contact {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Contact {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(email) = &self.email
+            && !email.contains('@')
+        {
+            ctx.error_field("email", "must be an email address");
+        }
+    }
+}
+
+/// License information for the exposed API.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct License {
+    /// **Required** The license name used for the API.
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for License {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("name", &self.name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn deserializes_full_info_and_round_trips() {
+        let value = json!({
+            "title": "Streetlights",
+            "version": "1.0.0",
+            "description": "Smart lighting",
+            "termsOfService": "https://example.com/tos",
+            "contact": { "name": "Ops", "email": "ops@example.com" },
+            "license": { "name": "Apache 2.0", "url": "https://example.com" },
+            "x-internal": true
+        });
+        let info: Info = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(info.title, "Streetlights");
+        assert_eq!(serde_json::to_value(&info).unwrap(), value);
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.info");
+        info.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn tags_and_external_docs_are_not_info_fields_in_2_6() {
+        // They belong to the document root here, so they are dropped
+        // as unknown keys rather than parsed.
+        let info: Info = serde_json::from_value(json!({
+            "title": "T",
+            "version": "1",
+            "tags": [ { "name": "x" } ],
+            "externalDocs": { "url": "https://e" }
+        }))
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(&info).unwrap(),
+            json!({ "title": "T", "version": "1" })
+        );
+    }
+
+    #[test]
+    fn empty_title_and_version_are_reported_unless_ignored() {
+        let info = Info::default();
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.info");
+        info.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.info.title: must not be empty")
+        );
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.info.version: must not be empty")
+        );
+
+        let mut ctx = Context::with_path(
+            ValidationOptions::IgnoreEmptyInfoTitle | ValidationOptions::IgnoreEmptyInfoVersion,
+            "#.info",
+        );
+        info.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn contact_email_and_license_name_are_checked() {
+        let info: Info = serde_json::from_value(json!({
+            "title": "T",
+            "version": "1",
+            "contact": { "email": "nope" },
+            "license": { "name": "" }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.info");
+        info.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.info.contact.email: must be an email address")
+        );
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.info.license.name: must not be empty")
+        );
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/message.rs
+++ b/crates/roas-asyncapi/src/v2_6/message.rs
@@ -14,7 +14,7 @@ use crate::common::bindings::Bindings;
 use crate::common::reference::RefOr;
 use crate::v2_6::correlation_id::CorrelationId;
 use crate::v2_6::external_documentation::ExternalDocumentation;
-use crate::v2_6::schema::SubSchema;
+use crate::v2_6::schema::{SchemaType, SubSchema};
 use crate::v2_6::tag::Tag;
 use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -245,7 +245,7 @@ impl ValidateWithContext for Message {
             ctx.require_non_empty("messageId", message_id);
         }
         if let Some(headers) = &self.headers {
-            ctx.in_field("headers", |ctx| headers.validate_with_context(ctx));
+            validate_headers(ctx, headers);
         }
         // A payload in the default dialect is a Schema Object and gets
         // the schema checks; one in a named foreign dialect does not.
@@ -275,15 +275,48 @@ impl ValidateWithContext for Message {
     }
 }
 
+/// Validate a headers schema, which must describe an *object*.
+///
+/// The schema pins `headers` to `allOf: [schema.json, { properties: {
+/// type: { const: "object" } } }]`, so a declared `type` has to be
+/// `object`. A boolean schema declares no type and stays valid.
+fn validate_headers(ctx: &mut Context, headers: &SubSchema) {
+    ctx.in_field("headers", |ctx| {
+        headers.validate_with_context(ctx);
+        if let SubSchema::Schema(schema) = headers {
+            match &schema.schema_type {
+                Some(SchemaType::Single(name)) if name != "object" => {
+                    ctx.error_field("type", format!("must be `object`, not `{name}`"));
+                }
+                Some(SchemaType::Multiple(names)) if !names.iter().all(|name| name == "object") => {
+                    ctx.error_field("type", "must be `object`");
+                }
+                _ => {}
+            }
+        }
+    });
+}
+
 /// Validate a tag list and enforce the schema's `uniqueItems: true`.
 ///
 /// Lives here because every object carrying tags needs it; the
 /// comparison is whole-value, as `uniqueItems` specifies.
 pub(crate) fn validate_tags(ctx: &mut Context, tags: &[Tag]) {
+    // `uniqueItems` compares JSON *instances*, where `1` and `1.0` are
+    // the same value — so serialize and use the schema module's
+    // instance equality rather than Rust's `PartialEq`, which would let
+    // two tags differing only by `x-order: 1` vs `1.0` through.
+    let as_json: Vec<serde_json::Value> = tags
+        .iter()
+        .map(|tag| serde_json::to_value(tag).unwrap_or(serde_json::Value::Null))
+        .collect();
     for (i, tag) in tags.iter().enumerate() {
         ctx.in_index("tags", i, |ctx| {
             tag.validate_with_context(ctx);
-            if tags[..i].contains(tag) {
+            if as_json[..i]
+                .iter()
+                .any(|seen| crate::v2_6::schema::json_instance_eq(seen, &as_json[i]))
+            {
                 ctx.error("duplicate tag");
             }
         });
@@ -353,7 +386,7 @@ impl ValidateWithContext for MessageTrait {
             ctx.require_non_empty("contentType", content_type);
         }
         if let Some(headers) = &self.headers {
-            ctx.in_field("headers", |ctx| headers.validate_with_context(ctx));
+            validate_headers(ctx, headers);
         }
         if let Some(correlation_id) = &self.correlation_id {
             ctx.in_field("correlationId", |ctx| {
@@ -574,6 +607,44 @@ mod tests {
                 .any(|e| e == "#.publish.message.oneOf[0].oneOf[0].contentType: must not be empty"),
             "got: {:?}",
             ctx.errors
+        );
+    }
+
+    #[test]
+    fn headers_must_describe_an_object() {
+        let errors = errors_for(json!({ "headers": { "type": "string" } }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.messages.signup.headers.type: must be `object`, not `string`"),
+            "got: {errors:?}"
+        );
+
+        assert!(errors_for(json!({ "headers": { "type": "object" } })).is_empty());
+        // No declared type, or a boolean schema, stays valid.
+        assert!(errors_for(json!({ "headers": { "properties": {} } })).is_empty());
+        assert!(errors_for(json!({ "headers": true })).is_empty());
+
+        // The list form must not admit anything but `object`.
+        assert!(
+            errors_for(json!({ "headers": { "type": ["object", "null"] } }))
+                .iter()
+                .any(|e| e.contains("headers.type: must be `object`"))
+        );
+    }
+
+    #[test]
+    fn tag_uniqueness_uses_json_instance_equality() {
+        // `x-order: 1` and `x-order: 1.0` are the same JSON instance,
+        // so these are duplicate tags.
+        let errors = errors_for(json!({
+            "tags": [ { "name": "a", "x-order": 1 }, { "name": "a", "x-order": 1.0 } ]
+        }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.messages.signup.tags[1]: duplicate tag"),
+            "got: {errors:?}"
         );
     }
 

--- a/crates/roas-asyncapi/src/v2_6/message.rs
+++ b/crates/roas-asyncapi/src/v2_6/message.rs
@@ -1,0 +1,535 @@
+//! AsyncAPI v2.6 `Message`, `Message Trait`, and `Message Example`
+//! objects.
+//!
+//! Per [Message Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#messageObject).
+//!
+//! Two shapes differ from v3. A message declares its payload dialect
+//! with its own `schemaFormat` field and carries the payload directly,
+//! where v3 wraps both in a Multi Format Schema Object. And an
+//! operation's `message` may be a *set* of alternatives — the
+//! `{ "oneOf": [...] }` form modeled by [`OperationMessage`] — which v3
+//! replaced with the channel's `messages` map.
+
+use crate::common::bindings::Bindings;
+use crate::common::reference::RefOr;
+use crate::v2_6::correlation_id::CorrelationId;
+use crate::v2_6::external_documentation::ExternalDocumentation;
+use crate::v2_6::schema::Schema;
+use crate::v2_6::tag::Tag;
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeMap;
+
+/// Keep an explicit `"payload": null` distinct from an absent one, so a
+/// null-payload example or message round-trips as written.
+fn deserialize_present_value<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    serde_json::Value::deserialize(deserializer).map(Some)
+}
+
+/// What an operation's `message` field holds: either one message (or a
+/// `$ref` to one), or a set of alternatives under `oneOf`.
+///
+/// Deserialization dispatches on the discriminating `oneOf` key.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum OperationMessage {
+    /// `{ "oneOf": [ … ] }` — the message is one of these.
+    OneOf(MessageOneOf),
+    /// A single message, inline or referenced.
+    Single(Box<RefOr<Message>>),
+}
+
+impl Default for OperationMessage {
+    fn default() -> Self {
+        Self::Single(Box::new(RefOr::Item(Message::default())))
+    }
+}
+
+impl<'de> Deserialize<'de> for OperationMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if value.get("oneOf").is_some() {
+            return serde_json::from_value(value)
+                .map(OperationMessage::OneOf)
+                .map_err(serde::de::Error::custom);
+        }
+        serde_json::from_value(value)
+            .map(|message| OperationMessage::Single(Box::new(message)))
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl ValidateWithContext for OperationMessage {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        match self {
+            OperationMessage::OneOf(one_of) => one_of.validate_with_context(ctx),
+            OperationMessage::Single(message) => message.validate_with_context(ctx),
+        }
+    }
+}
+
+/// The `{ "oneOf": [ … ] }` form of an operation's message.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct MessageOneOf {
+    /// **Required** The alternatives this operation may carry.
+    #[serde(rename = "oneOf")]
+    pub one_of: Vec<RefOr<Message>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for MessageOneOf {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if self.one_of.is_empty() {
+            ctx.error_field("oneOf", "must contain at least one message");
+        }
+        for (i, message) in self.one_of.iter().enumerate() {
+            ctx.in_index("oneOf", i, |ctx| message.validate_with_context(ctx));
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Message {
+    /// A machine-friendly identifier, unique across the document.
+    #[serde(rename = "messageId", skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+
+    /// The format of the `payload`, as a media type. Any string is
+    /// legal; when absent the payload is an AsyncAPI Schema Object.
+    #[serde(rename = "schemaFormat", skip_serializing_if = "Option::is_none")]
+    pub schema_format: Option<String>,
+
+    /// Schema definition of the application headers, which must
+    /// describe an object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<RefOr<Schema>>,
+
+    /// Definition of the message payload. Left as raw JSON because
+    /// `schemaFormat` may name a dialect this crate does not type; an
+    /// explicit `null` is preserved.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub payload: Option<serde_json::Value>,
+
+    /// Definition of the correlation ID used for message tracing.
+    #[serde(rename = "correlationId", skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<RefOr<CorrelationId>>,
+
+    /// The content type to use when encoding / decoding the payload.
+    #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<Tag>,
+
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bindings: Option<RefOr<Bindings>>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<MessageExample>,
+
+    /// Traits to apply to the message. Validated but not merged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub traits: Vec<RefOr<MessageTrait>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Message {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(format) = &self.schema_format {
+            ctx.require_non_empty("schemaFormat", format);
+        }
+        if let Some(content_type) = &self.content_type {
+            ctx.require_non_empty("contentType", content_type);
+        }
+        if let Some(message_id) = &self.message_id {
+            ctx.require_non_empty("messageId", message_id);
+        }
+        if let Some(headers) = &self.headers {
+            ctx.in_field("headers", |ctx| headers.validate_with_context(ctx));
+        }
+        if let Some(correlation_id) = &self.correlation_id {
+            ctx.in_field("correlationId", |ctx| {
+                correlation_id.validate_with_context(ctx);
+            });
+        }
+        for (i, tag) in self.tags.iter().enumerate() {
+            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
+        }
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+        if let Some(bindings) = &self.bindings {
+            ctx.in_field("bindings", |ctx| bindings.validate_with_context(ctx));
+        }
+        for (i, example) in self.examples.iter().enumerate() {
+            ctx.in_index("examples", i, |ctx| example.validate_with_context(ctx));
+        }
+        for (i, message_trait) in self.traits.iter().enumerate() {
+            ctx.in_index("traits", i, |ctx| message_trait.validate_with_context(ctx));
+        }
+    }
+}
+
+/// A trait that MAY be applied to a [`Message`].
+///
+/// Carries every Message field except `payload` and `traits`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct MessageTrait {
+    #[serde(rename = "messageId", skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+
+    #[serde(rename = "schemaFormat", skip_serializing_if = "Option::is_none")]
+    pub schema_format: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<RefOr<Schema>>,
+
+    #[serde(rename = "correlationId", skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<RefOr<CorrelationId>>,
+
+    #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<Tag>,
+
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bindings: Option<RefOr<Bindings>>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<MessageExample>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for MessageTrait {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(format) = &self.schema_format {
+            ctx.require_non_empty("schemaFormat", format);
+        }
+        if let Some(content_type) = &self.content_type {
+            ctx.require_non_empty("contentType", content_type);
+        }
+        if let Some(headers) = &self.headers {
+            ctx.in_field("headers", |ctx| headers.validate_with_context(ctx));
+        }
+        if let Some(correlation_id) = &self.correlation_id {
+            ctx.in_field("correlationId", |ctx| {
+                correlation_id.validate_with_context(ctx);
+            });
+        }
+        for (i, tag) in self.tags.iter().enumerate() {
+            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
+        }
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+        if let Some(bindings) = &self.bindings {
+            ctx.in_field("bindings", |ctx| bindings.validate_with_context(ctx));
+        }
+        for (i, example) in self.examples.iter().enumerate() {
+            ctx.in_index("examples", i, |ctx| example.validate_with_context(ctx));
+        }
+    }
+}
+
+/// An example of a message, carrying headers and / or a payload.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct MessageExample {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<BTreeMap<String, serde_json::Value>>,
+
+    /// An explicit `null` is preserved: presence is what satisfies the
+    /// headers-and/or-payload requirement.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub payload: Option<serde_json::Value>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for MessageExample {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if self.headers.is_none() && self.payload.is_none() {
+            ctx.error("must define `headers` and/or `payload`");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn errors_for(value: serde_json::Value) -> Vec<String> {
+        let message: Message = serde_json::from_value(value).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.messages.signup");
+        message.validate_with_context(&mut ctx);
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn round_trips_a_full_message() {
+        let value = json!({
+            "messageId": "userSignedUp",
+            "schemaFormat": "application/vnd.apache.avro;version=1.9.0",
+            "headers": { "type": "object", "properties": { "id": { "type": "string" } } },
+            "payload": { "type": "record", "name": "User" },
+            "correlationId": { "location": "$message.header#/id" },
+            "contentType": "application/json",
+            "name": "UserSignedUp",
+            "title": "User signed up",
+            "summary": "A user signed up",
+            "description": "Emitted on signup",
+            "deprecated": false,
+            "tags": [ { "name": "user" } ],
+            "externalDocs": { "url": "https://example.com" },
+            "bindings": { "kafka": { "key": { "type": "string" } } },
+            "examples": [ { "name": "basic", "payload": { "id": "1" } } ],
+            "traits": [ { "$ref": "#/components/messageTraits/common" } ],
+            "x-owner": "team"
+        });
+        let message: Message = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(message.message_id.as_deref(), Some("userSignedUp"));
+        assert_eq!(serde_json::to_value(&message).unwrap(), value);
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn any_schema_format_is_accepted() {
+        // 2.6 puts no enumeration on `schemaFormat` at all.
+        for format in [
+            "application/vnd.aai.asyncapi;version=2.6.0",
+            "application/vnd.apache.avro;version=1.9.0",
+            "application/vnd.example.custom+json;version=1.0",
+        ] {
+            let errors = errors_for(json!({ "schemaFormat": format, "payload": {} }));
+            assert!(errors.is_empty(), "{format}: {errors:?}");
+        }
+        assert!(
+            errors_for(json!({ "schemaFormat": "" }))
+                .iter()
+                .any(|e| e.contains("schemaFormat: must not be empty"))
+        );
+    }
+
+    #[test]
+    fn an_explicit_null_payload_is_preserved() {
+        let value = json!({ "payload": null });
+        let message: Message = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(message.payload, Some(serde_json::Value::Null));
+        assert_eq!(serde_json::to_value(&message).unwrap(), value);
+
+        let example: MessageExample =
+            serde_json::from_value(json!({ "name": "empty", "payload": null })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.examples[0]");
+        example.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn empty_message_is_valid_and_example_needs_content() {
+        assert!(errors_for(json!({})).is_empty());
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.examples[0]");
+        MessageExample::default().validate_with_context(&mut ctx);
+        assert!(ctx.errors[0] == "#.examples[0]: must define `headers` and/or `payload`");
+    }
+
+    #[test]
+    fn operation_message_picks_the_one_of_form_by_key() {
+        let value = json!({
+            "oneOf": [
+                { "name": "A" },
+                { "$ref": "#/components/messages/b" }
+            ]
+        });
+        let message: OperationMessage = serde_json::from_value(value.clone()).unwrap();
+        match &message {
+            OperationMessage::OneOf(one_of) => assert_eq!(one_of.one_of.len(), 2),
+            other => panic!("expected the oneOf form, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_value(&message).unwrap(), value);
+
+        let single: OperationMessage = serde_json::from_value(json!({ "name": "A" })).unwrap();
+        assert!(matches!(single, OperationMessage::Single(_)));
+
+        let referenced: OperationMessage =
+            serde_json::from_value(json!({ "$ref": "#/components/messages/a" })).unwrap();
+        assert!(matches!(referenced, OperationMessage::Single(_)));
+        assert!(matches!(
+            OperationMessage::default(),
+            OperationMessage::Single(_)
+        ));
+    }
+
+    #[test]
+    fn an_empty_one_of_is_reported_and_members_are_validated() {
+        let empty: OperationMessage = serde_json::from_value(json!({ "oneOf": [] })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.publish.message");
+        empty.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.publish.message.oneOf: must contain at least one message")
+        );
+
+        let members: OperationMessage =
+            serde_json::from_value(json!({ "oneOf": [ { "contentType": "" } ] })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.publish.message");
+        members.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.publish.message.oneOf[0].contentType: must not be empty")
+        );
+    }
+
+    #[test]
+    fn nested_errors_carry_their_path() {
+        let errors = errors_for(json!({
+            "messageId": "",
+            "headers": { "minItems": 2, "maxItems": 1 },
+            "correlationId": { "location": "nope" },
+            "contentType": "",
+            "tags": [ { "name": "" } ],
+            "externalDocs": { "url": "" },
+            "bindings": { "kafka": 1 },
+            "examples": [ {} ],
+            "traits": [ { "contentType": "" } ]
+        }));
+        for expected in [
+            "#.messages.signup.messageId: must not be empty",
+            "#.messages.signup.contentType: must not be empty",
+            "#.messages.signup.tags[0].name: must not be empty",
+            "#.messages.signup.externalDocs.url: must not be empty",
+            "#.messages.signup.examples[0]: must define `headers` and/or `payload`",
+            "#.messages.signup.traits[0].contentType: must not be empty",
+        ] {
+            assert!(
+                errors.iter().any(|e| e == expected),
+                "missing {expected}: {errors:?}"
+            );
+        }
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.starts_with("#.messages.signup.headers.minItems"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.starts_with("#.messages.signup.correlationId.location"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.starts_with("#.messages.signup.bindings.kafka"))
+        );
+    }
+
+    #[test]
+    fn trait_validates_its_own_nested_objects() {
+        let message_trait: MessageTrait = serde_json::from_value(json!({
+            "schemaFormat": "",
+            "headers": { "minLength": 5, "maxLength": 1 },
+            "correlationId": { "location": "bad" },
+            "tags": [ { "name": "" } ],
+            "externalDocs": { "url": "" },
+            "bindings": { "amqp": [] },
+            "examples": [ {} ]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.messageTraits.common");
+        message_trait.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        for needle in [
+            ".schemaFormat",
+            ".headers.minLength",
+            ".correlationId.location",
+            ".tags[0].name",
+            ".externalDocs.url",
+            ".bindings.amqp",
+            ".examples[0]",
+        ] {
+            assert!(
+                msgs.iter().any(|e| e.contains(needle)),
+                "missing {needle}: {msgs:?}"
+            );
+        }
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/message.rs
+++ b/crates/roas-asyncapi/src/v2_6/message.rs
@@ -288,8 +288,11 @@ fn validate_headers(ctx: &mut Context, headers: &SubSchema) {
                 Some(SchemaType::Single(name)) if name != "object" => {
                     ctx.error_field("type", format!("must be `object`, not `{name}`"));
                 }
-                Some(SchemaType::Multiple(names)) if !names.iter().all(|name| name == "object") => {
-                    ctx.error_field("type", "must be `object`");
+                // `const: "object"` constrains the whole `type` value,
+                // so the list form cannot satisfy it — not even
+                // `["object"]`.
+                Some(SchemaType::Multiple(_)) => {
+                    ctx.error_field("type", "must be the string `object`, not a list");
                 }
                 _ => {}
             }
@@ -625,12 +628,16 @@ mod tests {
         assert!(errors_for(json!({ "headers": { "properties": {} } })).is_empty());
         assert!(errors_for(json!({ "headers": true })).is_empty());
 
-        // The list form must not admit anything but `object`.
-        assert!(
-            errors_for(json!({ "headers": { "type": ["object", "null"] } }))
-                .iter()
-                .any(|e| e.contains("headers.type: must be `object`"))
-        );
+        // The list form never satisfies `const: "object"`, not even
+        // when every member is `object`.
+        for headers in [json!(["object", "null"]), json!(["object"])] {
+            assert!(
+                errors_for(json!({ "headers": { "type": headers } }))
+                    .iter()
+                    .any(|e| e.contains("must be the string `object`, not a list")),
+                "{headers} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/v2_6/message.rs
+++ b/crates/roas-asyncapi/src/v2_6/message.rs
@@ -14,11 +14,69 @@ use crate::common::bindings::Bindings;
 use crate::common::reference::RefOr;
 use crate::v2_6::correlation_id::CorrelationId;
 use crate::v2_6::external_documentation::ExternalDocumentation;
-use crate::v2_6::schema::Schema;
+use crate::v2_6::schema::SubSchema;
 use crate::v2_6::tag::Tag;
 use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
+
+/// The `schemaFormat` values that make a payload an AsyncAPI Schema
+/// Object — the document's own dialect in each of its three flavors,
+/// for every 2.x version.
+///
+/// When `schemaFormat` is absent it defaults to this dialect too, so a
+/// payload is a Schema Object unless the message names some *other*
+/// format (Avro, OpenAPI, RAML, draft-07 …), in which case its shape is
+/// that format's business and the payload stays raw JSON.
+pub const ASYNCAPI_SCHEMA_FORMATS: &[&str] = &[
+    "application/vnd.aai.asyncapi;version=2.0.0",
+    "application/vnd.aai.asyncapi;version=2.1.0",
+    "application/vnd.aai.asyncapi;version=2.2.0",
+    "application/vnd.aai.asyncapi;version=2.3.0",
+    "application/vnd.aai.asyncapi;version=2.4.0",
+    "application/vnd.aai.asyncapi;version=2.5.0",
+    "application/vnd.aai.asyncapi;version=2.6.0",
+    "application/vnd.aai.asyncapi+json;version=2.0.0",
+    "application/vnd.aai.asyncapi+json;version=2.1.0",
+    "application/vnd.aai.asyncapi+json;version=2.2.0",
+    "application/vnd.aai.asyncapi+json;version=2.3.0",
+    "application/vnd.aai.asyncapi+json;version=2.4.0",
+    "application/vnd.aai.asyncapi+json;version=2.5.0",
+    "application/vnd.aai.asyncapi+json;version=2.6.0",
+    "application/vnd.aai.asyncapi+yaml;version=2.0.0",
+    "application/vnd.aai.asyncapi+yaml;version=2.1.0",
+    "application/vnd.aai.asyncapi+yaml;version=2.2.0",
+    "application/vnd.aai.asyncapi+yaml;version=2.3.0",
+    "application/vnd.aai.asyncapi+yaml;version=2.4.0",
+    "application/vnd.aai.asyncapi+yaml;version=2.5.0",
+    "application/vnd.aai.asyncapi+yaml;version=2.6.0",
+];
+
+/// Whether a payload declared with this `schemaFormat` must be an
+/// AsyncAPI Schema Object.
+#[must_use]
+pub fn payload_is_asyncapi_schema(schema_format: Option<&str>) -> bool {
+    match schema_format {
+        None => true,
+        Some(format) => ASYNCAPI_SCHEMA_FORMATS.contains(&format),
+    }
+}
+
+/// Validate a payload that must be an AsyncAPI Schema Object.
+///
+/// The field is stored as raw JSON so any dialect round-trips, so the
+/// typing happens here: parse it as a [`SubSchema`] and run the usual
+/// schema checks, reporting a parse failure as a diagnostic rather than
+/// letting a malformed schema through.
+fn validate_schema_payload(ctx: &mut Context, payload: &serde_json::Value) {
+    match serde_json::from_value::<SubSchema>(payload.clone()) {
+        Ok(schema) => ctx.in_field("payload", |ctx| schema.validate_with_context(ctx)),
+        Err(err) => ctx.error_field(
+            "payload",
+            format!("is not a valid AsyncAPI Schema Object: {err}"),
+        ),
+    }
+}
 
 /// Keep an explicit `"payload": null` distinct from an absent one, so a
 /// null-payload example or message round-trips as written.
@@ -78,8 +136,12 @@ impl ValidateWithContext for OperationMessage {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct MessageOneOf {
     /// **Required** The alternatives this operation may carry.
+    ///
+    /// Each entry is a whole message *definition*, not just a message
+    /// object: the schema recurses into `message.json`, so an
+    /// alternative may itself be a `$ref` or another `oneOf` set.
     #[serde(rename = "oneOf")]
-    pub one_of: Vec<RefOr<Message>>,
+    pub one_of: Vec<OperationMessage>,
 
     /// `x-`-prefixed Specification Extensions.
     #[serde(flatten)]
@@ -113,7 +175,7 @@ pub struct Message {
     /// Schema definition of the application headers, which must
     /// describe an object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub headers: Option<RefOr<Schema>>,
+    pub headers: Option<SubSchema>,
 
     /// Definition of the message payload. Left as raw JSON because
     /// `schemaFormat` may name a dialect this crate does not type; an
@@ -152,10 +214,10 @@ pub struct Message {
     pub tags: Vec<Tag>,
 
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub external_docs: Option<ExternalDocumentation>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bindings: Option<RefOr<Bindings>>,
+    pub bindings: Option<Bindings>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub examples: Vec<MessageExample>,
@@ -185,14 +247,19 @@ impl ValidateWithContext for Message {
         if let Some(headers) = &self.headers {
             ctx.in_field("headers", |ctx| headers.validate_with_context(ctx));
         }
+        // A payload in the default dialect is a Schema Object and gets
+        // the schema checks; one in a named foreign dialect does not.
+        if let Some(payload) = &self.payload
+            && payload_is_asyncapi_schema(self.schema_format.as_deref())
+        {
+            validate_schema_payload(ctx, payload);
+        }
         if let Some(correlation_id) = &self.correlation_id {
             ctx.in_field("correlationId", |ctx| {
                 correlation_id.validate_with_context(ctx);
             });
         }
-        for (i, tag) in self.tags.iter().enumerate() {
-            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
-        }
+        validate_tags(ctx, &self.tags);
         if let Some(docs) = &self.external_docs {
             ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
         }
@@ -208,6 +275,21 @@ impl ValidateWithContext for Message {
     }
 }
 
+/// Validate a tag list and enforce the schema's `uniqueItems: true`.
+///
+/// Lives here because every object carrying tags needs it; the
+/// comparison is whole-value, as `uniqueItems` specifies.
+pub(crate) fn validate_tags(ctx: &mut Context, tags: &[Tag]) {
+    for (i, tag) in tags.iter().enumerate() {
+        ctx.in_index("tags", i, |ctx| {
+            tag.validate_with_context(ctx);
+            if tags[..i].contains(tag) {
+                ctx.error("duplicate tag");
+            }
+        });
+    }
+}
+
 /// A trait that MAY be applied to a [`Message`].
 ///
 /// Carries every Message field except `payload` and `traits`.
@@ -220,7 +302,7 @@ pub struct MessageTrait {
     pub schema_format: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub headers: Option<RefOr<Schema>>,
+    pub headers: Option<SubSchema>,
 
     #[serde(rename = "correlationId", skip_serializing_if = "Option::is_none")]
     pub correlation_id: Option<RefOr<CorrelationId>>,
@@ -247,10 +329,10 @@ pub struct MessageTrait {
     pub tags: Vec<Tag>,
 
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub external_docs: Option<ExternalDocumentation>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bindings: Option<RefOr<Bindings>>,
+    pub bindings: Option<Bindings>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub examples: Vec<MessageExample>,
@@ -278,9 +360,7 @@ impl ValidateWithContext for MessageTrait {
                 correlation_id.validate_with_context(ctx);
             });
         }
-        for (i, tag) in self.tags.iter().enumerate() {
-            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
-        }
+        crate::v2_6::message::validate_tags(ctx, &self.tags);
         if let Some(docs) = &self.external_docs {
             ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
         }
@@ -384,6 +464,146 @@ mod tests {
             errors_for(json!({ "schemaFormat": "" }))
                 .iter()
                 .any(|e| e.contains("schemaFormat: must not be empty"))
+        );
+    }
+
+    #[test]
+    fn a_default_dialect_payload_is_validated_as_a_schema() {
+        // Absent `schemaFormat` means the payload is an AsyncAPI Schema
+        // Object, so the schema checks apply to it.
+        let errors = errors_for(json!({ "payload": { "type": "bogus", "allOf": [] } }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.messages.signup.payload.type: `bogus` is not a JSON Schema type"),
+            "got: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(
+                |e| e == "#.messages.signup.payload.allOf: must contain at least one subschema"
+            ),
+            "got: {errors:?}"
+        );
+
+        // Naming an AsyncAPI dialect explicitly is the same thing.
+        let errors = errors_for(json!({
+            "schemaFormat": "application/vnd.aai.asyncapi;version=2.6.0",
+            "payload": { "type": "bogus" }
+        }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("is not a JSON Schema type"))
+        );
+
+        // A payload that is not a schema at all is reported rather than
+        // silently accepted.
+        let errors = errors_for(json!({ "payload": ["not", "a", "schema"] }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("is not a valid AsyncAPI Schema Object")),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn a_foreign_dialect_payload_is_left_alone() {
+        // Avro's `type: record` is not a JSON Schema type, and must not
+        // be judged as one.
+        for format in [
+            "application/vnd.apache.avro;version=1.9.0",
+            "application/schema+json;version=draft-07",
+            "application/vnd.example.custom+json;version=1.0",
+        ] {
+            let errors = errors_for(json!({
+                "schemaFormat": format,
+                "payload": { "type": "record", "name": "User", "allOf": [] }
+            }));
+            assert!(errors.is_empty(), "{format}: {errors:?}");
+            assert!(!payload_is_asyncapi_schema(Some(format)));
+        }
+        assert!(payload_is_asyncapi_schema(None));
+        for format in ASYNCAPI_SCHEMA_FORMATS {
+            assert!(payload_is_asyncapi_schema(Some(format)), "{format}");
+        }
+    }
+
+    #[test]
+    fn boolean_schemas_are_accepted_where_a_schema_is_expected() {
+        // draft-07 allows `true` / `false` as a whole schema.
+        let value = json!({ "headers": true, "payload": false });
+        let message: Message = serde_json::from_value(value.clone()).unwrap();
+        assert!(matches!(message.headers, Some(SubSchema::Bool(true))));
+        assert_eq!(serde_json::to_value(&message).unwrap(), value);
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn a_nested_one_of_round_trips() {
+        // The schema recurses into the whole message definition, so an
+        // alternative may itself be a `$ref` or another `oneOf`.
+        let value = json!({
+            "oneOf": [
+                { "name": "A" },
+                { "$ref": "#/components/messages/b" },
+                { "oneOf": [ { "name": "C" }, { "$ref": "#/components/messages/d" } ] }
+            ]
+        });
+        let message: OperationMessage = serde_json::from_value(value.clone()).unwrap();
+        match &message {
+            OperationMessage::OneOf(one_of) => {
+                assert_eq!(one_of.one_of.len(), 3);
+                assert!(matches!(one_of.one_of[2], OperationMessage::OneOf(_)));
+            }
+            other => panic!("expected the oneOf form, got {other:?}"),
+        }
+        // The nested alternative survives instead of collapsing to `{}`.
+        assert_eq!(serde_json::to_value(&message).unwrap(), value);
+
+        // Errors inside a nested alternative still carry their path.
+        let broken: OperationMessage = serde_json::from_value(json!({
+            "oneOf": [ { "oneOf": [ { "contentType": "" } ] } ]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.publish.message");
+        broken.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.publish.message.oneOf[0].oneOf[0].contentType: must not be empty"),
+            "got: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn tags_must_be_unique() {
+        let errors = errors_for(json!({
+            "tags": [ { "name": "a" }, { "name": "b" }, { "name": "a" } ]
+        }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.messages.signup.tags[2]: duplicate tag"),
+            "got: {errors:?}"
+        );
+
+        // Same name, different description, is a different tag value.
+        let errors = errors_for(json!({
+            "tags": [ { "name": "a" }, { "name": "a", "description": "d" } ]
+        }));
+        assert!(errors.is_empty(), "got: {errors:?}");
+    }
+
+    #[test]
+    fn external_docs_does_not_accept_a_reference() {
+        // 2.6 points at `externalDocs.json` directly, with no
+        // `oneOf: [Reference, …]`, so a `$ref` is not a valid value.
+        assert!(
+            serde_json::from_value::<Message>(json!({ "externalDocs": { "$ref": "#/x" } }))
+                .is_err(),
+            "a `$ref` must not parse as an External Documentation Object",
         );
     }
 

--- a/crates/roas-asyncapi/src/v2_6/mod.rs
+++ b/crates/roas-asyncapi/src/v2_6/mod.rs
@@ -1,0 +1,68 @@
+//! AsyncAPI v2.6 — see
+//! <https://www.asyncapi.com/docs/reference/specification/v2.6.0>.
+//!
+//! Authoritative JSON Schema:
+//! <https://asyncapi.com/schema-store/2.6.0.json>.
+//!
+//! This is the pre-v3 model, and it is a different document rather than
+//! an earlier draft of the same one:
+//!
+//! - `channels` is required and keyed by the channel *path*, which
+//!   carries the `{parameter}` placeholders. v3 gave a channel its own
+//!   key plus a separate `address`.
+//! - Operations live under a channel as `publish` / `subscribe`, named
+//!   from the *consumer's* point of view. v3 hoisted them to a
+//!   top-level map and inverted the naming to `send` / `receive`, from
+//!   the application's own point of view.
+//! - An operation's `message` may be a set of alternatives
+//!   (`{ "oneOf": [...] }`); v3 replaced that with the channel's
+//!   `messages` map.
+//! - A message declares its payload dialect with `schemaFormat` and
+//!   carries the payload directly, where v3 wraps both in a Multi
+//!   Format Schema Object.
+//! - A parameter carries a full `Schema`; v3 parameters are strings
+//!   constrained by `enum` / `default` / `examples`.
+//! - `security` is a list of OpenAPI-style requirement maps (name →
+//!   scopes) rather than inline schemes, and an OAuth flow's scope map
+//!   is spelled `scopes`, which v3 renamed to `availableScopes`.
+//! - `tags` and `externalDocs` sit at the document root; v3 moved them
+//!   under `info`.
+//! - A server is addressed by a single `url`, which v3 split into
+//!   `host` + `pathname`.
+//!
+//! Protocol bindings are held as raw JSON — see
+//! [`Bindings`] for why.
+
+pub mod channel_item;
+pub mod components;
+pub mod correlation_id;
+pub mod document;
+pub mod external_documentation;
+pub mod info;
+pub mod message;
+pub mod operation;
+pub mod parameter;
+pub mod schema;
+pub mod security_scheme;
+pub mod server;
+pub mod tag;
+pub mod version;
+
+pub use crate::common::bindings::Bindings;
+pub use crate::common::reference::{RefOr, Reference};
+pub use channel_item::ChannelItem;
+pub use components::Components;
+pub use correlation_id::CorrelationId;
+pub use document::Document;
+pub use external_documentation::ExternalDocumentation;
+pub use info::{Contact, Info, License};
+pub use message::{Message, MessageExample, MessageOneOf, MessageTrait, OperationMessage};
+pub use operation::{Operation, OperationKind, OperationTrait};
+pub use parameter::Parameter;
+pub use schema::{Dependency, Items, Schema, SchemaType, SubSchema};
+pub use security_scheme::{
+    ApiKeyLocation, OAuthFlow, OAuthFlows, SecurityRequirement, SecurityScheme, SecuritySchemeType,
+};
+pub use server::{Server, ServerVariable};
+pub use tag::Tag;
+pub use version::Version;

--- a/crates/roas-asyncapi/src/v2_6/operation.rs
+++ b/crates/roas-asyncapi/src/v2_6/operation.rs
@@ -68,11 +68,11 @@ pub struct Operation {
 
     /// Additional external documentation for this operation.
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub external_docs: Option<ExternalDocumentation>,
 
     /// Protocol-specific definitions for the operation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bindings: Option<RefOr<Bindings>>,
+    pub bindings: Option<Bindings>,
 
     /// Traits to apply to the operation. Validated but not merged.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -97,9 +97,7 @@ impl ValidateWithContext for Operation {
         for (i, requirement) in self.security.iter().enumerate() {
             ctx.in_index("security", i, |ctx| requirement.validate_with_context(ctx));
         }
-        for (i, tag) in self.tags.iter().enumerate() {
-            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
-        }
+        crate::v2_6::message::validate_tags(ctx, &self.tags);
         if let Some(docs) = &self.external_docs {
             ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
         }
@@ -136,10 +134,10 @@ pub struct OperationTrait {
     pub tags: Vec<Tag>,
 
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub external_docs: Option<ExternalDocumentation>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bindings: Option<RefOr<Bindings>>,
+    pub bindings: Option<Bindings>,
 
     /// `x-`-prefixed Specification Extensions.
     #[serde(flatten)]
@@ -156,9 +154,7 @@ impl ValidateWithContext for OperationTrait {
         for (i, requirement) in self.security.iter().enumerate() {
             ctx.in_index("security", i, |ctx| requirement.validate_with_context(ctx));
         }
-        for (i, tag) in self.tags.iter().enumerate() {
-            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
-        }
+        crate::v2_6::message::validate_tags(ctx, &self.tags);
         if let Some(docs) = &self.external_docs {
             ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
         }

--- a/crates/roas-asyncapi/src/v2_6/operation.rs
+++ b/crates/roas-asyncapi/src/v2_6/operation.rs
@@ -1,0 +1,275 @@
+//! AsyncAPI v2.6 `Operation` and `Operation Trait` objects.
+//!
+//! Per [Operation Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#operationObject).
+//!
+//! In 2.6 an operation is not a top-level object with an `action`: it
+//! is the `publish` or `subscribe` member of a channel, and those names
+//! are stated from the *consumer's* point of view — `publish` describes
+//! messages an application may publish *to* the channel, so the
+//! application described here receives them. v3 inverted this to
+//! `receive` / `send` stated from the application's own point of view.
+
+use crate::common::bindings::Bindings;
+use crate::common::reference::RefOr;
+use crate::v2_6::external_documentation::ExternalDocumentation;
+use crate::v2_6::message::OperationMessage;
+use crate::v2_6::security_scheme::SecurityRequirement;
+use crate::v2_6::tag::Tag;
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Which half of a channel an operation is.
+///
+/// Not a document field — the position under `publish` / `subscribe`
+/// carries it — but named so diagnostics and conversions can talk about
+/// it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperationKind {
+    /// Messages an application may publish to the channel; the
+    /// application described by this document *receives* them.
+    Publish,
+    /// Messages an application may subscribe to; the application
+    /// described by this document *sends* them.
+    Subscribe,
+}
+
+impl OperationKind {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Publish => "publish",
+            Self::Subscribe => "subscribe",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Operation {
+    /// A machine-friendly identifier, unique across the document.
+    #[serde(rename = "operationId", skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+
+    /// A short summary of what the operation is about.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// A verbose explanation, CommonMark-formatted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The security requirements for this operation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityRequirement>,
+
+    /// Tags for logical grouping and categorization of operations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<Tag>,
+
+    /// Additional external documentation for this operation.
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    /// Protocol-specific definitions for the operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bindings: Option<RefOr<Bindings>>,
+
+    /// Traits to apply to the operation. Validated but not merged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub traits: Vec<RefOr<OperationTrait>>,
+
+    /// The message (or set of alternatives) this operation carries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<OperationMessage>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Operation {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(operation_id) = &self.operation_id {
+            ctx.require_non_empty("operationId", operation_id);
+        }
+        for (i, requirement) in self.security.iter().enumerate() {
+            ctx.in_index("security", i, |ctx| requirement.validate_with_context(ctx));
+        }
+        for (i, tag) in self.tags.iter().enumerate() {
+            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
+        }
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+        if let Some(bindings) = &self.bindings {
+            ctx.in_field("bindings", |ctx| bindings.validate_with_context(ctx));
+        }
+        for (i, operation_trait) in self.traits.iter().enumerate() {
+            ctx.in_index("traits", i, |ctx| {
+                operation_trait.validate_with_context(ctx)
+            });
+        }
+        if let Some(message) = &self.message {
+            ctx.in_field("message", |ctx| message.validate_with_context(ctx));
+        }
+    }
+}
+
+/// A trait that MAY be applied to an [`Operation`].
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct OperationTrait {
+    #[serde(rename = "operationId", skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityRequirement>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<Tag>,
+
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bindings: Option<RefOr<Bindings>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for OperationTrait {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(operation_id) = &self.operation_id {
+            ctx.require_non_empty("operationId", operation_id);
+        }
+        for (i, requirement) in self.security.iter().enumerate() {
+            ctx.in_index("security", i, |ctx| requirement.validate_with_context(ctx));
+        }
+        for (i, tag) in self.tags.iter().enumerate() {
+            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
+        }
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+        if let Some(bindings) = &self.bindings {
+            ctx.in_field("bindings", |ctx| bindings.validate_with_context(ctx));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn errors_for(value: serde_json::Value) -> Vec<String> {
+        let operation: Operation = serde_json::from_value(value).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.channels.user.publish");
+        operation.validate_with_context(&mut ctx);
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn round_trips_a_full_operation() {
+        let value = json!({
+            "operationId": "receiveSignup",
+            "summary": "Consume signups",
+            "description": "Long form",
+            "security": [ { "user_pass": [] } ],
+            "tags": [ { "name": "user" } ],
+            "externalDocs": { "url": "https://example.com" },
+            "bindings": { "kafka": { "groupId": { "type": "string" } } },
+            "traits": [ { "$ref": "#/components/operationTraits/common" } ],
+            "message": { "name": "UserSignedUp" },
+            "x-owner": "team"
+        });
+        let operation: Operation = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(operation.operation_id.as_deref(), Some("receiveSignup"));
+        assert_eq!(serde_json::to_value(&operation).unwrap(), value);
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn an_empty_operation_is_valid() {
+        // Every field is optional in 2.6 — a channel may declare
+        // `publish: {}` to say "messages flow here" and nothing more.
+        assert!(errors_for(json!({})).is_empty());
+    }
+
+    #[test]
+    fn operation_kind_names_itself() {
+        assert_eq!(OperationKind::Publish.as_str(), "publish");
+        assert_eq!(OperationKind::Subscribe.as_str(), "subscribe");
+        assert_ne!(OperationKind::Publish, OperationKind::Subscribe);
+    }
+
+    #[test]
+    fn nested_errors_carry_their_path() {
+        let errors = errors_for(json!({
+            "operationId": "",
+            "security": [ { "auth": ["read", "read"] } ],
+            "tags": [ { "name": "" } ],
+            "externalDocs": { "url": "" },
+            "bindings": { "kafka": 1 },
+            "traits": [ { "operationId": "" } ],
+            "message": { "oneOf": [] }
+        }));
+        for expected in [
+            "#.channels.user.publish.operationId: must not be empty",
+            "#.channels.user.publish.security[0].auth: duplicate scope `read`",
+            "#.channels.user.publish.tags[0].name: must not be empty",
+            "#.channels.user.publish.externalDocs.url: must not be empty",
+            "#.channels.user.publish.traits[0].operationId: must not be empty",
+            "#.channels.user.publish.message.oneOf: must contain at least one message",
+        ] {
+            assert!(
+                errors.iter().any(|e| e == expected),
+                "missing {expected}: {errors:?}"
+            );
+        }
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.starts_with("#.channels.user.publish.bindings.kafka"))
+        );
+    }
+
+    #[test]
+    fn operation_trait_validates_its_nested_objects() {
+        let operation_trait: OperationTrait = serde_json::from_value(json!({
+            "operationId": "",
+            "security": [ { "auth": ["a", "a"] } ],
+            "tags": [ { "name": "" } ],
+            "externalDocs": { "url": "" },
+            "bindings": { "amqp": 1 }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.operationTraits.common");
+        operation_trait.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        for needle in [
+            ".operationId",
+            ".security[0].auth",
+            ".tags[0].name",
+            ".externalDocs.url",
+            ".bindings.amqp",
+        ] {
+            assert!(
+                msgs.iter().any(|e| e.contains(needle)),
+                "missing {needle}: {msgs:?}"
+            );
+        }
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/parameter.rs
+++ b/crates/roas-asyncapi/src/v2_6/parameter.rs
@@ -2,14 +2,13 @@
 //!
 //! Per [Parameter Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#parameterObject).
 //!
-//! A 2.6 parameter carries a full [`Schema`], which is the field v3
+//! A 2.6 parameter carries a full [`SubSchema`], which is the field v3
 //! dropped: there a parameter is always a string constrained by `enum`
 //! / `default` / `examples`. Converting 2.6 → 3.0 therefore cannot
 //! preserve a non-string parameter schema.
 
-use crate::common::reference::RefOr;
 use crate::common::runtime_expression;
-use crate::v2_6::schema::Schema;
+use crate::v2_6::schema::SubSchema;
 use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -22,7 +21,7 @@ pub struct Parameter {
 
     /// Definition of the parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema: Option<RefOr<Schema>>,
+    pub schema: Option<SubSchema>,
 
     /// A runtime expression locating the parameter value inside the
     /// message, e.g. `$message.payload#/user/id`.
@@ -90,6 +89,17 @@ mod tests {
         let mut ctx = Context::with_path(EnumSet::empty(), "#.parameters.p");
         parameter.validate_with_context(&mut ctx);
         assert!(ctx.errors.is_empty());
+    }
+
+    #[test]
+    fn a_boolean_schema_is_accepted() {
+        // draft-07 allows `true` / `false` wherever a schema is
+        // expected, and a 2.6 parameter takes a full schema.
+        for value in [json!({ "schema": true }), json!({ "schema": false })] {
+            let parameter: Parameter = serde_json::from_value(value.clone()).unwrap();
+            assert!(matches!(parameter.schema, Some(SubSchema::Bool(_))));
+            assert_eq!(serde_json::to_value(&parameter).unwrap(), value);
+        }
     }
 
     #[test]

--- a/crates/roas-asyncapi/src/v2_6/parameter.rs
+++ b/crates/roas-asyncapi/src/v2_6/parameter.rs
@@ -1,0 +1,137 @@
+//! AsyncAPI v2.6 `Parameter` object.
+//!
+//! Per [Parameter Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#parameterObject).
+//!
+//! A 2.6 parameter carries a full [`Schema`], which is the field v3
+//! dropped: there a parameter is always a string constrained by `enum`
+//! / `default` / `examples`. Converting 2.6 → 3.0 therefore cannot
+//! preserve a non-string parameter schema.
+
+use crate::common::reference::RefOr;
+use crate::common::runtime_expression;
+use crate::v2_6::schema::Schema;
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Parameter {
+    /// A verbose explanation, CommonMark-formatted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Definition of the parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<RefOr<Schema>>,
+
+    /// A runtime expression locating the parameter value inside the
+    /// message, e.g. `$message.payload#/user/id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Parameter {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(location) = &self.location {
+            if location.is_empty() {
+                ctx.error_field("location", "must not be empty");
+            } else if let Err(err) = runtime_expression::parse(location) {
+                ctx.error_field(
+                    "location",
+                    format!(
+                        "`{location}` is not a valid runtime expression: {}",
+                        err.message()
+                    ),
+                );
+            }
+        }
+        if let Some(schema) = &self.schema {
+            ctx.in_field("schema", |ctx| schema.validate_with_context(ctx));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn round_trips_a_parameter_with_a_schema() {
+        let value = json!({
+            "description": "Street id",
+            "schema": { "type": "string", "pattern": "^[0-9]+$" },
+            "location": "$message.payload#/streetId"
+        });
+        let parameter: Parameter = serde_json::from_value(value.clone()).unwrap();
+        assert!(parameter.schema.is_some());
+        assert_eq!(serde_json::to_value(&parameter).unwrap(), value);
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.parameters.streetId");
+        parameter.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn a_parameter_schema_may_be_any_json_schema() {
+        // The v3 model cannot express this, which is why the 2.6 → 3.0
+        // conversion has to report it.
+        let parameter: Parameter = serde_json::from_value(json!({
+            "schema": { "type": "integer", "minimum": 1.0 }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.parameters.p");
+        parameter.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+    }
+
+    #[test]
+    fn empty_parameter_is_valid() {
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.parameters.p");
+        Parameter::default().validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+    }
+
+    #[test]
+    fn rejects_malformed_and_empty_location() {
+        for (location, needle) in [
+            ("payload#/id", "is not a valid runtime expression"),
+            ("$message.payload", "is not a valid runtime expression"),
+            ("", "must not be empty"),
+        ] {
+            let parameter = Parameter {
+                location: Some(location.to_owned()),
+                ..Default::default()
+            };
+            let mut ctx = Context::with_path(EnumSet::empty(), "#.parameters.p");
+            parameter.validate_with_context(&mut ctx);
+            assert!(
+                ctx.errors.iter().any(|e| e.contains(needle)),
+                "{location:?}: {:?}",
+                ctx.errors
+            );
+        }
+    }
+
+    #[test]
+    fn nested_schema_errors_carry_their_path() {
+        let parameter: Parameter =
+            serde_json::from_value(json!({ "schema": { "minItems": 2, "maxItems": 1 } })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.parameters.p");
+        parameter.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("#.parameters.p.schema.minItems")),
+            "got: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/schema.rs
+++ b/crates/roas-asyncapi/src/v2_6/schema.rs
@@ -9,7 +9,6 @@
 //! payload directly, so [`Message`](crate::v2_6::Message) holds an
 //! untyped payload and this type covers the default dialect only.
 
-use crate::common::reference::RefOr;
 use crate::v2_6::external_documentation::ExternalDocumentation;
 use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -31,12 +30,12 @@ where
 #[serde(untagged)]
 pub enum SubSchema {
     Bool(bool),
-    Schema(Box<RefOr<Schema>>),
+    Schema(Box<Schema>),
 }
 
 impl Default for SubSchema {
     fn default() -> Self {
-        Self::Schema(Box::new(RefOr::Item(Schema::default())))
+        Self::Schema(Box::default())
     }
 }
 
@@ -125,6 +124,16 @@ pub enum SchemaType {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Schema {
     // ---- identification ----
+    /// The draft-07 `$ref` keyword.
+    ///
+    /// It is a *keyword*, not a replacement for the schema, so
+    /// `description` and `x-` extensions may sit alongside it and are
+    /// preserved. draft-07 says an implementation ignores such siblings
+    /// when applying the schema; this crate keeps them so a document
+    /// round-trips as written.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+
     #[serde(rename = "$id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
@@ -319,7 +328,7 @@ const SIMPLE_TYPES: &[&str] = &[
 /// `1` and `1.0` are the same instance. `serde_json`'s `PartialEq`
 /// compares the stored representation instead and would call them
 /// different, which is why `uniqueItems` cannot use it.
-fn json_instance_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+pub(crate) fn json_instance_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
     use serde_json::Value;
     match (a, b) {
         (Value::Number(a), Value::Number(b)) => numbers_eq(a, b),
@@ -1122,10 +1131,10 @@ mod tests {
         SubSchema::Bool(true).validate_with_context(&mut ctx);
         assert!(ctx.errors.is_empty());
 
-        let nested = SubSchema::Schema(Box::new(RefOr::Item(Schema {
+        let nested = SubSchema::Schema(Box::new(Schema {
             discriminator: Some(String::new()),
             ..Default::default()
-        })));
+        }));
         let mut ctx = Context::with_path(EnumSet::empty(), "#.payload.additionalProperties");
         nested.validate_with_context(&mut ctx);
         assert!(

--- a/crates/roas-asyncapi/src/v2_6/schema.rs
+++ b/crates/roas-asyncapi/src/v2_6/schema.rs
@@ -289,7 +289,7 @@ pub struct Schema {
     pub discriminator: Option<String>,
 
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub external_docs: Option<ExternalDocumentation>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<bool>,

--- a/crates/roas-asyncapi/src/v2_6/schema.rs
+++ b/crates/roas-asyncapi/src/v2_6/schema.rs
@@ -1,0 +1,1146 @@
+//! AsyncAPI v2.6 `Schema` object.
+//!
+//! Per [Schema Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#schemaObject):
+//! JSON Schema draft-07 plus AsyncAPI's `discriminator` /
+//! `externalDocs` / `deprecated` additions.
+//!
+//! Unlike v3, 2.6 has no Multi Format Schema Object — a message names
+//! its dialect with its own `schemaFormat` field and carries the
+//! payload directly, so [`Message`](crate::v2_6::Message) holds an
+//! untyped payload and this type covers the default dialect only.
+
+use crate::common::reference::RefOr;
+use crate::v2_6::external_documentation::ExternalDocumentation;
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeMap;
+
+/// Keep an explicit `null` distinct from an absent property. Plain
+/// `Option<Value>` collapses both to `None`, which would drop a valid
+/// `"default": null` or `"const": null`.
+fn deserialize_present_value<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    serde_json::Value::deserialize(deserializer).map(Some)
+}
+
+/// A subschema: JSON Schema allows `true` / `false` wherever a schema
+/// is expected, so every child position accepts either.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum SubSchema {
+    Bool(bool),
+    Schema(Box<RefOr<Schema>>),
+}
+
+impl Default for SubSchema {
+    fn default() -> Self {
+        Self::Schema(Box::new(RefOr::Item(Schema::default())))
+    }
+}
+
+impl ValidateWithContext for SubSchema {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        match self {
+            SubSchema::Bool(_) => {}
+            SubSchema::Schema(s) => s.validate_with_context(ctx),
+        }
+    }
+}
+
+/// `items` is a single schema (every element) or a tuple of schemas
+/// (positional), per draft-07.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum Items {
+    Tuple(Vec<SubSchema>),
+    Single(Box<SubSchema>),
+}
+
+impl Items {
+    /// Validate under `items`, indexing each entry of the tuple form so
+    /// diagnostics read `…items[1]` rather than `…items`.
+    fn validate_under_items(&self, ctx: &mut Context) {
+        match self {
+            Items::Single(schema) => {
+                ctx.in_field("items", |ctx| schema.validate_with_context(ctx));
+            }
+            Items::Tuple(schemas) => {
+                // The tuple form is a `schemaArray`: `minItems: 1`.
+                if schemas.is_empty() {
+                    ctx.error_field("items", "must contain at least one subschema");
+                }
+                for (i, schema) in schemas.iter().enumerate() {
+                    ctx.in_index("items", i, |ctx| schema.validate_with_context(ctx));
+                }
+            }
+        }
+    }
+}
+
+/// A `dependencies` entry: either a schema that applies when the
+/// property is present, or the property names it requires.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum Dependency {
+    Required(Vec<String>),
+    Schema(SubSchema),
+}
+
+impl ValidateWithContext for Dependency {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        match self {
+            // The property-name form is a `stringArray`, so entries
+            // must be unique. The dependency is already the current
+            // path, so the index goes in the message.
+            Dependency::Required(names) => {
+                for (i, name) in names.iter().enumerate() {
+                    if names[..i].contains(name) {
+                        ctx.error(format!("duplicate entry `{name}` at index {i}"));
+                    }
+                }
+            }
+            Dependency::Schema(schema) => schema.validate_with_context(ctx),
+        }
+    }
+}
+
+/// The `type` keyword, which draft-07 allows to be a single name or a
+/// list of them.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum SchemaType {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+/// An AsyncAPI Schema Object — JSON Schema draft-07 plus AsyncAPI's own
+/// additions (`discriminator`, `externalDocs`, `deprecated`).
+///
+/// Every draft-07 keyword is modeled, so a schema round-trips
+/// unchanged. A payload in another dialect is not a `Schema` at all:
+/// the message declares a `schemaFormat` and its `payload` stays raw
+/// JSON.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Schema {
+    // ---- identification ----
+    #[serde(rename = "$id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// The `$schema` dialect declaration.
+    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    pub dialect: Option<String>,
+
+    #[serde(rename = "$comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub schema_type: Option<SchemaType>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+
+    /// An explicit `null` is preserved as `Some(Value::Null)`; absent
+    /// is `None`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default: Option<serde_json::Value>,
+
+    /// `minItems: 1` in the meta-schema, so an empty-but-present
+    /// `enum` is an error rather than an absent one — hence the
+    /// `Option`.
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<serde_json::Value>>,
+
+    /// An explicit `null` is preserved as `Some(Value::Null)`; absent
+    /// is `None`.
+    #[serde(
+        rename = "const",
+        default,
+        deserialize_with = "deserialize_present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub const_value: Option<serde_json::Value>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<serde_json::Value>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub definitions: BTreeMap<String, SubSchema>,
+
+    // ---- objects ----
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub properties: BTreeMap<String, SubSchema>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+
+    #[serde(
+        rename = "additionalProperties",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_properties: Option<SubSchema>,
+
+    #[serde(
+        rename = "patternProperties",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub pattern_properties: BTreeMap<String, SubSchema>,
+
+    #[serde(rename = "propertyNames", skip_serializing_if = "Option::is_none")]
+    pub property_names: Option<Box<SubSchema>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dependencies: BTreeMap<String, Dependency>,
+
+    #[serde(rename = "minProperties", skip_serializing_if = "Option::is_none")]
+    pub min_properties: Option<u64>,
+
+    #[serde(rename = "maxProperties", skip_serializing_if = "Option::is_none")]
+    pub max_properties: Option<u64>,
+
+    // ---- arrays ----
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Items>,
+
+    #[serde(rename = "additionalItems", skip_serializing_if = "Option::is_none")]
+    pub additional_items: Option<Box<SubSchema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contains: Option<Box<SubSchema>>,
+
+    #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
+    pub min_items: Option<u64>,
+
+    #[serde(rename = "maxItems", skip_serializing_if = "Option::is_none")]
+    pub max_items: Option<u64>,
+
+    #[serde(rename = "uniqueItems", skip_serializing_if = "Option::is_none")]
+    pub unique_items: Option<bool>,
+
+    // ---- strings ----
+    #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<u64>,
+
+    #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+
+    #[serde(rename = "contentMediaType", skip_serializing_if = "Option::is_none")]
+    pub content_media_type: Option<String>,
+
+    #[serde(rename = "contentEncoding", skip_serializing_if = "Option::is_none")]
+    pub content_encoding: Option<String>,
+
+    // ---- numbers ----
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<f64>,
+
+    #[serde(rename = "exclusiveMinimum", skip_serializing_if = "Option::is_none")]
+    pub exclusive_minimum: Option<f64>,
+
+    #[serde(rename = "exclusiveMaximum", skip_serializing_if = "Option::is_none")]
+    pub exclusive_maximum: Option<f64>,
+
+    #[serde(rename = "multipleOf", skip_serializing_if = "Option::is_none")]
+    pub multiple_of: Option<f64>,
+
+    // ---- composition ----
+    #[serde(rename = "allOf", skip_serializing_if = "Option::is_none")]
+    pub all_of: Option<Vec<SubSchema>>,
+
+    #[serde(rename = "anyOf", skip_serializing_if = "Option::is_none")]
+    pub any_of: Option<Vec<SubSchema>>,
+
+    #[serde(rename = "oneOf", skip_serializing_if = "Option::is_none")]
+    pub one_of: Option<Vec<SubSchema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub not: Option<Box<SubSchema>>,
+
+    #[serde(rename = "if", skip_serializing_if = "Option::is_none")]
+    pub if_schema: Option<Box<SubSchema>>,
+
+    #[serde(rename = "then", skip_serializing_if = "Option::is_none")]
+    pub then_schema: Option<Box<SubSchema>>,
+
+    #[serde(rename = "else", skip_serializing_if = "Option::is_none")]
+    pub else_schema: Option<Box<SubSchema>>,
+
+    // ---- AsyncAPI additions ----
+    /// The property name used to differentiate between other schemas.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<String>,
+
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    #[serde(rename = "readOnly", skip_serializing_if = "Option::is_none")]
+    pub read_only: Option<bool>,
+
+    #[serde(rename = "writeOnly", skip_serializing_if = "Option::is_none")]
+    pub write_only: Option<bool>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// The draft-07 `simpleTypes` enumeration.
+const SIMPLE_TYPES: &[&str] = &[
+    "array", "boolean", "integer", "null", "number", "object", "string",
+];
+
+/// JSON instance equality, per
+/// [draft-07 §4.2.3](https://json-schema.org/draft-07/json-schema-core#rfc.section.4.2.3).
+///
+/// Numbers are equal when they have the same *mathematical* value, so
+/// `1` and `1.0` are the same instance. `serde_json`'s `PartialEq`
+/// compares the stored representation instead and would call them
+/// different, which is why `uniqueItems` cannot use it.
+fn json_instance_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    use serde_json::Value;
+    match (a, b) {
+        (Value::Number(a), Value::Number(b)) => numbers_eq(a, b),
+        (Value::Array(a), Value::Array(b)) => {
+            a.len() == b.len() && a.iter().zip(b).all(|(a, b)| json_instance_eq(a, b))
+        }
+        (Value::Object(a), Value::Object(b)) => {
+            a.len() == b.len()
+                && a.iter()
+                    .all(|(key, a)| b.get(key).is_some_and(|b| json_instance_eq(a, b)))
+        }
+        _ => a == b,
+    }
+}
+
+/// Two JSON numbers with the same mathematical value.
+///
+/// Integers are compared as integers — going through `f64` would make
+/// distinct values above 2^53 collide, e.g. `9007199254740993` and
+/// `9007199254740992.0`. A mixed integer / float pair is equal only when
+/// the float is integral and converts back to exactly that integer.
+///
+/// ## Limits of the comparison
+///
+/// Non-integer literals are rounded to `f64` by the parser, before this
+/// function ever sees them, so two decimals that differ only past
+/// `f64`'s precision are indistinguishable here: `0.1` and
+/// `0.10000000000000001` both arrive as `0.1` and are reported as
+/// duplicates, and `9223372036854775807.0` arrives as
+/// `9223372036854775808.0` so it does not match the integer
+/// `9223372036854775807`.
+///
+/// Fixing that needs the original text, which means `serde_json`'s
+/// `arbitrary_precision`. That feature changes how *every*
+/// `serde_json::Value` serializes through other serializers — a YAML
+/// dump becomes `$serde_json::private::Number` marker maps — and Cargo
+/// feature unification would impose it on the sibling crates too. Both
+/// costs are worse than the edge case, which needs 17+ significant
+/// digits to trigger.
+fn numbers_eq(a: &serde_json::Number, b: &serde_json::Number) -> bool {
+    /// `None` when the number is not an exact integer.
+    fn as_integer(n: &serde_json::Number) -> Option<i128> {
+        n.as_u64()
+            .map(i128::from)
+            .or_else(|| n.as_i64().map(i128::from))
+    }
+
+    match (as_integer(a), as_integer(b)) {
+        (Some(a), Some(b)) => a == b,
+        (Some(int), None) | (None, Some(int)) => {
+            let float = if as_integer(a).is_some() { b } else { a };
+            // `serde_json` numbers never exceed u64 / i64, so the cast
+            // below cannot saturate into a false match.
+            float
+                .as_f64()
+                .is_some_and(|f| f.is_finite() && f.fract() == 0.0 && f as i128 == int)
+        }
+        (None, None) => match (a.as_f64(), b.as_f64()) {
+            (Some(a), Some(b)) => a == b,
+            _ => false,
+        },
+    }
+}
+
+/// Report the index of every entry that repeats an earlier one, per the
+/// meta-schema's `uniqueItems` on `stringArray`.
+fn check_unique_strings(ctx: &mut Context, field: &str, values: &[String]) {
+    for (i, value) in values.iter().enumerate() {
+        if values[..i].contains(value) {
+            ctx.in_index(field, i, |ctx| ctx.error("duplicate entry"));
+        }
+    }
+}
+
+impl ValidateWithContext for Schema {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        // ---- keyword constraints from the draft-07 meta-schema ----
+        match &self.schema_type {
+            Some(SchemaType::Single(name)) if !SIMPLE_TYPES.contains(&name.as_str()) => {
+                ctx.error_field("type", format!("`{name}` is not a JSON Schema type"));
+            }
+            Some(SchemaType::Single(_)) => {}
+            Some(SchemaType::Multiple(names)) => {
+                if names.is_empty() {
+                    ctx.error_field("type", "must contain at least one type");
+                }
+                for (i, name) in names.iter().enumerate() {
+                    if !SIMPLE_TYPES.contains(&name.as_str()) {
+                        ctx.in_index("type", i, |ctx| {
+                            ctx.error(format!("`{name}` is not a JSON Schema type"));
+                        });
+                    } else if names[..i].contains(name) {
+                        ctx.in_index("type", i, |ctx| ctx.error("duplicate type"));
+                    }
+                }
+            }
+            None => {}
+        }
+
+        if let Some(values) = &self.enum_values {
+            if values.is_empty() {
+                ctx.error_field("enum", "must contain at least one value");
+            }
+            for (i, value) in values.iter().enumerate() {
+                if values[..i].iter().any(|seen| json_instance_eq(seen, value)) {
+                    ctx.in_index("enum", i, |ctx| ctx.error("duplicate value"));
+                }
+            }
+        }
+
+        if let Some(multiple_of) = self.multiple_of
+            && multiple_of <= 0.0
+        {
+            ctx.error_field("multipleOf", "must be greater than zero");
+        }
+
+        check_bounds(
+            ctx,
+            "minLength",
+            self.min_length,
+            "maxLength",
+            self.max_length,
+        );
+        check_bounds(ctx, "minItems", self.min_items, "maxItems", self.max_items);
+        check_bounds(
+            ctx,
+            "minProperties",
+            self.min_properties,
+            "maxProperties",
+            self.max_properties,
+        );
+        if let (Some(min), Some(max)) = (self.minimum, self.maximum)
+            && min > max
+        {
+            ctx.error_field("minimum", "must not be greater than `maximum`");
+        }
+
+        // "The property name used MUST be defined at this schema and it
+        // MUST be in the required property list." *This* schema — the
+        // one carrying the discriminator — so a composition keyword
+        // does not delegate the obligation to its subschemas.
+        if let Some(discriminator) = &self.discriminator {
+            if discriminator.is_empty() {
+                ctx.error_field("discriminator", "must not be empty");
+            } else {
+                if !self.properties.contains_key(discriminator) {
+                    ctx.error_field(
+                        "discriminator",
+                        format!("property `{discriminator}` is not declared in `properties`"),
+                    );
+                }
+                if !self.required.contains(discriminator) {
+                    ctx.error_field(
+                        "discriminator",
+                        format!("property `{discriminator}` must be listed in `required`"),
+                    );
+                }
+            }
+        }
+
+        // `required` is a `stringArray`: entries must be unique. An
+        // empty property name is legal — JSON objects may have one.
+        check_unique_strings(ctx, "required", &self.required);
+
+        for (field, map) in [
+            ("properties", &self.properties),
+            ("patternProperties", &self.pattern_properties),
+            ("definitions", &self.definitions),
+        ] {
+            for (name, schema) in map {
+                ctx.in_key(field, name, |ctx| schema.validate_with_context(ctx));
+            }
+        }
+        for (name, dependency) in &self.dependencies {
+            ctx.in_key("dependencies", name, |ctx| {
+                dependency.validate_with_context(ctx);
+            });
+        }
+        if let Some(items) = &self.items {
+            items.validate_under_items(ctx);
+        }
+        for (field, list) in [
+            ("allOf", self.all_of.as_ref()),
+            ("anyOf", self.any_of.as_ref()),
+            ("oneOf", self.one_of.as_ref()),
+        ] {
+            let Some(list) = list else { continue };
+            if list.is_empty() {
+                ctx.error_field(field, "must contain at least one subschema");
+            }
+            for (i, schema) in list.iter().enumerate() {
+                ctx.in_index(field, i, |ctx| schema.validate_with_context(ctx));
+            }
+        }
+        for (field, schema) in [
+            ("additionalProperties", self.additional_properties.as_ref()),
+            ("propertyNames", self.property_names.as_deref()),
+            ("additionalItems", self.additional_items.as_deref()),
+            ("contains", self.contains.as_deref()),
+            ("not", self.not.as_deref()),
+            ("if", self.if_schema.as_deref()),
+            ("then", self.then_schema.as_deref()),
+            ("else", self.else_schema.as_deref()),
+        ] {
+            if let Some(schema) = schema {
+                ctx.in_field(field, |ctx| schema.validate_with_context(ctx));
+            }
+        }
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+    }
+}
+
+fn check_bounds(
+    ctx: &mut Context,
+    min_field: &str,
+    min: Option<u64>,
+    max_field: &str,
+    max: Option<u64>,
+) {
+    if let (Some(min), Some(max)) = (min, max)
+        && min > max
+    {
+        ctx.error_field(min_field, format!("must not be greater than `{max_field}`"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn parses_a_nested_object_schema_and_round_trips() {
+        let value = json!({
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+                "id": { "type": "string", "format": "uuid" },
+                "tags": { "type": "array", "items": { "type": "string" } },
+                "ref": { "$ref": "#/components/schemas/other" },
+                "anything": true
+            },
+            "additionalProperties": false,
+            "x-extra": 1
+        });
+        let schema: Schema = serde_json::from_value(value.clone()).unwrap();
+        assert!(matches!(schema.schema_type, Some(SchemaType::Single(ref t)) if t == "object"));
+        assert_eq!(schema.properties.len(), 4);
+        assert!(matches!(
+            schema.properties["anything"],
+            SubSchema::Bool(true)
+        ));
+        assert!(matches!(
+            schema.additional_properties,
+            Some(SubSchema::Bool(false))
+        ));
+        assert_eq!(serde_json::to_value(&schema).unwrap(), value);
+    }
+
+    #[test]
+    fn every_draft_07_keyword_round_trips() {
+        let value = json!({
+            "$id": "https://example.com/user.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$comment": "internal note",
+            "definitions": { "positiveInt": { "type": "integer", "minimum": 0.0 } },
+            "dependencies": {
+                "creditCard": ["billingAddress"],
+                "shipping": { "required": ["address"] }
+            },
+            "items": [ { "type": "string" }, { "type": "integer" } ],
+            "additionalItems": false,
+            "contentMediaType": "application/json",
+            "contentEncoding": "base64",
+            "propertyNames": { "pattern": "^[a-z]+$" },
+            "contains": { "type": "string" },
+            "if": { "required": ["a"] },
+            "then": { "required": ["b"] },
+            "else": true,
+            "not": { "type": "null" },
+            "allOf": [ { "type": "object" } ],
+            "anyOf": [ true ],
+            "oneOf": [ { "type": "string" } ],
+            "uniqueItems": true,
+            "multipleOf": 2.0,
+            "exclusiveMinimum": 1.0,
+            "exclusiveMaximum": 9.0,
+            "readOnly": true,
+            "writeOnly": false,
+            "deprecated": true,
+            "discriminator": "kind",
+            "externalDocs": { "url": "https://example.com" }
+        });
+        let schema: Schema = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(schema.id.as_deref(), Some("https://example.com/user.json"));
+        assert_eq!(schema.definitions.len(), 1);
+        assert!(matches!(
+            schema.dependencies["creditCard"],
+            Dependency::Required(_)
+        ));
+        assert!(matches!(
+            schema.dependencies["shipping"],
+            Dependency::Schema(_)
+        ));
+        assert!(matches!(schema.items, Some(Items::Tuple(ref t)) if t.len() == 2));
+        assert_eq!(serde_json::to_value(&schema).unwrap(), value);
+    }
+
+    #[test]
+    fn explicit_null_default_and_const_survive_a_round_trip() {
+        let value = json!({ "default": null, "const": null });
+        let schema: Schema = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(schema.default, Some(serde_json::Value::Null));
+        assert_eq!(schema.const_value, Some(serde_json::Value::Null));
+        assert_eq!(serde_json::to_value(&schema).unwrap(), value);
+
+        // An absent keyword stays absent.
+        let bare: Schema = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(bare.default, None);
+        assert_eq!(bare.const_value, None);
+        assert_eq!(serde_json::to_value(&bare).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn single_form_items_validate_under_items_without_an_index() {
+        let schema: Schema =
+            serde_json::from_value(json!({ "items": { "minItems": 2, "maxItems": 1 } })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("#.payload.items.minItems")),
+            "got: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn single_and_tuple_items_are_distinguished() {
+        let single: Schema =
+            serde_json::from_value(json!({ "items": { "type": "string" } })).unwrap();
+        assert!(matches!(single.items, Some(Items::Single(_))));
+        assert_eq!(
+            serde_json::to_value(&single).unwrap(),
+            json!({ "items": { "type": "string" } })
+        );
+
+        let tuple: Schema =
+            serde_json::from_value(json!({ "items": [ { "type": "string" }, false ] })).unwrap();
+        match tuple.items {
+            Some(Items::Tuple(ref t)) => {
+                assert_eq!(t.len(), 2);
+                assert!(matches!(t[1], SubSchema::Bool(false)));
+            }
+            ref other => panic!("expected a tuple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn meta_schema_keyword_constraints_are_enforced() {
+        // `type: []`, `oneOf: []`, `enum: []` and `multipleOf: 0` are
+        // all rejected by the meta-schema.
+        let schema: Schema = serde_json::from_value(json!({
+            "type": [],
+            "oneOf": [],
+            "enum": [],
+            "multipleOf": 0.0
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.type: must contain at least one type")
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.oneOf: must contain at least one subschema")
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.enum: must contain at least one value")
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.multipleOf: must be greater than zero")
+        );
+
+        // …and the empty arrays survive serialization rather than being
+        // silently dropped.
+        assert_eq!(
+            serde_json::to_value(&schema).unwrap(),
+            json!({ "type": [], "oneOf": [], "enum": [], "multipleOf": 0.0 })
+        );
+    }
+
+    #[test]
+    fn type_names_must_be_json_schema_types_and_unique() {
+        let schema: Schema =
+            serde_json::from_value(json!({ "type": ["string", "strng", "string"] })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.type[1]: `strng` is not a JSON Schema type")
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.type[2]: duplicate type")
+        );
+
+        let single: Schema = serde_json::from_value(json!({ "type": "objekt" })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        single.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.payload.type: `objekt` is not a JSON Schema type")
+        );
+
+        // Every simple type is accepted.
+        for name in SIMPLE_TYPES {
+            let ok: Schema = serde_json::from_value(json!({ "type": name })).unwrap();
+            let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+            ok.validate_with_context(&mut ctx);
+            assert!(ctx.errors.is_empty(), "{name}: {:?}", ctx.errors);
+        }
+    }
+
+    #[test]
+    fn enum_values_must_be_unique() {
+        let schema: Schema = serde_json::from_value(json!({ "enum": ["a", "b", "a"] })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.payload.enum[2]: duplicate value"),
+            "got: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn enum_uniqueness_uses_json_instance_equality() {
+        // Draft-07 compares numbers by mathematical value, so `1` and
+        // `1.0` are the same instance even though `serde_json`'s
+        // `PartialEq` calls them different.
+        for values in [
+            json!([1, 1.0]),
+            json!([1.5, 1.50]),
+            json!([0, -0.0]),
+            json!([{ "a": 1 }, { "a": 1.0 }]),
+            json!([[1, 2], [1.0, 2.0]]),
+        ] {
+            let schema: Schema = serde_json::from_value(json!({ "enum": values })).unwrap();
+            let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+            schema.validate_with_context(&mut ctx);
+            assert!(
+                ctx.errors
+                    .iter()
+                    .any(|e| e == "#.payload.enum[1]: duplicate value"),
+                "{values} should be a duplicate, got: {:?}",
+                ctx.errors
+            );
+        }
+
+        // …and genuinely distinct values still pass.
+        for values in [
+            json!([1, 2]),
+            json!([1, "1"]),
+            json!([{ "a": 1 }, { "a": 2 }]),
+            json!([{ "a": 1 }, { "b": 1 }]),
+            json!([[1, 2], [2, 1]]),
+            json!([null, false]),
+        ] {
+            let schema: Schema = serde_json::from_value(json!({ "enum": values })).unwrap();
+            let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+            schema.validate_with_context(&mut ctx);
+            assert!(ctx.errors.is_empty(), "{values}: {:?}", ctx.errors);
+        }
+    }
+
+    #[test]
+    fn large_integers_do_not_collide_through_f64() {
+        // 2^53 + 1 and 2^53 are distinct integers that share an `f64`
+        // representation, so comparing via `as_f64` would call them
+        // equal.
+        let schema: Schema = serde_json::from_value(json!({
+            "enum": [9007199254740993i64, 9007199254740992.0]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+
+        // The exact pairing is still a duplicate.
+        let exact: Schema = serde_json::from_value(json!({
+            "enum": [9007199254740992i64, 9007199254740992.0]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        exact.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.payload.enum[1]: duplicate value"),
+            "got: {:?}",
+            ctx.errors
+        );
+
+        // A float with a fractional part never equals an integer, and
+        // an out-of-range float does not saturate into a match.
+        for values in [
+            json!([2, 2.5]),
+            json!([1, 1e300]),
+            json!([-1, 18446744073709551615u64]),
+        ] {
+            let schema: Schema = serde_json::from_value(json!({ "enum": values })).unwrap();
+            let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+            schema.validate_with_context(&mut ctx);
+            assert!(ctx.errors.is_empty(), "{values}: {:?}", ctx.errors);
+        }
+    }
+
+    /// Pins the documented limit of `enum` uniqueness: the parser
+    /// rounds non-integer literals to `f64` before the comparison runs,
+    /// so decimals that differ only past `f64`'s precision cannot be
+    /// told apart. See `numbers_eq` for why preserving the exact text
+    /// costs more than it is worth here. If this test ever starts
+    /// failing, the underlying representation changed and the note on
+    /// `numbers_eq` needs revisiting.
+    #[test]
+    fn f64_rounding_bounds_what_enum_uniqueness_can_see() {
+        // Distinct decimals, but the same `f64` — reported as a
+        // duplicate even though draft-07 calls them different. Parsed
+        // from text, since a Rust literal would round identically (and
+        // clippy would flag it as excessive precision).
+        let rounded: Schema =
+            serde_json::from_str(r#"{"enum": [0.1, 0.10000000000000001]}"#).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        rounded.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.payload.enum[1]: duplicate value")
+        );
+
+        // The mirror image: `9223372036854775807.0` is parsed as
+        // 2^63, so it no longer matches the integer 2^63 - 1.
+        let widened: Schema = serde_json::from_value(json!({
+            "enum": [9223372036854775807i64, 9223372036854775807.0]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        widened.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn discriminator_must_be_declared_and_required() {
+        // Named but nothing declared at all.
+        let bare: Schema = serde_json::from_value(json!({ "discriminator": "kind" })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        bare.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        assert!(
+            msgs.iter()
+                .any(|e| e.contains("is not declared in `properties`"))
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e.contains("must be listed in `required`"))
+        );
+
+        // Declared, but not required.
+        let optional: Schema = serde_json::from_value(json!({
+            "discriminator": "kind",
+            "properties": { "kind": { "type": "string" } }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        optional.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e
+                    == "#.payload.discriminator: property `kind` must be listed in `required`"),
+            "got: {:?}",
+            ctx.errors
+        );
+
+        // Declared and required.
+        let ok: Schema = serde_json::from_value(json!({
+            "discriminator": "kind",
+            "required": ["kind"],
+            "properties": { "kind": { "type": "string" } }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        ok.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn string_arrays_allow_empty_names_but_not_duplicates() {
+        // `stringArray` constrains uniqueness, not non-emptiness — an
+        // empty property name is a legal JSON object key.
+        let schema: Schema = serde_json::from_value(json!({ "required": ["", "a", "a"] })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        assert_eq!(msgs, vec!["#.payload.required[2]: duplicate entry"]);
+
+        // The `dependencies` property-name form is a `stringArray` too.
+        let dependent: Schema =
+            serde_json::from_value(json!({ "dependencies": { "card": ["a", "a"] } })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        dependent.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.payload.dependencies.card: duplicate entry `a` at index 1"),
+            "got: {:?}",
+            ctx.errors
+        );
+    }
+
+    #[test]
+    fn an_empty_items_tuple_is_rejected() {
+        let schema: Schema = serde_json::from_value(json!({ "items": [] })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.payload.items: must contain at least one subschema"),
+            "got: {:?}",
+            ctx.errors
+        );
+        // …and it round-trips rather than being dropped.
+        assert_eq!(
+            serde_json::to_value(&schema).unwrap(),
+            json!({ "items": [] })
+        );
+    }
+
+    #[test]
+    fn positive_multiple_of_and_populated_compositions_pass() {
+        let schema: Schema = serde_json::from_value(json!({
+            "multipleOf": 2.5,
+            "allOf": [ { "type": "object" } ],
+            "anyOf": [ true ],
+            "oneOf": [ { "type": "string" } ],
+            "enum": ["a"],
+            "type": ["string", "null"]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn type_accepts_a_list_of_names() {
+        let schema: Schema = serde_json::from_value(json!({ "type": ["string", "null"] })).unwrap();
+        match schema.schema_type {
+            Some(SchemaType::Multiple(ref t)) => assert_eq!(t, &["string", "null"]),
+            other => panic!("expected multiple types, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inverted_bounds_are_reported() {
+        let schema: Schema = serde_json::from_value(json!({
+            "minLength": 5, "maxLength": 1,
+            "minItems": 3, "maxItems": 2,
+            "minProperties": 4, "maxProperties": 1,
+            "minimum": 10.0, "maximum": 1.0
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        for field in ["minLength", "minItems", "minProperties", "minimum"] {
+            assert!(
+                ctx.errors.iter().any(|e| e.contains(field)),
+                "expected an error for {field}, got: {:?}",
+                ctx.errors
+            );
+        }
+    }
+
+    #[test]
+    fn discriminator_must_name_a_declared_property() {
+        let schema: Schema = serde_json::from_value(json!({
+            "type": "object",
+            "discriminator": "kind",
+            "properties": { "other": { "type": "string" } }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e.contains("property `kind` is not declared")),
+            "got: {:?}",
+            ctx.errors
+        );
+
+        // A composition keyword does not delegate the obligation: the
+        // property must be defined at *this* schema either way.
+        let composed: Schema = serde_json::from_value(json!({
+            "discriminator": "kind",
+            "properties": { "other": { "type": "string" } },
+            "oneOf": [ { "$ref": "#/components/schemas/a" } ]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        composed.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        assert!(
+            msgs.iter()
+                .any(|e| e.contains("is not declared in `properties`"))
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e.contains("must be listed in `required`"))
+        );
+
+        // The idiomatic base schema — which declares and requires the
+        // discriminator, and is inherited via `allOf` elsewhere — still
+        // passes with a composition keyword present.
+        let base: Schema = serde_json::from_value(json!({
+            "discriminator": "petType",
+            "required": ["petType"],
+            "properties": { "petType": { "type": "string" } },
+            "oneOf": [ { "$ref": "#/components/schemas/cat" } ]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        base.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty(), "got: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn nested_schema_errors_carry_their_path() {
+        let schema: Schema = serde_json::from_value(json!({
+            "properties": { "a": { "minItems": 2, "maxItems": 1 } },
+            "patternProperties": { "^x-": { "minLength": 2, "maxLength": 1 } },
+            "definitions": { "d": { "minimum": 5.0, "maximum": 1.0 } },
+            "dependencies": { "dep": { "minItems": 2, "maxItems": 1 } },
+            "items": [ { "minItems": 2, "maxItems": 1 } ],
+            "additionalItems": { "discriminator": "" },
+            "additionalProperties": { "minLength": 5, "maxLength": 1 },
+            "oneOf": [ { "minimum": 5.0, "maximum": 1.0 } ],
+            "not": { "discriminator": "" },
+            "externalDocs": { "url": "" },
+            "required": ["a", "a"]
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload");
+        schema.validate_with_context(&mut ctx);
+        let msgs: Vec<_> = ctx.errors.iter().map(ToString::to_string).collect();
+        for expected in [
+            "#.payload.properties.a.minItems",
+            "#.payload.patternProperties.^x-.minLength",
+            "#.payload.definitions.d.minimum",
+            "#.payload.dependencies.dep.minItems",
+            "#.payload.items[0].minItems",
+            "#.payload.additionalItems.discriminator",
+            "#.payload.additionalProperties.minLength",
+            "#.payload.oneOf[0].minimum",
+            "#.payload.not.discriminator",
+        ] {
+            assert!(
+                msgs.iter().any(|e| e.starts_with(expected)),
+                "expected {expected}, got: {msgs:?}"
+            );
+        }
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.externalDocs.url: must not be empty")
+        );
+        assert!(
+            msgs.iter()
+                .any(|e| e == "#.payload.required[1]: duplicate entry")
+        );
+    }
+
+    #[test]
+    fn sub_schema_validates_only_the_schema_arm() {
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload.additionalProperties");
+        SubSchema::Bool(true).validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+
+        let nested = SubSchema::Schema(Box::new(RefOr::Item(Schema {
+            discriminator: Some(String::new()),
+            ..Default::default()
+        })));
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload.additionalProperties");
+        nested.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.payload.additionalProperties.discriminator: must not be empty")
+        );
+        assert!(matches!(SubSchema::default(), SubSchema::Schema(_)));
+    }
+
+    #[test]
+    fn dependency_required_form_needs_no_validation() {
+        let dependency: Dependency = serde_json::from_value(json!(["a", "b"])).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.payload.dependencies.d");
+        dependency.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/schema.rs
+++ b/crates/roas-asyncapi/src/v2_6/schema.rs
@@ -405,6 +405,10 @@ fn check_unique_strings(ctx: &mut Context, field: &str, values: &[String]) {
 
 impl ValidateWithContext for Schema {
     fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(reference) = &self.reference {
+            ctx.require_non_empty("$ref", reference);
+            crate::common::reference::check_external(ctx, reference);
+        }
         // ---- keyword constraints from the draft-07 meta-schema ----
         match &self.schema_type {
             Some(SchemaType::Single(name)) if !SIMPLE_TYPES.contains(&name.as_str()) => {

--- a/crates/roas-asyncapi/src/v2_6/security_scheme.rs
+++ b/crates/roas-asyncapi/src/v2_6/security_scheme.rs
@@ -1,0 +1,610 @@
+//! AsyncAPI v2.6 `Security Scheme`, `Security Requirement`, and OAuth 2
+//! flow objects.
+//!
+//! Per [Security Scheme Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#securitySchemeObject).
+//!
+//! Two shapes differ from v3. A *requirement* here is the OpenAPI-style
+//! map of scheme name → scopes ([`SecurityRequirement`]), where v3
+//! carries a list of schemes inline. And an OAuth flow spells its scope
+//! map `scopes`, which v3 renamed to `availableScopes`.
+
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A map of security scheme name → the scopes it requires.
+///
+/// The scope list must be empty for every scheme type except `oauth2`
+/// and `openIdConnect`; the document validator checks that, since only
+/// it can resolve a name to its scheme.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+#[serde(transparent)]
+pub struct SecurityRequirement(pub BTreeMap<String, Vec<String>>);
+
+impl SecurityRequirement {
+    /// The scopes required for `name`, if the requirement names it.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&Vec<String>> {
+        self.0.get(name)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl ValidateWithContext for SecurityRequirement {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        for (name, scopes) in &self.0 {
+            // `uniqueItems` on the scope array.
+            for (i, scope) in scopes.iter().enumerate() {
+                if scopes[..i].contains(scope) {
+                    ctx.error_field(name, format!("duplicate scope `{scope}`"));
+                }
+            }
+        }
+    }
+}
+
+/// The `type` discriminator of a security scheme.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+pub enum SecuritySchemeType {
+    #[default]
+    #[serde(rename = "userPassword")]
+    UserPassword,
+    #[serde(rename = "apiKey")]
+    ApiKey,
+    #[serde(rename = "X509")]
+    X509,
+    #[serde(rename = "symmetricEncryption")]
+    SymmetricEncryption,
+    #[serde(rename = "asymmetricEncryption")]
+    AsymmetricEncryption,
+    #[serde(rename = "httpApiKey")]
+    HttpApiKey,
+    #[serde(rename = "http")]
+    Http,
+    #[serde(rename = "oauth2")]
+    OAuth2,
+    #[serde(rename = "openIdConnect")]
+    OpenIdConnect,
+    #[serde(rename = "plain")]
+    Plain,
+    #[serde(rename = "scramSha256")]
+    ScramSha256,
+    #[serde(rename = "scramSha512")]
+    ScramSha512,
+    #[serde(rename = "gssapi")]
+    Gssapi,
+}
+
+impl SecuritySchemeType {
+    /// The `type` value as it appears in a document.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UserPassword => "userPassword",
+            Self::ApiKey => "apiKey",
+            Self::X509 => "X509",
+            Self::SymmetricEncryption => "symmetricEncryption",
+            Self::AsymmetricEncryption => "asymmetricEncryption",
+            Self::HttpApiKey => "httpApiKey",
+            Self::Http => "http",
+            Self::OAuth2 => "oauth2",
+            Self::OpenIdConnect => "openIdConnect",
+            Self::Plain => "plain",
+            Self::ScramSha256 => "scramSha256",
+            Self::ScramSha512 => "scramSha512",
+            Self::Gssapi => "gssapi",
+        }
+    }
+
+    /// Whether a security requirement naming this scheme may list
+    /// scopes.
+    #[must_use]
+    pub fn takes_scopes(self) -> bool {
+        matches!(self, Self::OAuth2 | Self::OpenIdConnect)
+    }
+}
+
+/// Where an API key lives.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiKeyLocation {
+    User,
+    Password,
+    Query,
+    Header,
+    Cookie,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct SecurityScheme {
+    /// **Required** The type of the security scheme.
+    #[serde(rename = "type")]
+    pub scheme_type: SecuritySchemeType,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// **Required for `apiKey` / `httpApiKey`** — where the key is
+    /// carried.
+    #[serde(rename = "in", skip_serializing_if = "Option::is_none")]
+    pub in_: Option<ApiKeyLocation>,
+
+    /// **Required for `httpApiKey`** — the header / query / cookie name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// **Required for `http`** — the HTTP Authorization scheme.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
+
+    #[serde(rename = "bearerFormat", skip_serializing_if = "Option::is_none")]
+    pub bearer_format: Option<String>,
+
+    /// **Required for `oauth2`** — the supported flows.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flows: Option<OAuthFlows>,
+
+    /// **Required for `openIdConnect`** — the discovery URL.
+    #[serde(rename = "openIdConnectUrl", skip_serializing_if = "Option::is_none")]
+    pub open_id_connect_url: Option<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl SecurityScheme {
+    /// The fields this scheme's `type` may carry, beyond `type`,
+    /// `description`, and `x-` extensions.
+    fn allowed_fields(&self) -> &'static [&'static str] {
+        match self.scheme_type {
+            SecuritySchemeType::ApiKey => &["in"],
+            SecuritySchemeType::HttpApiKey => &["in", "name"],
+            SecuritySchemeType::Http => &["scheme", "bearerFormat"],
+            SecuritySchemeType::OAuth2 => &["flows"],
+            SecuritySchemeType::OpenIdConnect => &["openIdConnectUrl"],
+            _ => &[],
+        }
+    }
+
+    /// Report any field belonging to a different variant — each branch
+    /// of the schema's `oneOf` is `additionalProperties: false`.
+    fn check_forbidden_fields(&self, ctx: &mut Context) {
+        let allowed = self.allowed_fields();
+        for (field, present) in [
+            ("in", self.in_.is_some()),
+            ("name", self.name.is_some()),
+            ("scheme", self.scheme.is_some()),
+            ("bearerFormat", self.bearer_format.is_some()),
+            ("flows", self.flows.is_some()),
+            ("openIdConnectUrl", self.open_id_connect_url.is_some()),
+        ] {
+            if present && !allowed.contains(&field) {
+                ctx.error_field(
+                    field,
+                    format!(
+                        "is not allowed on a `{}` security scheme",
+                        self.scheme_type.as_str()
+                    ),
+                );
+            }
+        }
+    }
+}
+
+impl ValidateWithContext for SecurityScheme {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        self.check_forbidden_fields(ctx);
+        match self.scheme_type {
+            SecuritySchemeType::ApiKey => match self.in_ {
+                None => ctx.error_field("in", "is required for the `apiKey` type"),
+                Some(ApiKeyLocation::User | ApiKeyLocation::Password) => {}
+                Some(_) => ctx.error_field("in", "must be `user` or `password` for `apiKey`"),
+            },
+            SecuritySchemeType::HttpApiKey => {
+                match self.in_ {
+                    None => ctx.error_field("in", "is required for the `httpApiKey` type"),
+                    Some(
+                        ApiKeyLocation::Query | ApiKeyLocation::Header | ApiKeyLocation::Cookie,
+                    ) => {}
+                    Some(_) => ctx.error_field(
+                        "in",
+                        "must be `query`, `header` or `cookie` for `httpApiKey`",
+                    ),
+                }
+                match &self.name {
+                    None => ctx.error_field("name", "is required for the `httpApiKey` type"),
+                    Some(name) => ctx.require_non_empty("name", name),
+                }
+            }
+            SecuritySchemeType::Http => {
+                match &self.scheme {
+                    None => ctx.error_field("scheme", "is required for the `http` type"),
+                    Some(scheme) => ctx.require_non_empty("scheme", scheme),
+                }
+                if self.bearer_format.is_some()
+                    && self.scheme.as_deref().is_some_and(|s| s != "bearer")
+                {
+                    ctx.error_field("bearerFormat", "is only allowed when `scheme` is `bearer`");
+                }
+            }
+            SecuritySchemeType::OAuth2 => match &self.flows {
+                None => ctx.error_field("flows", "is required for the `oauth2` type"),
+                Some(flows) => ctx.in_field("flows", |ctx| flows.validate_with_context(ctx)),
+            },
+            SecuritySchemeType::OpenIdConnect => match &self.open_id_connect_url {
+                None => ctx.error_field(
+                    "openIdConnectUrl",
+                    "is required for the `openIdConnect` type",
+                ),
+                Some(url) => ctx.require_non_empty("openIdConnectUrl", url),
+            },
+            _ => {}
+        }
+    }
+}
+
+/// The OAuth 2 flows a scheme supports.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct OAuthFlows {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implicit: Option<OAuthFlow>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<OAuthFlow>,
+
+    #[serde(rename = "clientCredentials", skip_serializing_if = "Option::is_none")]
+    pub client_credentials: Option<OAuthFlow>,
+
+    #[serde(rename = "authorizationCode", skip_serializing_if = "Option::is_none")]
+    pub authorization_code: Option<OAuthFlow>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for OAuthFlows {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if self.implicit.is_none()
+            && self.password.is_none()
+            && self.client_credentials.is_none()
+            && self.authorization_code.is_none()
+        {
+            ctx.error("must define at least one OAuth flow");
+        }
+
+        for (field, flow, required, forbidden) in [
+            (
+                "implicit",
+                self.implicit.as_ref(),
+                &["authorizationUrl"][..],
+                &["tokenUrl"][..],
+            ),
+            (
+                "password",
+                self.password.as_ref(),
+                &["tokenUrl"][..],
+                &["authorizationUrl"][..],
+            ),
+            (
+                "clientCredentials",
+                self.client_credentials.as_ref(),
+                &["tokenUrl"][..],
+                &["authorizationUrl"][..],
+            ),
+            (
+                "authorizationCode",
+                self.authorization_code.as_ref(),
+                &["authorizationUrl", "tokenUrl"][..],
+                &[][..],
+            ),
+        ] {
+            let Some(flow) = flow else { continue };
+            ctx.in_field(field, |ctx| {
+                flow.validate_grant(ctx, field, required, forbidden);
+            });
+        }
+    }
+}
+
+/// Configuration for one OAuth 2 flow.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct OAuthFlow {
+    #[serde(rename = "authorizationUrl", skip_serializing_if = "Option::is_none")]
+    pub authorization_url: Option<String>,
+
+    #[serde(rename = "tokenUrl", skip_serializing_if = "Option::is_none")]
+    pub token_url: Option<String>,
+
+    #[serde(rename = "refreshUrl", skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<String>,
+
+    /// **Required** The available scopes, keyed by scope name. v3
+    /// renamed this field to `availableScopes`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<BTreeMap<String, String>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl OAuthFlow {
+    fn url(&self, field: &str) -> Option<&String> {
+        match field {
+            "authorizationUrl" => self.authorization_url.as_ref(),
+            "tokenUrl" => self.token_url.as_ref(),
+            _ => None,
+        }
+    }
+
+    /// Validate this flow against its grant type's contract.
+    fn validate_grant(
+        &self,
+        ctx: &mut Context,
+        grant: &str,
+        required: &[&str],
+        forbidden: &[&str],
+    ) {
+        for field in required {
+            match self.url(field) {
+                None => ctx.error_field(field, format!("is required for the `{grant}` flow")),
+                Some(url) => ctx.require_non_empty(field, url),
+            }
+        }
+        for field in forbidden {
+            if self.url(field).is_some() {
+                ctx.error_field(field, format!("is not allowed on the `{grant}` flow"));
+            }
+        }
+        if self.scopes.is_none() {
+            ctx.error_field("scopes", format!("is required for the `{grant}` flow"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn validate(value: serde_json::Value) -> Vec<String> {
+        let scheme: SecurityScheme = serde_json::from_value(value).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.securitySchemes.s");
+        scheme.validate_with_context(&mut ctx);
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn simple_types_need_nothing_beyond_the_discriminator() {
+        for scheme_type in [
+            "userPassword",
+            "X509",
+            "symmetricEncryption",
+            "asymmetricEncryption",
+            "plain",
+            "scramSha256",
+            "scramSha512",
+            "gssapi",
+        ] {
+            assert!(
+                validate(json!({ "type": scheme_type })).is_empty(),
+                "{scheme_type} should be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth_flows_use_the_2_6_scopes_field() {
+        let value = json!({
+            "type": "oauth2",
+            "flows": {
+                "authorizationCode": {
+                    "authorizationUrl": "https://example.com/auth",
+                    "tokenUrl": "https://example.com/token",
+                    "scopes": { "read": "Read access" }
+                }
+            }
+        });
+        let scheme: SecurityScheme = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&scheme).unwrap(), value);
+        assert!(validate(value).is_empty());
+
+        // `availableScopes` is the v3 spelling and is not recognized
+        // here, so the flow reads as missing its scopes.
+        let errors = validate(json!({
+            "type": "oauth2",
+            "flows": { "implicit": { "authorizationUrl": "https://e/a", "availableScopes": {} } }
+        }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("implicit.scopes: is required")),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn each_grant_type_forbids_the_url_it_does_not_use() {
+        let errors = validate(json!({
+            "type": "oauth2",
+            "flows": {
+                "implicit": {
+                    "authorizationUrl": "https://e/a",
+                    "tokenUrl": "https://e/t",
+                    "scopes": {}
+                }
+            }
+        }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("implicit.tokenUrl: is not allowed")),
+            "got: {errors:?}"
+        );
+
+        for grant in ["password", "clientCredentials"] {
+            let errors = validate(json!({
+                "type": "oauth2",
+                "flows": {
+                    grant: { "tokenUrl": "https://e/t", "authorizationUrl": "https://e/a", "scopes": {} }
+                }
+            }));
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.contains(&format!("{grant}.authorizationUrl: is not allowed"))),
+                "{grant}: {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn per_type_requirements_are_enforced() {
+        assert!(validate(json!({ "type": "apiKey", "in": "user" })).is_empty());
+        assert!(
+            validate(json!({ "type": "apiKey", "in": "header" }))[0]
+                .contains("must be `user` or `password`")
+        );
+        assert!(validate(json!({ "type": "http" }))[0].contains("scheme: is required"));
+        assert!(
+            validate(json!({ "type": "http", "scheme": "basic", "bearerFormat": "JWT" }))[0]
+                .contains("only allowed when `scheme` is `bearer`")
+        );
+        assert!(validate(json!({ "type": "oauth2" }))[0].contains("flows: is required"));
+        assert!(validate(json!({ "type": "openIdConnect" }))[0].contains("openIdConnectUrl"));
+        assert!(
+            validate(json!({ "type": "httpApiKey", "in": "header", "name": "X-Key" })).is_empty()
+        );
+    }
+
+    #[test]
+    fn missing_and_empty_per_type_fields_are_each_reported() {
+        for (value, needle) in [
+            (
+                json!({ "type": "apiKey" }),
+                "in: is required for the `apiKey` type",
+            ),
+            (
+                json!({ "type": "httpApiKey", "name": "X-Key" }),
+                "in: is required for the `httpApiKey` type",
+            ),
+            (
+                json!({ "type": "httpApiKey", "in": "user", "name": "X-Key" }),
+                "must be `query`, `header` or `cookie`",
+            ),
+            (
+                json!({ "type": "httpApiKey", "in": "header" }),
+                "name: is required for the `httpApiKey` type",
+            ),
+            (
+                json!({ "type": "httpApiKey", "in": "header", "name": "" }),
+                "name: must not be empty",
+            ),
+            (
+                json!({ "type": "openIdConnect", "openIdConnectUrl": "" }),
+                "openIdConnectUrl: must not be empty",
+            ),
+            (
+                json!({ "type": "oauth2", "flows": {} }),
+                "at least one OAuth flow",
+            ),
+            (
+                json!({
+                    "type": "oauth2",
+                    "flows": { "password": { "tokenUrl": "", "scopes": {} } }
+                }),
+                "password.tokenUrl: must not be empty",
+            ),
+            (
+                json!({
+                    "type": "oauth2",
+                    "flows": { "authorizationCode": { "scopes": {} } }
+                }),
+                "authorizationCode.authorizationUrl: is required",
+            ),
+        ] {
+            let errors = validate(value.clone());
+            assert!(
+                errors.iter().any(|e| e.contains(needle)),
+                "{value}: expected {needle}, got {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fields_belonging_to_another_variant_are_rejected() {
+        let errors = validate(json!({ "type": "userPassword", "flows": {} }));
+        assert!(
+            errors.iter().any(|e| e
+                == "#.securitySchemes.s.flows: is not allowed on a `userPassword` security scheme"),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn type_renders_as_its_document_spelling_and_knows_about_scopes() {
+        for (scheme_type, text, scopes) in [
+            (SecuritySchemeType::UserPassword, "userPassword", false),
+            (SecuritySchemeType::ApiKey, "apiKey", false),
+            (SecuritySchemeType::X509, "X509", false),
+            (
+                SecuritySchemeType::SymmetricEncryption,
+                "symmetricEncryption",
+                false,
+            ),
+            (
+                SecuritySchemeType::AsymmetricEncryption,
+                "asymmetricEncryption",
+                false,
+            ),
+            (SecuritySchemeType::HttpApiKey, "httpApiKey", false),
+            (SecuritySchemeType::Http, "http", false),
+            (SecuritySchemeType::OAuth2, "oauth2", true),
+            (SecuritySchemeType::OpenIdConnect, "openIdConnect", true),
+            (SecuritySchemeType::Plain, "plain", false),
+            (SecuritySchemeType::ScramSha256, "scramSha256", false),
+            (SecuritySchemeType::ScramSha512, "scramSha512", false),
+            (SecuritySchemeType::Gssapi, "gssapi", false),
+        ] {
+            assert_eq!(scheme_type.as_str(), text);
+            assert_eq!(serde_json::to_value(scheme_type).unwrap(), json!(text));
+            assert_eq!(scheme_type.takes_scopes(), scopes, "{text}");
+        }
+    }
+
+    #[test]
+    fn security_requirement_round_trips_and_rejects_duplicate_scopes() {
+        let value = json!({ "petstore_auth": ["write:pets", "read:pets"] });
+        let requirement: SecurityRequirement = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&requirement).unwrap(), value);
+        assert_eq!(requirement.get("petstore_auth").map(Vec::len), Some(2));
+        assert!(requirement.get("absent").is_none());
+        assert!(!requirement.is_empty());
+        assert!(SecurityRequirement::default().is_empty());
+
+        let dup: SecurityRequirement =
+            serde_json::from_value(json!({ "auth": ["read", "read"] })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.security[0]");
+        dup.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.security[0].auth: duplicate scope `read`"),
+            "got: {:?}",
+            ctx.errors
+        );
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/server.rs
+++ b/crates/roas-asyncapi/src/v2_6/server.rs
@@ -8,7 +8,6 @@
 
 use crate::common::bindings::Bindings;
 use crate::common::reference::RefOr;
-use crate::v2_6::external_documentation::ExternalDocumentation;
 use crate::v2_6::security_scheme::SecurityRequirement;
 use crate::v2_6::tag::Tag;
 use crate::validation::{Context, ValidateWithContext};
@@ -47,11 +46,7 @@ pub struct Server {
 
     /// Protocol-specific definitions for the server.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bindings: Option<RefOr<Bindings>>,
-
-    /// Additional external documentation for this server.
-    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub bindings: Option<Bindings>,
 
     /// `x-`-prefixed Specification Extensions.
     #[serde(flatten)]
@@ -81,14 +76,9 @@ impl ValidateWithContext for Server {
         for (i, requirement) in self.security.iter().enumerate() {
             ctx.in_index("security", i, |ctx| requirement.validate_with_context(ctx));
         }
-        for (i, tag) in self.tags.iter().enumerate() {
-            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
-        }
+        crate::v2_6::message::validate_tags(ctx, &self.tags);
         if let Some(bindings) = &self.bindings {
             ctx.in_field("bindings", |ctx| bindings.validate_with_context(ctx));
-        }
-        if let Some(docs) = &self.external_docs {
-            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
         }
     }
 }
@@ -133,6 +123,14 @@ pub struct ServerVariable {
 
 impl ValidateWithContext for ServerVariable {
     fn validate_with_context(&self, ctx: &mut Context) {
+        // `uniqueItems: true` on the enumeration.
+        for (i, value) in self.enum_values.iter().enumerate() {
+            if self.enum_values[..i].contains(value) {
+                ctx.in_index("enum", i, |ctx| {
+                    ctx.error(format!("duplicate value `{value}`"))
+                });
+            }
+        }
         if let Some(default) = &self.default
             && !self.enum_values.is_empty()
             && !self.enum_values.contains(default)
@@ -172,7 +170,6 @@ mod tests {
             "security": [ { "user_pass": [] } ],
             "tags": [ { "name": "prod" } ],
             "bindings": { "amqp": { "bindingVersion": "0.3.0" } },
-            "externalDocs": { "url": "https://example.com" },
             "x-team": "infra"
         });
         let server: Server = serde_json::from_value(value.clone()).unwrap();
@@ -227,8 +224,7 @@ mod tests {
             "variables": { "v": { "enum": ["a"], "default": "b" } },
             "security": [ { "auth": ["read", "read"] } ],
             "tags": [ { "name": "" } ],
-            "bindings": { "amqp": 1 },
-            "externalDocs": { "url": "" }
+            "bindings": { "amqp": 1 }
         }));
         assert!(
             errors
@@ -250,10 +246,42 @@ mod tests {
                 .iter()
                 .any(|e| e.starts_with("#.servers.prod.bindings.amqp"))
         );
+    }
+
+    #[test]
+    fn tags_and_variable_enums_must_be_unique() {
+        let errors = errors_for(json!({
+            "url": "amqp://e",
+            "protocol": "amqp",
+            "tags": [ { "name": "a" }, { "name": "a" } ],
+            "variables": { "v": { "enum": ["a", "b", "a"] } }
+        }));
         assert!(
             errors
                 .iter()
-                .any(|e| e == "#.servers.prod.externalDocs.url: must not be empty")
+                .any(|e| e == "#.servers.prod.tags[1]: duplicate tag")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.servers.prod.variables.v.enum[2]: duplicate value `a`"),
+            "got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn a_server_has_no_external_docs_field_in_2_6() {
+        // The 2.6 Server Object has no `externalDocs`; it is dropped as
+        // an unknown key rather than parsed.
+        let server: Server = serde_json::from_value(json!({
+            "url": "amqp://e",
+            "protocol": "amqp",
+            "externalDocs": { "url": "https://e" }
+        }))
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(&server).unwrap(),
+            json!({ "url": "amqp://e", "protocol": "amqp" })
         );
     }
 

--- a/crates/roas-asyncapi/src/v2_6/server.rs
+++ b/crates/roas-asyncapi/src/v2_6/server.rs
@@ -1,0 +1,273 @@
+//! AsyncAPI v2.6 `Server` and `Server Variable` objects.
+//!
+//! Per [Server Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#serverObject).
+//!
+//! 2.6 addresses a server with a single `url` (which v3 split into
+//! `host` + `pathname`), and its `security` is a list of
+//! [`SecurityRequirement`] maps rather than inline schemes.
+
+use crate::common::bindings::Bindings;
+use crate::common::reference::RefOr;
+use crate::v2_6::external_documentation::ExternalDocumentation;
+use crate::v2_6::security_scheme::SecurityRequirement;
+use crate::v2_6::tag::Tag;
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Server {
+    /// **Required** The server URL. It MAY contain `{variable}`
+    /// template placeholders, and MAY be relative.
+    pub url: String,
+
+    /// **Required** The protocol this server supports for connectivity.
+    pub protocol: String,
+
+    /// The version of the protocol used for connection.
+    #[serde(rename = "protocolVersion", skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<String>,
+
+    /// An optional description, CommonMark-formatted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// A map between a variable name and its value, for substitution
+    /// into `url`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub variables: BTreeMap<String, RefOr<ServerVariable>>,
+
+    /// The security requirements for this server.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityRequirement>,
+
+    /// Tags for logical grouping and categorization of servers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<Tag>,
+
+    /// Protocol-specific definitions for the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bindings: Option<RefOr<Bindings>>,
+
+    /// Additional external documentation for this server.
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Server {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("url", &self.url);
+        ctx.require_non_empty("protocol", &self.protocol);
+
+        // Every `{placeholder}` in the URL needs a variable.
+        for placeholder in placeholders(&self.url) {
+            if !self.variables.contains_key(placeholder) {
+                ctx.error_field(
+                    "variables",
+                    format!("`{{{placeholder}}}` is not declared in `variables`"),
+                );
+            }
+        }
+
+        for (name, variable) in &self.variables {
+            ctx.in_key("variables", name, |ctx| variable.validate_with_context(ctx));
+        }
+        for (i, requirement) in self.security.iter().enumerate() {
+            ctx.in_index("security", i, |ctx| requirement.validate_with_context(ctx));
+        }
+        for (i, tag) in self.tags.iter().enumerate() {
+            ctx.in_index("tags", i, |ctx| tag.validate_with_context(ctx));
+        }
+        if let Some(bindings) = &self.bindings {
+            ctx.in_field("bindings", |ctx| bindings.validate_with_context(ctx));
+        }
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+    }
+}
+
+/// The `{placeholder}` names appearing in `input`, in order.
+pub(crate) fn placeholders(input: &str) -> Vec<&str> {
+    let mut found = Vec::new();
+    let mut rest = input;
+    while let Some(start) = rest.find('{') {
+        let after = &rest[start + 1..];
+        let Some(end) = after.find('}') else { break };
+        let name = &after[..end];
+        if !name.is_empty() {
+            found.push(name);
+        }
+        rest = &after[end + 1..];
+    }
+    found
+}
+
+/// A variable substituted into a server's `url`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct ServerVariable {
+    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
+    pub enum_values: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for ServerVariable {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        if let Some(default) = &self.default
+            && !self.enum_values.is_empty()
+            && !self.enum_values.contains(default)
+        {
+            ctx.error_field(
+                "default",
+                format!("`{default}` is not one of the values listed in `enum`"),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    fn errors_for(value: serde_json::Value) -> Vec<String> {
+        let server: Server = serde_json::from_value(value).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.servers.prod");
+        server.validate_with_context(&mut ctx);
+        ctx.errors.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn round_trips_a_full_server() {
+        let value = json!({
+            "url": "amqp://{stage}.example.com:{port}",
+            "protocol": "amqp",
+            "protocolVersion": "0.9.1",
+            "description": "The production broker",
+            "variables": {
+                "stage": { "enum": ["prod", "staging"], "default": "prod" },
+                "port": { "default": "5672", "examples": ["5672"] }
+            },
+            "security": [ { "user_pass": [] } ],
+            "tags": [ { "name": "prod" } ],
+            "bindings": { "amqp": { "bindingVersion": "0.3.0" } },
+            "externalDocs": { "url": "https://example.com" },
+            "x-team": "infra"
+        });
+        let server: Server = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(server.protocol, "amqp");
+        assert_eq!(serde_json::to_value(&server).unwrap(), value);
+        assert!(errors_for(value).is_empty());
+    }
+
+    #[test]
+    fn url_and_protocol_are_required() {
+        let errors = errors_for(json!({ "url": "", "protocol": "" }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.servers.prod.url: must not be empty")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.servers.prod.protocol: must not be empty")
+        );
+    }
+
+    #[test]
+    fn undeclared_url_placeholders_are_reported() {
+        let errors = errors_for(json!({
+            "url": "amqp://{stage}.example.com:{port}",
+            "protocol": "amqp",
+            "variables": { "port": { "default": "5672" } }
+        }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("`{stage}` is not declared"))
+        );
+        assert!(!errors.iter().any(|e| e.contains("`{port}`")));
+    }
+
+    #[test]
+    fn placeholders_handles_edge_cases() {
+        assert_eq!(placeholders("{a}.b.{c}"), vec!["a", "c"]);
+        assert_eq!(placeholders("no-placeholders"), Vec::<&str>::new());
+        assert_eq!(placeholders("{}"), Vec::<&str>::new());
+        assert_eq!(placeholders("{a}.{unclosed"), vec!["a"]);
+    }
+
+    #[test]
+    fn nested_objects_report_under_their_own_path() {
+        let errors = errors_for(json!({
+            "url": "amqp://e",
+            "protocol": "amqp",
+            "variables": { "v": { "enum": ["a"], "default": "b" } },
+            "security": [ { "auth": ["read", "read"] } ],
+            "tags": [ { "name": "" } ],
+            "bindings": { "amqp": 1 },
+            "externalDocs": { "url": "" }
+        }));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.starts_with("#.servers.prod.variables.v.default"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.servers.prod.security[0].auth: duplicate scope `read`")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.servers.prod.tags[0].name: must not be empty")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.starts_with("#.servers.prod.bindings.amqp"))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e == "#.servers.prod.externalDocs.url: must not be empty")
+        );
+    }
+
+    #[test]
+    fn server_variable_default_must_be_enumerated() {
+        let variable: ServerVariable =
+            serde_json::from_value(json!({ "enum": ["a"], "default": "z" })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.variables.v");
+        variable.validate_with_context(&mut ctx);
+        assert!(ctx.errors[0].contains("is not one of the values listed in `enum`"));
+
+        let free: ServerVariable = serde_json::from_value(json!({ "default": "z" })).unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.variables.v");
+        free.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/tag.rs
+++ b/crates/roas-asyncapi/src/v2_6/tag.rs
@@ -1,0 +1,81 @@
+//! AsyncAPI v2.6 `Tag` object.
+//!
+//! Per [Tag Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#tagObject).
+
+use crate::common::reference::RefOr;
+use crate::v2_6::external_documentation::ExternalDocumentation;
+use crate::validation::{Context, ValidateWithContext};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
+pub struct Tag {
+    /// **Required** The name of the tag.
+    pub name: String,
+
+    /// A short description, CommonMark-formatted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Additional external documentation for this tag.
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+
+    /// `x-`-prefixed Specification Extensions.
+    #[serde(flatten)]
+    #[serde(with = "crate::common::extensions")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+impl ValidateWithContext for Tag {
+    fn validate_with_context(&self, ctx: &mut Context) {
+        ctx.require_non_empty("name", &self.name);
+        if let Some(docs) = &self.external_docs {
+            ctx.in_field("externalDocs", |ctx| docs.validate_with_context(ctx));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enumset::EnumSet;
+    use serde_json::json;
+
+    #[test]
+    fn round_trips_with_external_docs() {
+        let value = json!({
+            "name": "user",
+            "description": "User events",
+            "externalDocs": { "url": "https://example.com" }
+        });
+        let tag: Tag = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&tag).unwrap(), value);
+
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.tags[0]");
+        tag.validate_with_context(&mut ctx);
+        assert!(ctx.errors.is_empty());
+    }
+
+    #[test]
+    fn requires_a_name_and_validates_nested_docs() {
+        let tag: Tag = serde_json::from_value(json!({
+            "name": "",
+            "externalDocs": { "url": "" }
+        }))
+        .unwrap();
+        let mut ctx = Context::with_path(EnumSet::empty(), "#.tags[0]");
+        tag.validate_with_context(&mut ctx);
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.tags[0].name: must not be empty")
+        );
+        assert!(
+            ctx.errors
+                .iter()
+                .any(|e| e == "#.tags[0].externalDocs.url: must not be empty")
+        );
+    }
+}

--- a/crates/roas-asyncapi/src/v2_6/tag.rs
+++ b/crates/roas-asyncapi/src/v2_6/tag.rs
@@ -2,7 +2,6 @@
 //!
 //! Per [Tag Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#tagObject).
 
-use crate::common::reference::RefOr;
 use crate::v2_6::external_documentation::ExternalDocumentation;
 use crate::validation::{Context, ValidateWithContext};
 use serde::{Deserialize, Serialize};
@@ -19,7 +18,7 @@ pub struct Tag {
 
     /// Additional external documentation for this tag.
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<RefOr<ExternalDocumentation>>,
+    pub external_docs: Option<ExternalDocumentation>,
 
     /// `x-`-prefixed Specification Extensions.
     #[serde(flatten)]

--- a/crates/roas-asyncapi/src/v2_6/version.rs
+++ b/crates/roas-asyncapi/src/v2_6/version.rs
@@ -1,0 +1,178 @@
+//! Version newtype for AsyncAPI v2.6 (`asyncapi: "2.6.0"`).
+//!
+//! The schema pins this field to `enum: ["2.6.0"]`
+//! ([JSON Schema](https://asyncapi.com/schema-store/2.6.0.json)) — a
+//! single-value enumeration, which is the same constraint the 3.x
+//! schemas spell as `const`. Deserialization rejects anything else up
+//! front, so a 2.5 or 3.x document fails at parse time rather than
+//! validation time.
+
+use std::fmt::{self, Display, Formatter};
+
+/// The only `asyncapi` value an AsyncAPI v2.6 document may carry.
+pub const VERSION: &str = "2.6.0";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Version(String);
+
+impl Default for Version {
+    fn default() -> Self {
+        Self(VERSION.to_owned())
+    }
+}
+
+impl Version {
+    /// The canonical — and only — `2.6.0` value.
+    #[allow(non_snake_case)]
+    pub fn V2_6_0() -> Self {
+        Self(VERSION.to_owned())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+const VERSION_SCHEMA_DESCRIPTION: &str = "exactly `2.6.0` (AsyncAPI v2.6)";
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        Version::try_from(String::deserialize(de)?).map_err(|InvalidVersion(s)| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &VERSION_SCHEMA_DESCRIPTION,
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidVersion(pub String);
+
+impl Display for InvalidVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "asyncapi version {:?} must be {VERSION_SCHEMA_DESCRIPTION}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidVersion {}
+
+impl std::str::FromStr for Version {
+    type Err = InvalidVersion;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == VERSION {
+            Ok(Version(s.to_owned()))
+        } else {
+            Err(InvalidVersion(s.to_owned()))
+        }
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for Version {
+    type Error = InvalidVersion;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if s == VERSION {
+            Ok(Version(s))
+        } else {
+            Err(InvalidVersion(s))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_2_6_0() {
+        assert_eq!(Version::default().as_str(), VERSION);
+        assert_eq!(VERSION, "2.6.0");
+    }
+
+    #[test]
+    fn accepts_only_the_exact_constant() {
+        assert!("2.6.0".parse::<Version>().is_ok());
+    }
+
+    #[test]
+    fn rejects_everything_else() {
+        // The schema enumerates a single value, so neither an earlier
+        // 2.x nor a later patch is a v2.6 document.
+        for bad in [
+            "2.6.1",
+            "2.5.0",
+            "2.6.0-rc1",
+            "3.0.0",
+            "3.1.0",
+            "2.6",
+            "2.6.x",
+            "2.6.0-",
+            " 2.6.0",
+            "2.6.0 ",
+            "",
+        ] {
+            assert!(bad.parse::<Version>().is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn serialize_round_trips() {
+        let v = Version::V2_6_0();
+        let s = serde_json::to_string(&v).unwrap();
+        assert_eq!(s, r#""2.6.0""#);
+        assert_eq!(serde_json::from_str::<Version>(&s).unwrap(), v);
+    }
+
+    #[test]
+    fn deserialize_rejects_v3_documents() {
+        assert!(serde_json::from_value::<Version>(serde_json::json!("3.0.0")).is_err());
+        assert!(serde_json::from_value::<Version>(serde_json::json!("3.1.0")).is_err());
+    }
+
+    #[test]
+    fn display_renders_inner_string() {
+        assert_eq!(format!("{}", Version::V2_6_0()), "2.6.0");
+    }
+
+    #[test]
+    fn try_from_str_and_string_match_from_str() {
+        assert_eq!(Version::try_from("2.6.0").unwrap(), Version::V2_6_0());
+        assert!(Version::try_from("3.0.0").is_err());
+
+        let owned_ok = Version::try_from(String::from("2.6.0")).unwrap();
+        assert_eq!(owned_ok.as_str(), "2.6.0");
+        let owned_err = Version::try_from(String::from("nope")).unwrap_err();
+        assert_eq!(owned_err.0, "nope");
+    }
+
+    #[test]
+    fn invalid_version_error_echoes_input() {
+        let err = "2.6.1".parse::<Version>().unwrap_err();
+        assert!(err.to_string().contains("2.6.1"));
+        assert!(err.to_string().contains("2.6.0"));
+    }
+}

--- a/crates/roas-asyncapi/tests/v2_6_data/bad_parameters.json
+++ b/crates/roas-asyncapi/tests/v2_6_data/bad_parameters.json
@@ -1,0 +1,12 @@
+{
+  "asyncapi": "2.6.0",
+  "info": { "title": "Broken parameters", "version": "1.0.0" },
+  "channels": {
+    "streetlights/{streetlightId}/lighting/{metric}": {
+      "parameters": {
+        "streetlightId": { "location": "not-a-runtime-expression" },
+        "unused": { "schema": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/crates/roas-asyncapi/tests/v2_6_data/bad_wiring.json
+++ b/crates/roas-asyncapi/tests/v2_6_data/bad_wiring.json
@@ -1,0 +1,24 @@
+{
+  "asyncapi": "2.6.0",
+  "info": { "title": "Broken wiring", "version": "1.0.0" },
+  "servers": {
+    "production": { "url": "kafka://broker:9092", "protocol": "kafka" }
+  },
+  "channels": {
+    "user/signedup": {
+      "servers": ["staging"],
+      "publish": {
+        "operationId": "handleUser",
+        "security": [{ "saslScram": ["read"] }, { "missingScheme": [] }]
+      }
+    },
+    "user/deleted": {
+      "subscribe": { "operationId": "handleUser" }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "saslScram": { "type": "scramSha512" }
+    }
+  }
+}

--- a/crates/roas-asyncapi/tests/v2_6_data/minimal.json
+++ b/crates/roas-asyncapi/tests/v2_6_data/minimal.json
@@ -1,0 +1,8 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Streetlights",
+    "version": "1.0.0"
+  },
+  "channels": {}
+}

--- a/crates/roas-asyncapi/tests/v2_6_data/streetlights.yaml
+++ b/crates/roas-asyncapi/tests/v2_6_data/streetlights.yaml
@@ -1,0 +1,144 @@
+# An AsyncAPI 2.6 document in the shape v3 replaced: channels keyed by
+# path, publish/subscribe operations, a parameter carrying a full
+# schema, OpenAPI-style security requirements, and a message declaring
+# its own schemaFormat.
+asyncapi: 2.6.0
+id: urn:example:streetlights
+info:
+  title: Streetlights Kafka API
+  version: 1.0.0
+  description: Smart lighting telemetry and control.
+  contact:
+    name: Lighting Ops
+    email: ops@example.com
+  license:
+    name: Apache 2.0
+defaultContentType: application/json
+
+servers:
+  production:
+    url: '{stage}.broker.example.com:9092'
+    protocol: kafka-secure
+    protocolVersion: '3.5'
+    description: Production broker
+    variables:
+      stage:
+        enum: ['prod', 'staging']
+        default: prod
+    security:
+      - saslScram: []
+    tags:
+      - name: prod
+    bindings:
+      kafka:
+        schemaRegistryUrl: https://registry.example.com
+        bindingVersion: 0.5.0
+
+channels:
+  smartylighting/streetlights/{streetlightId}/lighting/measured:
+    description: Telemetry from a single streetlight.
+    servers:
+      - production
+    parameters:
+      streetlightId:
+        description: The streetlight id
+        schema:
+          type: string
+          pattern: '^[0-9]+$'
+        location: $message.payload#/streetlightId
+    publish:
+      operationId: receiveLightMeasurement
+      summary: Consume telemetry from streetlights.
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/lightMeasured'
+    bindings:
+      kafka:
+        topic: light-measured
+        bindingVersion: 0.5.0
+
+  smartylighting/streetlights/{streetlightId}/command/turn:
+    parameters:
+      streetlightId:
+        schema:
+          type: string
+    subscribe:
+      operationId: sendTurnCommand
+      security:
+        - saslScram: []
+      message:
+        oneOf:
+          - name: TurnOn
+            payload:
+              type: object
+              properties:
+                command:
+                  type: string
+                  enum: ['on']
+          - name: TurnOff
+            payload:
+              type: object
+              properties:
+                command:
+                  type: string
+                  enum: ['off']
+
+components:
+  messages:
+    lightMeasured:
+      messageId: lightMeasured
+      name: LightMeasured
+      title: Light measured
+      contentType: application/json
+      schemaFormat: 'application/vnd.aai.asyncapi;version=2.6.0'
+      correlationId:
+        location: $message.header#/correlationId
+      headers:
+        type: object
+        properties:
+          correlationId:
+            type: string
+      payload:
+        type: object
+        required: [lumens]
+        properties:
+          streetlightId:
+            type: string
+          lumens:
+            type: integer
+            minimum: 0
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      examples:
+        - name: simple
+          payload:
+            streetlightId: '1'
+            lumens: 100
+
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          sentAt:
+            type: string
+            format: date-time
+
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId:
+            type: string
+          bindingVersion: 0.5.0
+
+  securitySchemes:
+    saslScram:
+      type: scramSha512
+      description: SASL/SCRAM authentication.
+
+tags:
+  - name: telemetry
+externalDocs:
+  url: https://example.com/docs

--- a/crates/roas-asyncapi/tests/v2_6_test.rs
+++ b/crates/roas-asyncapi/tests/v2_6_test.rs
@@ -53,9 +53,7 @@ fn streetlights_yaml_parses_validates_and_round_trips() {
 
     // Operations hang off the channel path, from the consumer's point
     // of view.
-    let measured = doc.channels["smartylighting/streetlights/{streetlightId}/lighting/measured"]
-        .item()
-        .expect("inline channel");
+    let measured = &doc.channels["smartylighting/streetlights/{streetlightId}/lighting/measured"];
     assert!(measured.publish.is_some());
     assert!(measured.subscribe.is_none());
     assert_eq!(measured.servers, vec!["production"]);
@@ -67,9 +65,7 @@ fn streetlights_yaml_parses_validates_and_round_trips() {
     assert!(parameter.schema.is_some());
 
     // An operation's message may be a set of alternatives.
-    let turn = doc.channels["smartylighting/streetlights/{streetlightId}/command/turn"]
-        .item()
-        .expect("inline channel");
+    let turn = &doc.channels["smartylighting/streetlights/{streetlightId}/command/turn"];
     let subscribe = turn.subscribe.as_ref().expect("subscribe operation");
     match subscribe.message.as_ref().expect("message") {
         OperationMessage::OneOf(one_of) => assert_eq!(one_of.one_of.len(), 2),

--- a/crates/roas-asyncapi/tests/v2_6_test.rs
+++ b/crates/roas-asyncapi/tests/v2_6_test.rs
@@ -1,0 +1,195 @@
+//! Integration tests for AsyncAPI v2.6: load fixtures from
+//! `tests/v2_6_data/`, parse them (JSON and YAML), and validate.
+
+#![cfg(feature = "v2_6")]
+
+use enumset::EnumSet;
+use roas_asyncapi::v2_6::{Document, OperationKind, OperationMessage};
+use roas_asyncapi::validation::{Validate, ValidationOptions};
+use std::path::{Path, PathBuf};
+
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("v2_6_data")
+}
+
+fn read(name: &str) -> String {
+    let path = data_dir().join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn load_json(name: &str) -> Document {
+    serde_json::from_str(&read(name)).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+fn load_yaml(name: &str) -> Document {
+    serde_yaml_ng::from_str(&read(name)).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+#[test]
+fn minimal_document_parses_and_validates() {
+    let doc = load_json("minimal.json");
+    doc.validate(EnumSet::empty()).expect("must validate");
+    assert_eq!(doc.info.title, "Streetlights");
+    assert!(doc.channels.is_empty());
+}
+
+#[test]
+fn streetlights_yaml_parses_validates_and_round_trips() {
+    let doc = load_yaml("streetlights.yaml");
+    doc.validate(EnumSet::empty()).expect("must validate");
+
+    assert_eq!(doc.id.as_deref(), Some("urn:example:streetlights"));
+    assert_eq!(doc.channels.len(), 2);
+    // 2.6 keeps tags and externalDocs at the root, not under `info`.
+    assert_eq!(doc.tags.len(), 1);
+    assert!(doc.external_docs.is_some());
+
+    // A server is one `url`, not host + pathname.
+    let server = doc.servers["production"].item().expect("inline server");
+    assert_eq!(server.url, "{stage}.broker.example.com:9092");
+    assert!(server.variables.contains_key("stage"));
+
+    // Operations hang off the channel path, from the consumer's point
+    // of view.
+    let measured = doc.channels["smartylighting/streetlights/{streetlightId}/lighting/measured"]
+        .item()
+        .expect("inline channel");
+    assert!(measured.publish.is_some());
+    assert!(measured.subscribe.is_none());
+    assert_eq!(measured.servers, vec!["production"]);
+
+    // A 2.6 parameter carries a full schema — the field v3 dropped.
+    let parameter = measured.parameters["streetlightId"]
+        .item()
+        .expect("inline parameter");
+    assert!(parameter.schema.is_some());
+
+    // An operation's message may be a set of alternatives.
+    let turn = doc.channels["smartylighting/streetlights/{streetlightId}/command/turn"]
+        .item()
+        .expect("inline channel");
+    let subscribe = turn.subscribe.as_ref().expect("subscribe operation");
+    match subscribe.message.as_ref().expect("message") {
+        OperationMessage::OneOf(one_of) => assert_eq!(one_of.one_of.len(), 2),
+        other => panic!("expected the oneOf form, got {other:?}"),
+    }
+
+    // The message declares its own dialect rather than wrapping it.
+    let message = doc.components.as_ref().unwrap().messages["lightMeasured"]
+        .item()
+        .expect("inline message");
+    assert_eq!(
+        message.schema_format.as_deref(),
+        Some("application/vnd.aai.asyncapi;version=2.6.0")
+    );
+    assert!(message.payload.is_some());
+
+    let json = serde_json::to_string(&doc).expect("serialize");
+    let reparsed: Document = serde_json::from_str(&json).expect("reparse");
+    assert_eq!(reparsed, doc);
+}
+
+#[test]
+fn operations_enumerates_every_channel_half() {
+    let doc = load_yaml("streetlights.yaml");
+    let operations = doc.operations();
+    assert_eq!(operations.len(), 2);
+
+    let kinds: Vec<_> = operations.iter().map(|(_, kind, _)| *kind).collect();
+    assert!(kinds.contains(&OperationKind::Publish));
+    assert!(kinds.contains(&OperationKind::Subscribe));
+
+    let ids: Vec<_> = operations
+        .iter()
+        .filter_map(|(_, _, op)| op.operation_id.as_deref())
+        .collect();
+    assert!(ids.contains(&"receiveLightMeasurement"));
+    assert!(ids.contains(&"sendTurnCommand"));
+}
+
+#[test]
+fn a_v3_document_does_not_parse_as_2_6() {
+    let v3 = read("../v3_1_data/minimal.json");
+    assert!(
+        serde_json::from_str::<Document>(&v3).is_err(),
+        "the version newtype must reject 3.1.0",
+    );
+}
+
+#[test]
+fn broken_wiring_reports_every_problem() {
+    let err = load_json("bad_wiring.json")
+        .validate(EnumSet::empty())
+        .unwrap_err();
+    let errors: Vec<_> = err.errors.iter().map(ToString::to_string).collect();
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("server `staging` is not declared")),
+        "got: {errors:?}",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("duplicate operationId `handleUser`")),
+        "got: {errors:?}",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("missingScheme: is not declared in `components.securitySchemes`")),
+        "got: {errors:?}",
+    );
+    // `scramSha512` takes no scopes.
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("must not list scopes: the `scramSha512` scheme type takes none")),
+        "got: {errors:?}",
+    );
+}
+
+#[test]
+fn channel_parameters_must_match_the_path() {
+    let err = load_json("bad_parameters.json")
+        .validate(EnumSet::empty())
+        .unwrap_err();
+    let errors: Vec<_> = err.errors.iter().map(ToString::to_string).collect();
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("`{metric}` in the channel path is not declared in `parameters`")),
+        "got: {errors:?}",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("`unused` is declared but never used in the channel path")),
+        "got: {errors:?}",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("is not a valid runtime expression")),
+        "got: {errors:?}",
+    );
+}
+
+#[test]
+fn unused_channel_parameters_can_be_allowed() {
+    let err = load_json("bad_parameters.json")
+        .validate(EnumSet::only(
+            ValidationOptions::IgnoreUnusedChannelParameter,
+        ))
+        .unwrap_err();
+    assert!(
+        !err.errors
+            .iter()
+            .any(|e| e.contains("declared but never used")),
+        "got: {err}",
+    );
+}


### PR DESCRIPTION
Third of the AsyncAPI PRs (3.0 in #238, 3.1 in #239). Adds the `v2_6` feature — off by default, since `v3_1` stays the default.

**2.6 is a different document, not an earlier draft of v3**, so this module is written rather than derived from `v3_0`. What changed between them:

| | 2.6 | 3.x |
|---|---|---|
| Channels | required, keyed by the channel *path* | keyed by a name, with a separate `address` |
| Operations | `publish` / `subscribe` under a channel, from the *consumer's* point of view | a top-level map, `send` / `receive` from the *application's* point of view |
| Messages | one message, or `{ "oneOf": [...] }`, on the operation | the channel's `messages` map, referenced by the operation |
| Payload dialect | `schemaFormat` on the message, payload alongside it | a Multi Format Schema Object wrapping both |
| Parameters | carry a full `Schema` | strings constrained by `enum` / `default` / `examples` |
| Security | OpenAPI-style requirement maps (name → scopes) | inline schemes; OAuth's `scopes` renamed `availableScopes` |
| `tags` / `externalDocs` | at the document root | under `info` |
| Servers | one `url` | `host` + `pathname` |

The one shared piece is the Schema Object — draft-07 plus AsyncAPI's additions — which is the same in both, minus v3's Multi Format wrapper.

**Validation** carries over the per-object checks (runtime expressions, schema keyword constraints, security-scheme variants, channel path ↔ parameters) and adds what only the root can see in this shape:

- a channel's `servers` are plain *names* here, not `$ref`s, so they are resolved against the root `servers` map;
- `operationId` must be unique across every operation in the document — including between one channel's own `publish` and `subscribe` — and the diagnostic names the first use;
- `messageId` likewise;
- a security requirement must name a declared scheme, and may list scopes only where the scheme's type takes them (`oauth2` / `openIdConnect`), which is the check the v3 shape does not need.

`Document::operations()` enumerates every `(path, kind, operation)` triple, which is both useful on its own and the traversal the 2.6 → 3.0 conversion will need.

The `publish` / `subscribe` inversion is documented wherever it could mislead — module docs, the `OperationKind` variants, and the README — since mapping `publish` to `send` is the classic migration bug, and that conversion is the next PR.

Verified across every feature combination in isolation: `v2_6` only (140 tests), `v3_0` only (164), `v3_1` only (163), `--all-features` (398), workspace 2546. Clippy `-D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc` clean under default, all-features, and `v2_6`-only. Coverage on the crate is 99.75% lines / 100% functions.